### PR TITLE
fix(db): restore models and converters lost during PR #44/#45/#51 merges

### DIFF
--- a/app/db/converters.py
+++ b/app/db/converters.py
@@ -19,6 +19,28 @@ from ..schemas.billing import (
     AlertSeverity,
     KYCStatus,
 )
+from ..schemas.content_factory import (
+    ContentFormat,
+    ContentStatus,
+    GeneratedContent,
+    ScheduleRecommendation,
+)
+from ..schemas.oracle import (
+    CompatibilityTier,
+    DirectoryType,
+    IndexedAPI,
+    IndexedCapability,
+    OracleStatus,
+    RegistrationResult,
+)
+from ..schemas.red_team import (
+    AttackCategory,
+    RemediationStatus,
+    ScanReport,
+    ScanStatus,
+    Severity as RTSeverity,
+    Vulnerability,
+)
 from ..schemas.telemetry import (
     TelemetryEvent,
     TelemetryEventType,
@@ -28,6 +50,15 @@ from .models import (
     WalletModel,
     LedgerEntryModel,
     BillingAlertModel,
+    ContentCampaignModel,
+    ContentPieceModel,
+    ContentPipelineModel,
+    ContentScheduleModel,
+    OracleCrawlTargetModel,
+    OracleIndexedAPIModel,
+    OracleRegistrationModel,
+    SecurityScanModel,
+    SecurityVulnerabilityModel,
     TelemetryEventModel,
 )
 
@@ -174,4 +205,282 @@ def telemetry_event_model_to_schema(row: TelemetryEventModel) -> TelemetryEvent:
         stack_trace=row.stack_trace,
         metadata=parse_metadata_json(row.payload_json),
         timestamp=row.event_timestamp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Oracle
+# ---------------------------------------------------------------------------
+
+def indexed_api_to_model(api: IndexedAPI) -> OracleIndexedAPIModel:
+    """Flatten an IndexedAPI schema into its stored row."""
+    return OracleIndexedAPIModel(
+        api_id=api.api_id,
+        url=api.url,
+        name=api.name,
+        description=api.description,
+        directory_type=api.directory_type.value,
+        compatibility_tier=api.compatibility_tier.value,
+        compatibility_score=api.compatibility_score,
+        capabilities_json=json.dumps(
+            [c.model_dump() for c in api.capabilities], default=str
+        ),
+        tags_json=json.dumps(api.tags, default=str),
+        status=api.status.value,
+        last_crawled=api.last_crawled,
+    )
+
+
+def indexed_api_model_to_schema(row: OracleIndexedAPIModel) -> IndexedAPI:
+    """Rebuild an IndexedAPI from its row."""
+    caps: list[IndexedCapability] = []
+    if row.capabilities_json:
+        try:
+            for item in json.loads(row.capabilities_json):
+                caps.append(IndexedCapability.model_validate(item))
+        except (json.JSONDecodeError, ValueError):
+            pass
+
+    tags: list[str] = []
+    if row.tags_json:
+        try:
+            parsed = json.loads(row.tags_json)
+            if isinstance(parsed, list):
+                tags = [str(t) for t in parsed]
+        except json.JSONDecodeError:
+            pass
+
+    return IndexedAPI(
+        api_id=row.api_id,
+        url=row.url,
+        name=row.name,
+        description=row.description,
+        directory_type=DirectoryType(row.directory_type),
+        capabilities=caps,
+        compatibility_tier=CompatibilityTier(row.compatibility_tier),
+        compatibility_score=row.compatibility_score,
+        tags=tags,
+        last_crawled=row.last_crawled,
+        status=OracleStatus(row.status),
+    )
+
+
+def registration_result_to_model(
+    result: RegistrationResult,
+) -> OracleRegistrationModel:
+    """Store a RegistrationResult (caller synthesizes id for failures)."""
+    return OracleRegistrationModel(
+        registration_id=result.registration_id or "",
+        directory_url=result.directory_url,
+        directory_type=result.directory_type.value,
+        status=result.status.value,
+        message=result.message,
+    )
+
+
+def registration_model_to_schema(
+    row: OracleRegistrationModel,
+) -> RegistrationResult:
+    return RegistrationResult(
+        directory_url=row.directory_url,
+        directory_type=DirectoryType(row.directory_type),
+        status=OracleStatus(row.status),
+        registration_id=row.registration_id or None,
+        message=row.message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Security scans (shared by red_team + rtaas)
+# ---------------------------------------------------------------------------
+
+def _str_list_to_json(values: list | None) -> str | None:
+    if not values:
+        return None
+    return json.dumps(list(values), default=str)
+
+
+def _parse_json_list(raw: str | None) -> list:
+    if not raw:
+        return []
+    try:
+        parsed = json.loads(raw)
+        return parsed if isinstance(parsed, list) else []
+    except json.JSONDecodeError:
+        return []
+
+
+def scan_report_to_scan_model(report: ScanReport) -> SecurityScanModel:
+    """Internal red_team ScanReport → row (no tenant)."""
+    return SecurityScanModel(
+        scan_id=report.scan_id,
+        scan_type="internal",
+        tenant_id=None,
+        targets_json=_str_list_to_json(report.target_services),
+        attack_categories_json=_str_list_to_json(report.attack_categories),
+        intensity=report.intensity,
+        status=report.status.value,
+        total_tests_run=report.total_tests_run,
+        total_passed=report.total_passed,
+        total_failed=report.total_failed,
+        security_score=report.score,
+        recommendations_json=_str_list_to_json(report.recommendations),
+        started_at=report.started_at,
+        completed_at=report.completed_at,
+    )
+
+
+def vulnerability_to_model(vuln: Vulnerability) -> SecurityVulnerabilityModel:
+    return SecurityVulnerabilityModel(
+        vuln_id=vuln.vuln_id,
+        scan_id=vuln.scan_id,
+        category=vuln.category.value,
+        severity=vuln.severity.value,
+        title=vuln.title,
+        description=vuln.description,
+        endpoint=vuln.endpoint,
+        method=vuln.method,
+        evidence_json=(
+            json.dumps(vuln.evidence, default=str) if vuln.evidence else None
+        ),
+        remediation=vuln.remediation,
+        remediation_status=vuln.remediation_status.value,
+        cwe_id=vuln.cwe_id,
+        discovered_at=vuln.discovered_at,
+    )
+
+
+def vulnerability_model_to_schema(
+    row: SecurityVulnerabilityModel,
+) -> Vulnerability:
+    evidence: dict = {}
+    if row.evidence_json:
+        try:
+            loaded = json.loads(row.evidence_json)
+            evidence = loaded if isinstance(loaded, dict) else {"value": loaded}
+        except json.JSONDecodeError:
+            evidence = {}
+
+    return Vulnerability(
+        vuln_id=row.vuln_id,
+        scan_id=row.scan_id,
+        category=AttackCategory(row.category),
+        severity=RTSeverity(row.severity),
+        title=row.title,
+        description=row.description,
+        endpoint=row.endpoint,
+        method=row.method or "",
+        evidence=evidence,
+        remediation=row.remediation,
+        remediation_status=RemediationStatus(row.remediation_status),
+        cwe_id=row.cwe_id,
+        discovered_at=row.discovered_at,
+    )
+
+
+def scan_model_to_report(
+    scan: SecurityScanModel,
+    vulns: list[SecurityVulnerabilityModel],
+) -> ScanReport:
+    """Row + child vulns → internal ScanReport."""
+    vulnerabilities = [vulnerability_model_to_schema(v) for v in vulns]
+
+    severity_breakdown: dict[str, int] = {}
+    for v in vulnerabilities:
+        severity_breakdown[v.severity.value] = (
+            severity_breakdown.get(v.severity.value, 0) + 1
+        )
+
+    duration = None
+    if scan.started_at and scan.completed_at:
+        duration = (scan.completed_at - scan.started_at).total_seconds()
+
+    return ScanReport(
+        scan_id=scan.scan_id,
+        status=ScanStatus(scan.status),
+        started_at=scan.started_at or scan.created_at,
+        completed_at=scan.completed_at,
+        duration_seconds=duration,
+        target_services=_parse_json_list(scan.targets_json),
+        attack_categories=[
+            str(c) for c in _parse_json_list(scan.attack_categories_json)
+        ],
+        intensity=scan.intensity,
+        total_tests_run=scan.total_tests_run,
+        total_passed=scan.total_passed or 0,
+        total_failed=scan.total_failed or 0,
+        vulnerabilities_found=len(vulnerabilities),
+        severity_breakdown=severity_breakdown,
+        vulnerabilities=vulnerabilities,
+        recommendations=[
+            str(r) for r in _parse_json_list(scan.recommendations_json)
+        ],
+        score=scan.security_score,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Content factory
+# ---------------------------------------------------------------------------
+
+def content_piece_to_model(piece: GeneratedContent) -> ContentPieceModel:
+    return ContentPieceModel(
+        content_id=piece.content_id,
+        pipeline_id=piece.pipeline_id,
+        format=piece.format.value,
+        title=piece.title,
+        description=piece.description,
+        download_url=piece.download_url,
+        thumbnail_url=piece.thumbnail_url,
+        duration_seconds=piece.duration_seconds,
+        dimensions=piece.dimensions,
+        file_size_bytes=piece.file_size_bytes,
+        status=piece.status.value,
+        metadata_json=metadata_dict_to_json(piece.metadata),
+        generated_at=piece.generated_at,
+    )
+
+
+def content_piece_model_to_schema(row: ContentPieceModel) -> GeneratedContent:
+    return GeneratedContent(
+        content_id=row.content_id,
+        pipeline_id=row.pipeline_id,
+        format=ContentFormat(row.format),
+        title=row.title,
+        description=row.description,
+        download_url=row.download_url,
+        thumbnail_url=row.thumbnail_url,
+        duration_seconds=row.duration_seconds,
+        dimensions=row.dimensions,
+        file_size_bytes=row.file_size_bytes,
+        status=ContentStatus(row.status),
+        generated_at=row.generated_at,
+        metadata=parse_metadata_json(row.metadata_json),
+    )
+
+
+def schedule_recommendation_to_model(
+    rec: ScheduleRecommendation, schedule_id: str
+) -> ContentScheduleModel:
+    return ContentScheduleModel(
+        schedule_id=schedule_id,
+        content_id=rec.content_id,
+        platform=rec.platform,
+        recommended_time=rec.recommended_time,
+        confidence=rec.confidence,
+        reasoning=rec.reasoning,
+        estimated_views=rec.estimated_views,
+    )
+
+
+def schedule_model_to_recommendation(
+    row: ContentScheduleModel,
+) -> ScheduleRecommendation:
+    return ScheduleRecommendation(
+        content_id=row.content_id,
+        platform=row.platform,
+        recommended_time=row.recommended_time,
+        confidence=row.confidence,
+        reasoning=row.reasoning,
+        estimated_views=row.estimated_views,
     )

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -295,6 +295,214 @@ class TelemetryEventModel(SQLModel, table=True):
         arbitrary_types_allowed = True
 
 
+class OracleCrawlTargetModel(SQLModel, table=True):
+    """Crawl target lifecycle row (pending → crawling → indexed|failed)."""
+    __tablename__ = "oracle_crawl_targets"
+
+    target_id: str = Field(primary_key=True, max_length=64)
+    url: str = Field(max_length=2048, index=True)
+    directory_type: str = Field(max_length=30, index=True)
+    status: str = Field(max_length=20, index=True)
+    api_id: Optional[str] = Field(default=None, max_length=64, index=True)
+    queued_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    crawled_at: Optional[datetime] = Field(default=None)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class OracleIndexedAPIModel(SQLModel, table=True):
+    """An indexed external API with compatibility metadata."""
+    __tablename__ = "oracle_indexed_apis"
+
+    api_id: str = Field(primary_key=True, max_length=64)
+    url: str = Field(max_length=2048, index=True)
+    name: str = Field(max_length=255)
+    description: str = Field(default="", max_length=2000)
+    directory_type: str = Field(max_length=30, index=True)
+    compatibility_tier: str = Field(max_length=20, index=True)
+    compatibility_score: float = Field(default=0.0, index=True)
+    capabilities_json: Optional[str] = Field(default=None)
+    tags_json: Optional[str] = Field(default=None)
+    status: str = Field(max_length=20)
+    last_crawled: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class OracleRegistrationModel(SQLModel, table=True):
+    """One row per attempt to register our API in an external directory."""
+    __tablename__ = "oracle_registrations"
+
+    registration_id: str = Field(primary_key=True, max_length=64)
+    directory_url: str = Field(max_length=2048, index=True)
+    directory_type: str = Field(max_length=30, index=True)
+    status: str = Field(max_length=20, index=True)
+    message: str = Field(default="", max_length=2000)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class OracleDiscoveryHitModel(SQLModel, table=True):
+    """One row per inbound discovery hit for top-referrer aggregation."""
+    __tablename__ = "oracle_discovery_hits"
+
+    hit_id: str = Field(primary_key=True, max_length=64)
+    referrer: str = Field(default="direct", max_length=2048, index=True)
+    timestamp: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class SecurityScanModel(SQLModel, table=True):
+    """Shared scan table for red_team (internal) and rtaas (external)."""
+    __tablename__ = "security_scans"
+
+    scan_id: str = Field(primary_key=True, max_length=64)
+    scan_type: str = Field(max_length=20, index=True)
+    tenant_id: Optional[str] = Field(default=None, max_length=100, index=True)
+
+    targets_json: Optional[str] = Field(default=None)
+    attack_categories_json: Optional[str] = Field(default=None)
+    intensity: str = Field(default="standard", max_length=20)
+
+    status: str = Field(max_length=20, index=True)
+    total_tests_run: int = Field(default=0)
+    total_passed: Optional[int] = Field(default=None)
+    total_failed: Optional[int] = Field(default=None)
+    security_score: float = Field(default=0.0)
+
+    recommendations_json: Optional[str] = Field(default=None)
+
+    started_at: Optional[datetime] = Field(default=None)
+    completed_at: Optional[datetime] = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class SecurityVulnerabilityModel(SQLModel, table=True):
+    """Shared vulnerability rows for both scan types."""
+    __tablename__ = "security_vulnerabilities"
+
+    vuln_id: str = Field(primary_key=True, max_length=64)
+    scan_id: str = Field(
+        max_length=64,
+        foreign_key="security_scans.scan_id",
+        index=True,
+    )
+
+    category: str = Field(max_length=50, index=True)
+    severity: str = Field(max_length=20, index=True)
+    title: str = Field(max_length=500)
+    description: str = Field(default="", max_length=4000)
+
+    endpoint: str = Field(max_length=2048)
+    method: Optional[str] = Field(default=None, max_length=10)
+
+    evidence_json: Optional[str] = Field(default=None)
+    remediation: str = Field(default="", max_length=4000)
+    remediation_status: str = Field(default="open", max_length=30)
+    cwe_id: Optional[str] = Field(default=None, max_length=20)
+
+    discovered_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class ContentPipelineModel(SQLModel, table=True):
+    """Content factory pipeline instance."""
+    __tablename__ = "content_pipelines"
+
+    pipeline_id: str = Field(primary_key=True, max_length=64)
+    title: str = Field(max_length=500)
+    source_clip_id: Optional[str] = Field(default=None, max_length=100)
+    source_url: Optional[str] = Field(default=None, max_length=2048)
+    target_formats_json: Optional[str] = Field(default=None)
+    brand_config_json: Optional[str] = Field(default=None)
+    language: str = Field(default="en", max_length=10)
+    auto_schedule: bool = Field(default=True)
+    owner_key: str = Field(default="", max_length=255, index=True)
+    status: str = Field(default="queued", max_length=30, index=True)
+    hook_json: Optional[str] = Field(default=None)
+    caption_style: str = Field(default="bold_impact", max_length=30)
+    aspect_ratio: str = Field(default="9:16", max_length=10)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class ContentPieceModel(SQLModel, table=True):
+    """One generated content piece. download_url holds the blob ref."""
+    __tablename__ = "content_pieces"
+
+    content_id: str = Field(primary_key=True, max_length=64)
+    pipeline_id: str = Field(
+        max_length=64,
+        foreign_key="content_pipelines.pipeline_id",
+        index=True,
+    )
+    format: str = Field(max_length=30, index=True)
+    title: str = Field(max_length=500)
+    description: Optional[str] = Field(default=None, max_length=2000)
+    download_url: str = Field(max_length=2048)
+    thumbnail_url: Optional[str] = Field(default=None, max_length=2048)
+    duration_seconds: Optional[float] = Field(default=None)
+    dimensions: Optional[str] = Field(default=None, max_length=30)
+    file_size_bytes: Optional[int] = Field(default=None)
+    status: str = Field(max_length=20, index=True)
+    metadata_json: Optional[str] = Field(default=None)
+    generated_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class ContentCampaignModel(SQLModel, table=True):
+    """Top-level live campaign linking many pipelines + hooks."""
+    __tablename__ = "content_campaigns"
+
+    campaign_id: str = Field(primary_key=True, max_length=64)
+    campaign_title: str = Field(max_length=500)
+    source_url: str = Field(max_length=2048)
+    hooks_json: Optional[str] = Field(default=None)
+    pipeline_ids_json: Optional[str] = Field(default=None)
+    status: str = Field(default="running", max_length=30, index=True)
+    owner_key: str = Field(default="", max_length=255, index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
+class ContentScheduleModel(SQLModel, table=True):
+    """Persisted scheduler recommendations."""
+    __tablename__ = "content_schedules"
+
+    schedule_id: str = Field(primary_key=True, max_length=64)
+    content_id: str = Field(
+        max_length=64,
+        foreign_key="content_pieces.content_id",
+        index=True,
+    )
+    platform: str = Field(max_length=50, index=True)
+    recommended_time: datetime = Field(index=True)
+    confidence: float = Field(default=0.0)
+    reasoning: str = Field(default="", max_length=2000)
+    estimated_views: Optional[int] = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+
+    class Config:
+        arbitrary_types_allowed = True
+
+
 class KeyRotationLogModel(SQLModel, table=True):
     """
     Audit log for API key rotations.

--- a/app/services/content_factory.py
+++ b/app/services/content_factory.py
@@ -25,7 +25,19 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone, timedelta
 
+from sqlalchemy import select
+
 from ..core.runtime_mode import require_simulation
+from ..db.converters import (
+    content_piece_model_to_schema,
+    content_piece_to_model,
+)
+from ..db.database import get_session_factory, is_database_configured
+from ..db.models import (
+    ContentCampaignModel,
+    ContentPieceModel,
+    ContentPipelineModel,
+)
 from ..schemas.content_factory import (
     ContentFormat,
     ContentStatus,

--- a/app/services/oracle.py
+++ b/app/services/oracle.py
@@ -24,7 +24,22 @@ import hashlib
 from collections import defaultdict
 from datetime import datetime, timezone
 
+from sqlalchemy import select, func
+
 from ..core.runtime_mode import require_simulation
+from ..db.converters import (
+    indexed_api_to_model,
+    indexed_api_model_to_schema,
+    registration_result_to_model,
+    registration_model_to_schema,
+)
+from ..db.database import get_session_factory, is_database_configured
+from ..db.models import (
+    OracleCrawlTargetModel,
+    OracleDiscoveryHitModel,
+    OracleIndexedAPIModel,
+    OracleRegistrationModel,
+)
 from ..schemas.oracle import (
     OracleStatus,
     DirectoryType,

--- a/app/services/red_team.py
+++ b/app/services/red_team.py
@@ -24,7 +24,16 @@ from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from sqlalchemy import select
+
 from ..core.runtime_mode import require_simulation
+from ..db.converters import (
+    scan_report_to_scan_model,
+    scan_model_to_report,
+    vulnerability_to_model,
+)
+from ..db.database import get_session_factory, is_database_configured
+from ..db.models import SecurityScanModel, SecurityVulnerabilityModel
 
 from ..schemas.red_team import (
     AttackCategory,

--- a/app/services/rtaas.py
+++ b/app/services/rtaas.py
@@ -24,7 +24,11 @@ import logging
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 
+from sqlalchemy import select
+
 from ..core.runtime_mode import require_simulation
+from ..db.database import get_session_factory, is_database_configured
+from ..db.models import SecurityScanModel, SecurityVulnerabilityModel
 
 from ..schemas.red_team import AttackCategory, Severity
 


### PR DESCRIPTION
## What broke

PR squashes for [#44 (issue #29)](https://github.com/PetrefiedThunder/agent-middleware-api/pull/44), [#45 (#30)](https://github.com/PetrefiedThunder/agent-middleware-api/pull/45), and [#51 (#31)](https://github.com/PetrefiedThunder/agent-middleware-api/pull/51) landed with the \`app/db/models.py\` and \`app/db/converters.py\` edits dropped. The service rewrites and migrations merged fine, but the matching SQLModel classes and converter functions didn't. Result on master today: every test errors on collection with \`NameError: name 'OracleCrawlTargetModel' is not defined\` and similar.

Verified by looking at PR #44's stats — only 3 files: oracle.py, migration, test. Same pattern on #45 and #51. Only [#43 (#28)](https://github.com/PetrefiedThunder/agent-middleware-api/pull/43) merged cleanly with all files.

## What this PR restores

Rebuilt from the migration files as the schema source of truth.

- \`app/db/models.py\`: **10 SQLModel classes** — Oracle (4), Security (2 with discriminator), Content factory (4)
- \`app/db/converters.py\`: **12 converter functions** — schema ↔ row for each domain
- Service files: restored \`sqlalchemy\`, \`db.database\`, \`db.models\`, \`db.converters\` imports in oracle.py, red_team.py, rtaas.py, content_factory.py. Service code was already calling these at runtime — just brings the imports back.

## Test plan

- [x] \`pytest\` collects all tests (was 0 collected / 31 errors)
- [x] **485 passed, 2 skipped, 0 failed** — matches the pre-breakage state from #51
- [ ] Confirm on CI

## Follow-up

This unblocks issue [#32](https://github.com/PetrefiedThunder/agent-middleware-api/issues/32) (IoT DeviceRegistry → PG + Redis). I'll stack that PR on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added persistent storage for Oracle API crawling, indexing, and registration workflows
  * Enabled comprehensive storage and retrieval of security scan reports with vulnerability records
  * Introduced data persistence for content generation pipelines, individual content pieces, and scheduling recommendations
  * Integrated database storage across multiple services for reliable data persistence and retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->