### PR TITLE
chore: v1.0.0 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,66 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0] - 2026-04-16
+
+### 🚀 Major Release — Agent-Native Middleware Platform
+
+**This release completes the full Agentic Web Interface (AWI) vision from arXiv:2506.10953v1.**
+
+#### Phase 9: AWI Phase 9 — Paper Gap Closure
+
+- **Agentic Web Interface (AWI)** — Stateful sessions, semantic actions, progressive representations
+- **Passkey Authentication** — FIDO2/WebAuthn for high-risk action verification (`/v1/awi/passkey/*`)
+- **Bidirectional DOM Bridge** — Playwright-powered browser automation for real website interaction (`/v1/awi/dom/*`)
+- **RAG Memory Engine** — Semantic search over session histories with ChromaDB persistence (`/v1/awi/rag/*`)
+- **Agent Discoverability** — Full discovery surfaces: `/.well-known/agent.json`, `/v1/discover`, `/mcp/tools.json`, `/llm.txt`
+
+#### Phase 9.1: Agent Discoverability Sprint
+
+- All Phase 9 capabilities registered in MCP tool manifest (9 new tools)
+- `/.well-known/agent.json` updated with Phase 9 capabilities
+- `/llm.txt` documentation includes Phase 9 examples
+- Root endpoint includes `awi_phase9` service definition
+
+#### Phase 9.2: Playwright DOM Bridge
+
+- **Real browser execution** — `page.click()`, `page.fill()`, `page.goto()`, etc.
+- DOM extraction — forms, buttons, links, navigation from live pages
+- Session lifecycle — proper page/context management
+- AWISessionManager routing — actions automatically route to live browser when attached
+
+#### Phase 9.3: WebAuthn Real Verification
+
+- **py_webauthn integration** for production-ready cryptographic verification
+- Signature verification against stored public key
+- Authenticator counter checking (prevents cloned credentials)
+- Challenge freshness and origin validation
+- Credential registration API
+
+#### Production Hardening
+
+- **Auth fail-safe** — Rejects requests if `VALID_API_KEYS` unset in production
+- **Background cleanup** — Periodic task cleans expired WebAuthn challenges and AWI sessions
+- **ChromaDB RAG persistence** — Vector storage for semantic memory
+
+#### All Phase 9 MCP Tools
+
+| Tool | Credits | Description |
+|------|----------|-------------|
+| `awi_passkey_challenge` | 1 | Generate passkey challenge |
+| `awi_passkey_verify` | 2 | Verify passkey response |
+| `awi_dom_bridge_session` | 5 | Create browser session |
+| `awi_dom_sync` | 3 | Execute action via DOM |
+| `awi_dom_state` | 2 | Get DOM state representation |
+| `awi_dom_action_preview` | 2 | Preview action translation |
+| `awi_memory_index` | 5 | Index session for search |
+| `awi_rag_query` | 3 | Semantic search |
+| `awi_session_context` | 2 | Get session context |
+
+**Tests:** 69 Phase 9 tests passing (339 total)
+
+---
+
 ## [v0.3.0] - 2026-04-16
 
 ### ✨ Major Features — Agentic Web Interface (AWI)

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 
 [![CI](https://github.com/PetrefiedThunder/agent-middleware-api/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/PetrefiedThunder/agent-middleware-api/actions/workflows/ci.yml)
 [![Auto PR](https://github.com/PetrefiedThunder/agent-middleware-api/actions/workflows/auto-pr.yml/badge.svg?branch=master)](https://github.com/PetrefiedThunder/agent-middleware-api/actions/workflows/ci.yml)
+![Version](https://img.shields.io/badge/Version-v1.0.0-blue)
 ![Python](https://img.shields.io/badge/Python-3.11%2B-blue)
 ![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-green)
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue)
 ![Tests](https://img.shields.io/badge/Tests-339%20passing-brightgreen)
-![Phase](https://img.shields.io/badge/Phase-9%20Agent%20Discoverability-blue)
 ![MCP](https://img.shields.io/badge/MCP-Native-orange)
+![AWI](https://img.shields.io/badge/AWI-v1.0- purple)
 ![Docker](https://img.shields.io/badge/Docker-Ready-blue)
 ![Stars](https://img.shields.io/github/stars/PetrefiedThunder/agent-middleware-api?style=social)
+
+> **Now v1.0 — Fully Agent-Discoverable.** Built on arXiv:2506.10953v1.
 
 **The FastAPI control plane for agent-native infrastructure — MCP + AWI powered.**
 
@@ -26,6 +29,11 @@ It lets agents:
 * **Self-heal by diagnosing and fixing issues**
 * **Answer natural language queries**
 * **Remember and learn from experiences**
+* **Control real web browsers with semantic actions**
+* **Use passkey authentication for high-risk operations**
+* **Search past sessions semantically**
+
+**Deploy in minutes via Docker or Railway.**
 
 Deploy in minutes via Docker or Railway.
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
 
     # --- Application ---
     APP_NAME: str = "Agent-Native Middleware API"
-    APP_VERSION: str = "0.1.0"
+    APP_VERSION: str = "1.0.0"
     DEBUG: bool = False
 
     # --- Server ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agent-native-middleware"
-version = "0.3.0"
+version = "1.0.0"
 description = "Headless middleware API for the Business-to-Agent (B2A) economy"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
## Summary
v1.0.0 release preparation

- Update CHANGELOG.md with full v1.0.0 release notes
- Update README badges: v1.0.0, AWI-v1.0
- Update pyproject.toml version to 1.0.0
- Update config APP_VERSION to 1.0.0
- GitHub release created: https://github.com/PetrefiedThunder/agent-middleware-api/releases/tag/v1.0.0

## What's in v1.0.0

- Full AWI implementation from arXiv:2506.10953v1
- 9 new MCP tools for Phase 9 features
- Production hardening: auth fail-safe, background cleanup
- 339 tests passing