### PR TITLE
[codex] Harden production beta security surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,39 @@
 ![Python](https://img.shields.io/badge/Python-3.11%2B-blue)
 ![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-green)
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue)
-![Tests](https://img.shields.io/badge/Tests-339%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/Tests-517%20passing-brightgreen)
 ![MCP](https://img.shields.io/badge/MCP-Native-orange)
 ![AWI](https://img.shields.io/badge/AWI-v1.0- purple)
 ![Docker](https://img.shields.io/badge/Docker-Ready-blue)
 ![Stars](https://img.shields.io/github/stars/PetrefiedThunder/agent-middleware-api?style=social)
 
-> **Now v1.1 — Fully Agent-Discoverable.** Built on arXiv:2506.10953v1.
+> **Production beta — agent-discoverable, not production complete.** Built on arXiv:2506.10953v1.
 
 **The FastAPI control plane for agent-native infrastructure — MCP + AWI powered.**
+
+### Current Implementation Status
+
+This repository is a production-beta control plane, not a finished production
+platform. The wallet/key auth path, billing ledger, MCP discovery, health checks,
+golden-path flow, and core API contracts are executable and tested. Several
+larger product pillars intentionally default to simulation mode and return
+synthetic data until their real integrations land:
+
+- agent oracle
+- red-team swarm
+- RTaaS
+- media engine
+- IoT bridge
+- autonomous telemetry PM
+- agent comms
+- content factory
+
+Agents and operators should inspect `GET /health/dependencies` and the
+`SIMULATION_MODE_*` environment flags before assuming an endpoint performs real
+external work. Public arbitrary Python execution is disabled by default. Set
+`BEHAVIORAL_SANDBOX_PYTHON_BACKEND=docker` to run Python in an unprivileged
+Docker container; `ALLOW_UNSAFE_HOST_PYTHON_SANDBOX=true` is a
+local-development escape hatch and is not a production sandbox.
 
 ### For Autonomous Agents
 
@@ -44,7 +68,11 @@ from agent_middleware import CrewAIB2ATool
 crewai_tools = [CrewAIB2ATool(api_key="...", wallet_id="...")]
 ```
 
-**Agent Middleware API** is a production-ready FastAPI service that provides durable state, billing, telemetry, secure tool execution, IoT connectivity, and **AI-powered agent intelligence** for autonomous agents.
+**Agent Middleware API** is a FastAPI production-beta service that provides
+agent-discoverable contracts for durable state, wallet-scoped billing,
+telemetry, sandboxed tool workflows, IoT connectivity, and agent intelligence.
+Some domains are implemented as simulations until their production integrations
+are wired up.
 
 It lets agents:
 
@@ -523,13 +551,21 @@ POST /v1/billing/dry-run/session/{session_id}/revert
 
 ## Behavioral Sandbox Engine (Phase 6)
 
-**Real tool execution testing with subprocess isolation and resource limits.**
+**Authenticated tool-behavior testing with safe dry runs, mocked backends, and optional Docker isolation.**
 
-Unlike dry-run sandbox (cost simulation), the behavioral sandbox executes actual tools in isolated environments for testing behavior before production.
+The behavioral sandbox is not a general-purpose code execution platform. Python
+dry runs return synthetic execution metadata by default. Real Python execution
+requires `BEHAVIORAL_SANDBOX_PYTHON_BACKEND=docker`, which runs code with no
+network, dropped capabilities, a read-only filesystem, resource limits, and an
+unprivileged user. Direct host Python subprocess execution is blocked unless
+`ALLOW_UNSAFE_HOST_PYTHON_SANDBOX=true` is set for local development, and that
+mode must not be treated as production isolation.
 
 ### Features
 
-- **Python subprocess execution** with memory/CPU limits
+- **Python dry-run simulation** by default
+- **Docker backend** for container-bounded Python execution
+- **Opt-in unsafe host Python subprocess mode** for local development only
 - **MCP tool sandboxing** with mocked responses
 - **HTTP proxy mode** for API testing
 - **Redis-backed state isolation** per environment
@@ -538,23 +574,23 @@ Unlike dry-run sandbox (cost simulation), the behavioral sandbox executes actual
 
 ```bash
 # Create a sandbox environment
-curl -X POST http://localhost:8000/v1/sandbox/environments \
+curl -X POST http://localhost:8000/v1/sandbox/behavioral/environments \
   -H "X-API-Key: your-key" \
   -H "Content-Type: application/json" \
-  -d '{"env_type": "python", "name": "test-env"}'
+  -d '{"environment_type": "python_subprocess", "name": "test-env"}'
 
 # Execute a tool in sandbox
-curl -X POST http://localhost:8000/v1/sandbox/execute \
+curl -X POST http://localhost:8000/v1/sandbox/behavioral/execute \
   -H "X-API-Key: your-key" \
   -H "Content-Type: application/json" \
-  -d '{"env_id": "...", "tool": "my_tool", "params": {"input": "test"}}'
+  -d '{"env_id": "...", "tool_name": "my_tool", "tool_input": {"code": "print(42)"}, "dry_run": true}'
 
-# Get sandbox metrics
-curl http://localhost:8000/v1/sandbox/metrics/{env_id} \
+# Get sandbox state
+curl http://localhost:8000/v1/sandbox/behavioral/environments/{env_id} \
   -H "X-API-Key: your-key"
 
 # Cleanup sandbox
-curl -X DELETE http://localhost:8000/v1/sandbox/environments/{env_id} \
+curl -X DELETE http://localhost:8000/v1/sandbox/behavioral/environments/{env_id} \
   -H "X-API-Key: your-key"
 ```
 
@@ -879,8 +915,12 @@ railway variables get DATABASE_URL
 
 Current durable service stores:
 - Billing (`wallets`, `ledger`, `alerts`, `velocity_snapshots`, `services`)
-- Comms (`agent registry`, `inbox`, `outbox`)
+- Comms (`agent registry`, row-keyed `inbox` and `outbox` messages)
 - Telemetry (`events`, `anomalies`)
+
+Billing responses keep legacy numeric fields and also include `*_exact` decimal
+string companions for programmatic reconciliation, for example `balance_exact`,
+`amount_exact`, and `period_debits_exact`.
 
 ---
 
@@ -896,7 +936,7 @@ Current durable service stores:
 - [x] Stripe Identity (KYC) for sponsor verification
 - [x] Automated API key rotation for wallets
 - [x] Sandbox engine wired to billing
-- [x] Behavioral Sandbox Engine (subprocess isolation, MCP sandboxing)
+- [x] Behavioral Sandbox Engine (safe dry runs, mocked MCP sandboxing)
 - [x] Full Agentic Web Interface (AWI) control plane
 - [x] External AWI Adoption Kit (Python/TS SDKs, manifest generator, adapter)
 - [x] Add comprehensive agent interaction examples and recipes

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -44,6 +44,18 @@ class AuthContext:
             },
         )
 
+    def require_bootstrap_admin(self) -> None:
+        """Allow only trusted bootstrap/admin environment keys."""
+        if self.is_bootstrap_admin:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "admin_access_denied",
+                "message": "This operation requires a bootstrap admin API key.",
+            },
+        )
+
 
 async def get_auth_context(
     api_key: str | None = Security(api_key_header),

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -121,6 +121,18 @@ class Settings(BaseSettings):
     PLAYWRIGHT_HEADLESS: bool = True
     PLAYWRIGHT_BROWSER_TYPE: str = "chromium"
     PLAYWRIGHT_TIMEOUT_MS: int = 30000
+    PLAYWRIGHT_MAX_SESSIONS: int = 8
+
+    # --- Behavioral Sandbox ---
+    # Python execution backend: disabled, docker, or unsafe_host. Docker is the
+    # only built-in backend intended to provide an actual process boundary.
+    BEHAVIORAL_SANDBOX_PYTHON_BACKEND: str = "disabled"
+    BEHAVIORAL_SANDBOX_DOCKER_IMAGE: str = "python:3.12-slim"
+
+    # Legacy local-development escape hatch. Host Python execution is not a
+    # production sandbox; keep this false unless an external isolation layer
+    # such as a container runtime, gVisor, or Firecracker owns the boundary.
+    ALLOW_UNSAFE_HOST_PYTHON_SANDBOX: bool = False
 
     # --- Phase 9: RAG Engine ---
     RAG_VECTOR_STORE_PATH: str = "./data/awi_vectors"

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -174,6 +174,7 @@ def get_playwright_bridge() -> AWIPlaywrightBridge:
         headless=settings.PLAYWRIGHT_HEADLESS,
         browser_type=settings.PLAYWRIGHT_BROWSER_TYPE,
         default_timeout_ms=settings.PLAYWRIGHT_TIMEOUT_MS,
+        max_sessions=settings.PLAYWRIGHT_MAX_SESSIONS,
     )
 
 

--- a/app/core/durable_state.py
+++ b/app/core/durable_state.py
@@ -263,6 +263,49 @@ class DurableStateStore:
         await self._redis.delete(self._redis_key(key))
         return True
 
+    async def list_keys(self, prefix: str) -> list[str]:
+        """List durable state keys by prefix for row-keyed service state."""
+        await self._ensure_ready()
+        if self._backend == "memory":
+            return []
+
+        if self._backend == "postgres":
+            assert self._pg_pool is not None
+            async with self._pg_pool.acquire() as conn:
+                rows = await conn.fetch(
+                    """
+                    SELECT state_key
+                    FROM app_state_kv
+                    WHERE namespace = $1 AND state_key LIKE $2
+                    ORDER BY state_key
+                    """,
+                    self.namespace,
+                    f"{prefix}%",
+                )
+            return [row["state_key"] for row in rows]
+
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            async with self._sqlite_conn.execute(
+                """
+                SELECT state_key
+                FROM app_state_kv
+                WHERE namespace = ? AND state_key LIKE ?
+                ORDER BY state_key
+                """,
+                (self.namespace, f"{prefix}%"),
+            ) as cursor:
+                rows = await cursor.fetchall()
+            return [row["state_key"] for row in rows]
+
+        assert self._redis is not None
+        keys: list[str] = []
+        redis_prefix = self._redis_key(prefix)
+        async for key in self._redis.scan_iter(match=f"{redis_prefix}*"):
+            if key.startswith(f"{self.namespace}:"):
+                keys.append(key.split(":", 1)[1])
+        return sorted(keys)
+
     async def health_report(self) -> dict[str, Any]:
         await self._ensure_ready()
 

--- a/app/routers/awi.py
+++ b/app/routers/awi.py
@@ -13,8 +13,9 @@ Provides standardized, stateful interfaces for web agents with:
 
 import logging
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 
+from ..core.auth import AuthContext, get_auth_context
 from ..schemas.awi import (
     AWIHumanIntervention,
     AWIRepresentationRequest,
@@ -36,6 +37,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/v1/awi", tags=["AWI"])
 
 
+async def _require_session_access(session_id: str, auth: AuthContext) -> AWISession:
+    """Authorize access to an AWI session before exposing or mutating state."""
+    manager = get_awi_session_manager()
+    session = await manager.get_session(session_id)
+
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "not_found", "message": f"Session {session_id} not found"},
+        )
+
+    if session.wallet_id:
+        auth.require_wallet_access(session.wallet_id)
+    else:
+        auth.require_bootstrap_admin()
+
+    return session
+
+
 @router.post(
     "/sessions",
     response_model=AWISession,
@@ -46,13 +66,21 @@ router = APIRouter(prefix="/v1/awi", tags=["AWI"])
         "Based on arXiv:2506.10953v1 - Stateful interfaces for web agents."
     ),
 )
-async def create_session(request: AWISessionCreate):
+async def create_session(
+    request: AWISessionCreate,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Create a new Agentic Web Interface (AWI) session.
 
     Sessions provide stateful context for web agent interactions,
     enabling higher-level unified actions instead of raw DOM manipulation.
     """
+    if request.wallet_id:
+        auth.require_wallet_access(request.wallet_id)
+    else:
+        auth.require_bootstrap_admin()
+
     try:
         manager = get_awi_session_manager()
         return await manager.create_session(request)
@@ -69,18 +97,12 @@ async def create_session(request: AWISessionCreate):
     summary="Get AWI session",
     description="Get the current state of an AWI session.",
 )
-async def get_session(session_id: str):
+async def get_session(
+    session_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Get the current state of an AWI session."""
-    manager = get_awi_session_manager()
-    session = await manager.get_session(session_id)
-
-    if not session:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"error": "not_found", "message": f"Session {session_id} not found"},
-        )
-
-    return session
+    return await _require_session_access(session_id, auth)
 
 
 @router.delete(
@@ -89,8 +111,12 @@ async def get_session(session_id: str):
     summary="Destroy AWI session",
     description="Destroy an AWI session and release resources.",
 )
-async def destroy_session(session_id: str):
+async def destroy_session(
+    session_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Destroy an AWI session."""
+    await _require_session_access(session_id, auth)
     manager = get_awi_session_manager()
     destroyed = await manager.destroy_session(session_id)
 
@@ -107,7 +133,10 @@ async def destroy_session(session_id: str):
     summary="Execute AWI action",
     description="Execute a standardized AWI action within a session.",
 )
-async def execute_action(request: AWIExecutionRequest):
+async def execute_action(
+    request: AWIExecutionRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Execute a standardized AWI action.
 
@@ -115,8 +144,11 @@ async def execute_action(request: AWIExecutionRequest):
     of raw DOM manipulation, making agents more robust and website-independent.
     """
     try:
+        await _require_session_access(request.session_id, auth)
         manager = get_awi_session_manager()
         return await manager.execute_action(request)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception(f"AWI execution failed: {request.session_id}")
         raise HTTPException(
@@ -131,7 +163,10 @@ async def execute_action(request: AWIExecutionRequest):
     summary="Request representation",
     description="Request a specific representation of the current session state.",
 )
-async def request_representation(request: AWIRepresentationRequest):
+async def request_representation(
+    request: AWIRepresentationRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Request a specific representation of the session state.
 
@@ -139,6 +174,7 @@ async def request_representation(request: AWIRepresentationRequest):
     low-res screenshot, etc.) instead of receiving full DOM every time.
     """
     try:
+        await _require_session_access(request.session_id, auth)
         manager = get_awi_session_manager()
         result = await manager.request_representation(request)
 
@@ -167,7 +203,10 @@ async def request_representation(request: AWIRepresentationRequest):
     summary="Human intervention",
     description="Pause, resume, or steer an AWI session (human-in-the-loop).",
 )
-async def human_intervention(intervention: AWIHumanIntervention):
+async def human_intervention(
+    intervention: AWIHumanIntervention,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Human intervention in an AWI session.
 
@@ -175,8 +214,11 @@ async def human_intervention(intervention: AWIHumanIntervention):
     and alignment with human preferences.
     """
     try:
+        await _require_session_access(intervention.session_id, auth)
         manager = get_awi_session_manager()
         return await manager.human_intervention(intervention)
+    except HTTPException:
+        raise
     except Exception as e:
         logger.exception("Human intervention failed")
         raise HTTPException(
@@ -241,8 +283,12 @@ async def list_actions_by_category(category: AWIActionCategory):
     summary="Create AWI task",
     description="Create a new AWI task in the queue.",
 )
-async def create_task(request: AWITaskCreate):
+async def create_task(
+    request: AWITaskCreate,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Create a new AWI task in the queue."""
+    auth.require_bootstrap_admin()
     try:
         queue = get_awi_task_queue()
         return await queue.create_task(request)
@@ -259,8 +305,12 @@ async def create_task(request: AWITaskCreate):
     summary="Get task status",
     description="Get the status of an AWI task.",
 )
-async def get_task(task_id: str):
+async def get_task(
+    task_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Get the status of an AWI task."""
+    auth.require_bootstrap_admin()
     queue = get_awi_task_queue()
     task = await queue.get_task(task_id)
 
@@ -279,8 +329,9 @@ async def get_task(task_id: str):
     summary="Get queue status",
     description="Get current status of the AWI task queue.",
 )
-async def get_queue_status():
+async def get_queue_status(auth: AuthContext = Depends(get_auth_context)):
     """Get current status of the AWI task queue."""
+    auth.require_bootstrap_admin()
     queue = get_awi_task_queue()
     return await queue.get_queue_status()
 
@@ -290,8 +341,12 @@ async def get_queue_status():
     summary="Global pause",
     description="Pause all tasks globally (human intervention).",
 )
-async def global_pause(reason: str | None = None):
+async def global_pause(
+    reason: str | None = None,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Pause all AWI tasks globally."""
+    auth.require_bootstrap_admin()
     queue = get_awi_task_queue()
     await queue.global_pause(reason)
     return {"success": True, "status": "paused", "reason": reason}
@@ -302,8 +357,9 @@ async def global_pause(reason: str | None = None):
     summary="Global resume",
     description="Resume all AWI tasks after global pause.",
 )
-async def global_resume():
+async def global_resume(auth: AuthContext = Depends(get_auth_context)):
     """Resume all AWI tasks after global pause."""
+    auth.require_bootstrap_admin()
     queue = get_awi_task_queue()
     await queue.global_resume()
     return {"success": True, "status": "resumed"}

--- a/app/routers/awi_enhanced.py
+++ b/app/routers/awi_enhanced.py
@@ -15,9 +15,10 @@ from datetime import datetime
 from typing import Any
 from uuid import uuid4
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
+from ..core.auth import AuthContext, get_auth_context
 from ..schemas.awi_enhanced import (
     DOMBridgeSessionRequest,
     DOMBridgeSessionResponse,
@@ -39,10 +40,60 @@ from ..schemas.awi_enhanced import (
     SessionContextRequest,
     SessionContextResponse,
 )
+from ..services.awi_playwright_bridge import BrowserSessionLimitExceeded
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/v1/awi", tags=["AWI Enhanced"])
+_DOM_SESSION_WALLETS: dict[str, str | None] = {}
+
+
+async def _require_awi_session_access(session_id: str, auth: AuthContext) -> None:
+    """Authorize access to wallet-scoped AWI session state."""
+    from ..services.awi_session import get_awi_session_manager
+
+    manager = get_awi_session_manager()
+    session = await manager.get_session(session_id)
+
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "not_found", "message": f"Session {session_id} not found"},
+        )
+
+    if session.wallet_id:
+        auth.require_wallet_access(session.wallet_id)
+    else:
+        auth.require_bootstrap_admin()
+
+
+async def _require_dom_session_access(session_id: str, auth: AuthContext) -> None:
+    """Authorize access to standalone DOM bridge sessions."""
+    from ..services.awi_playwright_bridge import get_playwright_bridge
+
+    bridge = get_playwright_bridge()
+    session = await bridge.get_session(session_id)
+    if not session:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "not_found", "message": f"Session {session_id} not found"},
+        )
+
+    wallet_id = _DOM_SESSION_WALLETS.get(session_id)
+    if wallet_id:
+        auth.require_wallet_access(wallet_id)
+    else:
+        auth.require_bootstrap_admin()
+
+
+async def _require_memory_access(session_id: str, auth: AuthContext) -> None:
+    """Authorize access to RAG memories through their owning AWI session."""
+    try:
+        await _require_awi_session_access(session_id, auth)
+    except HTTPException as exc:
+        if exc.status_code != status.HTTP_404_NOT_FOUND:
+            raise
+        auth.require_bootstrap_admin()
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -56,7 +107,10 @@ router = APIRouter(prefix="/v1/awi", tags=["AWI Enhanced"])
     summary="Create passkey challenge",
     description="Create a WebAuthn challenge for high-risk AWI action verification.",
 )
-async def create_passkey_challenge(request: PasskeyChallengeRequest):
+async def create_passkey_challenge(
+    request: PasskeyChallengeRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Create a WebAuthn registration/authentication challenge.
 
@@ -64,6 +118,8 @@ async def create_passkey_challenge(request: PasskeyChallengeRequest):
     options, then call /passkey/verify with the credential response.
     """
     from ..services.webauthn_provider import get_webauthn_provider
+
+    await _require_awi_session_access(request.session_id, auth)
 
     webauthn = get_webauthn_provider()
 
@@ -102,7 +158,10 @@ async def create_passkey_challenge(request: PasskeyChallengeRequest):
     summary="Verify passkey response",
     description="Verify the WebAuthn credential response from the client.",
 )
-async def verify_passkey(request: PasskeyVerifyRequest):
+async def verify_passkey(
+    request: PasskeyVerifyRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Verify WebAuthn assertion response.
 
@@ -112,6 +171,14 @@ async def verify_passkey(request: PasskeyVerifyRequest):
     from ..services.webauthn_provider import get_webauthn_provider
 
     webauthn = get_webauthn_provider()
+    challenge = webauthn.get_challenge(request.challenge_id)
+    if not challenge:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail={"error": "verification_failed", "message": "Challenge not found"},
+        )
+
+    await _require_awi_session_access(challenge.session_id, auth)
 
     try:
         result = await webauthn.verify_response(
@@ -138,9 +205,15 @@ async def verify_passkey(request: PasskeyVerifyRequest):
     summary="Check passkey verification status",
     description="Check if a session:action pair has valid passkey verification.",
 )
-async def check_passkey_status(session_id: str, action: str):
+async def check_passkey_status(
+    session_id: str,
+    action: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Check if the action is currently verified for this session."""
     from ..services.webauthn_provider import get_webauthn_provider
+
+    await _require_awi_session_access(session_id, auth)
 
     webauthn = get_webauthn_provider()
 
@@ -153,9 +226,15 @@ async def check_passkey_status(session_id: str, action: str):
     summary="Invalidate passkey verifications",
     description="Invalidate all passkey verifications for a session.",
 )
-async def invalidate_passkey(session_id: str, action: str | None = None):
+async def invalidate_passkey(
+    session_id: str,
+    action: str | None = None,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Invalidate passkey verifications for a session."""
     from ..services.webauthn_provider import get_webauthn_provider
+
+    await _require_awi_session_access(session_id, auth)
 
     webauthn = get_webauthn_provider()
 
@@ -173,7 +252,7 @@ async def invalidate_passkey(session_id: str, action: str | None = None):
     summary="List high-risk actions",
     description="Get list of actions that require passkey verification.",
 )
-async def list_high_risk_actions():
+async def list_high_risk_actions(auth: AuthContext = Depends(get_auth_context)):
     """Get all actions that require passkey verification."""
     from ..services.webauthn_provider import get_webauthn_provider
 
@@ -213,7 +292,10 @@ class DOMAttachResponse(BaseModel):
     summary="Attach DOM bridge to AWI session",
     description="Attach a Playwright DOM bridge to an existing AWI session for live browser automation.",
 )
-async def attach_dom_bridge(request: DOMAttachRequest):
+async def attach_dom_bridge(
+    request: DOMAttachRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Attach a Playwright DOM bridge to an existing AWI session.
 
@@ -229,6 +311,8 @@ async def attach_dom_bridge(request: DOMAttachRequest):
     """
     from ..services.awi_session import get_awi_session_manager
 
+    await _require_awi_session_access(request.session_id, auth)
+
     manager = get_awi_session_manager()
 
     try:
@@ -237,6 +321,11 @@ async def attach_dom_bridge(request: DOMAttachRequest):
             target_url=request.target_url,
         )
         return DOMAttachResponse(**result)
+    except BrowserSessionLimitExceeded as e:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"error": "dom_session_limit_exceeded", "message": str(e)},
+        )
     except ValueError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -254,13 +343,18 @@ async def attach_dom_bridge(request: DOMAttachRequest):
     "/dom/attach/{session_id}",
     summary="Detach DOM bridge from AWI session",
 )
-async def detach_dom_bridge(session_id: str):
+async def detach_dom_bridge(
+    session_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Detach the Playwright DOM bridge from an AWI session.
 
     Returns the session to mock/internal AWI mode. The browser context is closed.
     """
     from ..services.awi_session import get_awi_session_manager
+
+    await _require_awi_session_access(session_id, auth)
 
     manager = get_awi_session_manager()
 
@@ -279,11 +373,16 @@ async def detach_dom_bridge(session_id: str):
     "/dom/attach/{session_id}/status",
     summary="Get DOM bridge status",
 )
-async def get_dom_bridge_status(session_id: str):
+async def get_dom_bridge_status(
+    session_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Check if a session has a DOM bridge attached.
     """
     from ..services.awi_session import get_awi_session_manager
+
+    await _require_awi_session_access(session_id, auth)
 
     manager = get_awi_session_manager()
 
@@ -298,14 +397,25 @@ async def get_dom_bridge_status(session_id: str):
     summary="Create DOM bridge session",
     description="Create a browser session for bidirectional DOM translation.",
 )
-async def create_dom_session(request: DOMBridgeSessionRequest):
+async def create_dom_session(
+    request: DOMBridgeSessionRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Create a new Playwright bridge session.
 
     The session opens a headless browser and navigates to the target URL.
     Use the returned session_id for subsequent DOM operations.
     """
-    from ..services.awi_playwright_bridge import get_playwright_bridge
+    from ..services.awi_playwright_bridge import (
+        BrowserSessionLimitExceeded,
+        get_playwright_bridge,
+    )
+
+    if request.wallet_id:
+        auth.require_wallet_access(request.wallet_id)
+    else:
+        auth.require_bootstrap_admin()
 
     bridge = get_playwright_bridge()
 
@@ -315,9 +425,15 @@ async def create_dom_session(request: DOMBridgeSessionRequest):
             headless=request.headless,
             viewport=(request.viewport_width, request.viewport_height),
         )
+        _DOM_SESSION_WALLETS[session.session_id] = request.wallet_id
         return DOMBridgeSessionResponse(
             session_id=session.session_id,
             current_url=session.current_url or request.target_url,
+        )
+    except BrowserSessionLimitExceeded as e:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail={"error": "dom_session_limit_exceeded", "message": str(e)},
         )
     except Exception as e:
         logger.exception("Failed to create DOM session")
@@ -332,13 +448,19 @@ async def create_dom_session(request: DOMBridgeSessionRequest):
     status_code=status.HTTP_204_NO_CONTENT,
     summary="Destroy DOM bridge session",
 )
-async def destroy_dom_session(session_id: str):
+async def destroy_dom_session(
+    session_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Destroy a Playwright bridge session and cleanup resources."""
     from ..services.awi_playwright_bridge import get_playwright_bridge
+
+    await _require_dom_session_access(session_id, auth)
 
     bridge = get_playwright_bridge()
 
     destroyed = await bridge.destroy_session(session_id)
+    _DOM_SESSION_WALLETS.pop(session_id, None)
 
     if not destroyed:
         raise HTTPException(
@@ -352,13 +474,19 @@ async def destroy_dom_session(session_id: str):
     summary="List DOM sessions",
     description="List all active DOM bridge sessions.",
 )
-async def list_dom_sessions():
+async def list_dom_sessions(auth: AuthContext = Depends(get_auth_context)):
     """List all active DOM bridge sessions."""
     from ..services.awi_playwright_bridge import get_playwright_bridge
 
     bridge = get_playwright_bridge()
 
     sessions = await bridge.list_sessions()
+    if not auth.is_bootstrap_admin:
+        sessions = [
+            s
+            for s in sessions
+            if _DOM_SESSION_WALLETS.get(s["session_id"]) == auth.wallet_id
+        ]
 
     return {
         "sessions": sessions,
@@ -372,7 +500,10 @@ async def list_dom_sessions():
     summary="Execute AWI action via DOM",
     description="Execute an AWI action against real browser DOM via Playwright.",
 )
-async def sync_dom(request: DOMSyncRequest):
+async def sync_dom(
+    request: DOMSyncRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Bidirectional AWI ↔ DOM translation.
 
@@ -380,6 +511,8 @@ async def sync_dom(request: DOMSyncRequest):
     and returns the resulting state representation.
     """
     from ..services.awi_playwright_bridge import get_playwright_bridge
+
+    await _require_dom_session_access(request.session_id, auth)
 
     bridge = get_playwright_bridge()
 
@@ -434,9 +567,12 @@ async def sync_dom(request: DOMSyncRequest):
 async def get_dom_state(
     session_id: str,
     representation_type: DOMRepresentationType = DOMRepresentationType.SUMMARY,
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """Get current DOM state as AWI representation."""
     from ..services.awi_playwright_bridge import get_playwright_bridge
+
+    await _require_dom_session_access(session_id, auth)
 
     bridge = get_playwright_bridge()
 
@@ -479,9 +615,14 @@ async def get_dom_state(
     summary="Preview AWI action translation",
     description="Preview what commands will be generated for an action.",
 )
-async def preview_action(request: DOMSyncRequest):
+async def preview_action(
+    request: DOMSyncRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Preview commands without executing them."""
     from ..services.awi_playwright_bridge import get_playwright_bridge
+
+    await _require_dom_session_access(request.session_id, auth)
 
     bridge = get_playwright_bridge()
 
@@ -517,13 +658,18 @@ async def preview_action(request: DOMSyncRequest):
     summary="Index AWI session",
     description="Index a completed AWI session for future retrieval.",
 )
-async def index_session(request: MemoryIndexRequest):
+async def index_session(
+    request: MemoryIndexRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Index an AWI session for semantic search.
 
     Extracts entities, infers intent, and generates embeddings for retrieval.
     """
     from ..services.awi_rag_engine import get_awi_rag_engine
+
+    await _require_awi_session_access(request.session_id, auth)
 
     rag = get_awi_rag_engine()
 
@@ -560,13 +706,18 @@ async def index_session(request: MemoryIndexRequest):
     summary="Query session memories",
     description="Semantic search over past AWI session memories.",
 )
-async def query_memories(request: RAGQueryRequest):
+async def query_memories(
+    request: RAGQueryRequest,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """
     Query session memories with natural language.
 
     Returns relevant past sessions sorted by similarity to the query.
     """
     from ..services.awi_rag_engine import get_awi_rag_engine
+
+    auth.require_bootstrap_admin()
 
     rag = get_awi_rag_engine()
 
@@ -618,7 +769,10 @@ async def query_memories(request: RAGQueryRequest):
     summary="Get memory details",
     description="Get detailed information about a specific memory.",
 )
-async def get_memory(memory_id: str):
+async def get_memory(
+    memory_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Get a specific memory by ID."""
     from ..services.awi_rag_engine import get_awi_rag_engine
 
@@ -631,6 +785,8 @@ async def get_memory(memory_id: str):
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"error": "not_found", "message": f"Memory {memory_id} not found"},
         )
+
+    await _require_memory_access(memory.session_id, auth)
 
     return {
         "memory_id": memory.memory_id,
@@ -653,11 +809,22 @@ async def get_memory(memory_id: str):
     summary="Delete memory",
     description="Delete a memory from the index.",
 )
-async def delete_memory(memory_id: str):
+async def delete_memory(
+    memory_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Delete a specific memory."""
     from ..services.awi_rag_engine import get_awi_rag_engine
 
     rag = get_awi_rag_engine()
+    memory = await rag.get_memory(memory_id)
+    if not memory:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "not_found", "message": f"Memory {memory_id} not found"},
+        )
+
+    await _require_memory_access(memory.session_id, auth)
 
     deleted = await rag.delete_memory(memory_id)
 
@@ -678,6 +845,7 @@ async def get_session_context(
     session_id: str,
     session_type: str | None = None,
     top_k: int = 3,
+    auth: AuthContext = Depends(get_auth_context),
 ):
     """
     Get relevant context from past sessions.
@@ -690,6 +858,8 @@ async def get_session_context(
 
     rag = get_awi_rag_engine()
     session_manager = get_awi_session_manager()
+
+    await _require_awi_session_access(session_id, auth)
 
     session = await session_manager.get_session(session_id)
 
@@ -727,9 +897,11 @@ async def get_session_context(
     summary="Get RAG statistics",
     description="Get statistics about the memory store.",
 )
-async def get_rag_stats():
+async def get_rag_stats(auth: AuthContext = Depends(get_auth_context)):
     """Get statistics about indexed memories."""
     from ..services.awi_rag_engine import get_awi_rag_engine
+
+    auth.require_bootstrap_admin()
 
     rag = get_awi_rag_engine()
 
@@ -743,9 +915,14 @@ async def get_rag_stats():
     summary="Get session memories",
     description="Get all indexed memories for a session.",
 )
-async def get_session_memories(session_id: str):
+async def get_session_memories(
+    session_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Get all memories for a specific session."""
     from ..services.awi_rag_engine import get_awi_rag_engine
+
+    await _require_awi_session_access(session_id, auth)
 
     rag = get_awi_rag_engine()
 
@@ -773,9 +950,14 @@ async def get_session_memories(session_id: str):
     summary="Delete session memories",
     description="Delete all memories for a session.",
 )
-async def delete_session_memories(session_id: str):
+async def delete_session_memories(
+    session_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+):
     """Delete all memories for a specific session."""
     from ..services.awi_rag_engine import get_awi_rag_engine
+
+    await _require_awi_session_access(session_id, auth)
 
     rag = get_awi_rag_engine()
 

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -9,6 +9,7 @@ This is how the API generates revenue autonomously.
 """
 
 from decimal import Decimal
+from typing import ClassVar
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
 
@@ -43,6 +44,7 @@ from ..schemas.billing import (
     AlertListResponse,
     RegisterServiceRequest,
     ServiceRegistration,
+    ExactDecimalFieldsMixin,
 )
 
 
@@ -702,12 +704,19 @@ class CreateDryRunSessionRequest(BaseModel):
     wallet_id: str = Field(..., description="Wallet to simulate charges against")
 
 
-class DryRunSessionResponse(BaseModel):
+class DryRunSessionResponse(ExactDecimalFieldsMixin):
     """Response when creating a dry-run session."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "real_balance": "real_balance_exact",
+        "virtual_balance": "virtual_balance_exact",
+    }
+
     session_id: str
     wallet_id: str
     real_balance: float
+    real_balance_exact: str | None = None
     virtual_balance: float
+    virtual_balance_exact: str | None = None
     created_at: str
     expires_in_seconds: int = 900
 
@@ -724,16 +733,25 @@ class SimulatedChargeRequest(BaseModel):
     )
 
 
-class SimulatedChargeResponse(BaseModel):
+class SimulatedChargeResponse(ExactDecimalFieldsMixin):
     """Result of a simulated charge."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "credits_would_charge": "credits_would_charge_exact",
+        "simulated_balance_before": "simulated_balance_before_exact",
+        "simulated_balance_after": "simulated_balance_after_exact",
+    }
+
     dry_run: bool = True
     session_id: str
     wallet_id: str
     service_category: str
     units: float
     credits_would_charge: float
+    credits_would_charge_exact: str | None = None
     simulated_balance_before: float
+    simulated_balance_before_exact: str | None = None
     simulated_balance_after: float
+    simulated_balance_after_exact: str | None = None
     would_succeed: bool
     reason: str | None = None
 

--- a/app/routers/sandbox_behavioral.py
+++ b/app/routers/sandbox_behavioral.py
@@ -4,7 +4,8 @@ Behavioral Sandbox Router — Phase 6
 Endpoints for creating and managing behavioral sandbox environments.
 
 Allows agents to test real tool execution in isolated environments
-with subprocess isolation and resource limits.
+when the selected backend provides isolation. Host Python subprocess execution
+is disabled by default and is not a production sandbox boundary.
 """
 
 import logging
@@ -39,9 +40,9 @@ async def create_environment(request: SandboxEnvironmentCreate):
     """
     Create a new behavioral sandbox environment.
 
-    The environment provides isolated execution for testing tools without
-    affecting production systems. Each environment has its own Redis
-    namespace for state isolation.
+    The environment provides dry-run and mocked execution for testing tools
+    without affecting production systems. Each environment has its own Redis
+    namespace for state isolation when Redis is available.
     """
     try:
         engine = get_behavioral_sandbox()
@@ -117,7 +118,7 @@ async def execute_tool(request: ToolExecutionRequest):
     Execute a tool within a sandbox environment.
 
     The tool can be:
-    - Python code (subprocess mode)
+    - Python code (dry-run by default; unsafe host subprocess mode requires opt-in)
     - MCP tool (sandboxed mode)
     - HTTP request (proxy mode)
 

--- a/app/schemas/awi.py
+++ b/app/schemas/awi.py
@@ -93,6 +93,7 @@ class AWISession(BaseModel):
 
     session_id: str = Field(..., description="Unique session identifier")
     target_url: str
+    wallet_id: str | None = Field(None, description="Wallet that owns this session")
     status: AWISessionStatus
     created_at: datetime
     updated_at: datetime

--- a/app/schemas/awi_enhanced.py
+++ b/app/schemas/awi_enhanced.py
@@ -147,6 +147,7 @@ class DOMBridgeSessionRequest(BaseModel):
         description="URL to open in the browser",
         examples=["https://example.com/shop"],
     )
+    wallet_id: Optional[str] = Field(None, description="Wallet that owns this session")
     headless: bool = Field(default=True, description="Run browser in headless mode")
     viewport_width: int = Field(default=1280, description="Viewport width in pixels")
     viewport_height: int = Field(default=720, description="Viewport height in pixels")

--- a/app/schemas/billing.py
+++ b/app/schemas/billing.py
@@ -5,12 +5,16 @@ Two-tiered wallet system:
 - Human Sponsor Layer: Fiat ingestion via Stripe/payment rails → ecosystem credits
 - Agent Wallet Layer: Pre-paid, programmatic wallets for autonomous spending
 
-IMPORTANT: While the API accepts/returns float for backward compatibility,
-the service layer uses Decimal for all monetary calculations to avoid
-floating-point precision errors (e.g., 0.1 + 0.2 ≠ 0.3 with floats).
+IMPORTANT: Numeric fields are retained for backward compatibility, and response
+models also expose *_exact decimal strings for agent-safe reconciliation. The
+service layer uses Decimal for all monetary calculations to avoid floating-point
+precision errors (e.g., 0.1 + 0.2 ≠ 0.3 with floats).
 """
 
-from pydantic import BaseModel, Field
+from decimal import Decimal
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from enum import Enum
 from datetime import datetime
 import re
@@ -109,6 +113,44 @@ class AlertSeverity(str, Enum):
 # ---------------------------------------------------------------------------
 
 SAFE_WALLET_ID = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$")
+
+
+def _exact_decimal(value: Any) -> str | None:
+    """Return a JSON-safe exact decimal string without binary float math."""
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return str(value)
+    return str(Decimal(str(value)))
+
+
+class ExactDecimalFieldsMixin(BaseModel):
+    """Populate *_exact string fields before legacy float coercion runs."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _populate_exact_fields(cls, data: Any) -> Any:
+        if not cls._decimal_exact_fields:
+            return data
+
+        if isinstance(data, dict):
+            payload = dict(data)
+        else:
+            payload = {
+                field_name: getattr(data, field_name)
+                for field_name in cls.model_fields
+                if hasattr(data, field_name)
+            }
+
+        for source_field, exact_field in cls._decimal_exact_fields.items():
+            if payload.get(exact_field) is None and source_field in payload:
+                payload[exact_field] = _exact_decimal(payload[source_field])
+
+        return payload
 
 
 class CreateSponsorWalletRequest(BaseModel):
@@ -218,15 +260,24 @@ class CreateChildWalletRequest(BaseModel):
     )
 
 
-class ChildWalletResponse(BaseModel):
+class ChildWalletResponse(ExactDecimalFieldsMixin):
     """Child wallet details with parent lineage."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "balance": "balance_exact",
+        "max_spend": "max_spend_exact",
+        "spent": "spent_exact",
+    }
+
     wallet_id: str
     wallet_type: WalletType
     parent_wallet_id: str | None = None
     child_agent_id: str | None = None
     balance: float
+    balance_exact: str | None = None
     max_spend: float | None = None
+    max_spend_exact: str | None = None
     spent: float = 0.0
+    spent_exact: str | None = None
     task_description: str = ""
     ttl_seconds: int | None = None
     auto_reclaim: bool = True
@@ -234,46 +285,81 @@ class ChildWalletResponse(BaseModel):
     created_at: datetime
 
 
-class SwarmBudgetSummary(BaseModel):
+class SwarmBudgetSummary(ExactDecimalFieldsMixin):
     """Hierarchical budget summary for an agent's child swarm."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "parent_balance": "parent_balance_exact",
+        "total_delegated": "total_delegated_exact",
+        "total_reclaimed": "total_reclaimed_exact",
+    }
+
     parent_wallet_id: str
     parent_balance: float
+    parent_balance_exact: str | None = None
     total_delegated: float
+    total_delegated_exact: str | None = None
     total_reclaimed: float
+    total_reclaimed_exact: str | None = None
     active_children: int
     completed_children: int
     frozen_children: int
     children: list["WalletResponse"]
 
 
-class ReclaimResponse(BaseModel):
+class ReclaimResponse(ExactDecimalFieldsMixin):
     """Result of reclaiming unspent credits from a child wallet."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "credits_reclaimed": "credits_reclaimed_exact",
+        "parent_balance_after": "parent_balance_after_exact",
+    }
+
     child_wallet_id: str
     parent_wallet_id: str
     credits_reclaimed: float
+    credits_reclaimed_exact: str | None = None
     parent_balance_after: float
+    parent_balance_after_exact: str | None = None
     child_status: WalletStatus
 
 
-class WalletResponse(BaseModel):
+class WalletResponse(ExactDecimalFieldsMixin):
     """Wallet details."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "balance": "balance_exact",
+        "lifetime_credits": "lifetime_credits_exact",
+        "lifetime_debits": "lifetime_debits_exact",
+        "daily_limit": "daily_limit_exact",
+        "auto_refill_threshold": "auto_refill_threshold_exact",
+        "auto_refill_amount": "auto_refill_amount_exact",
+        "max_spend": "max_spend_exact",
+    }
+
     wallet_id: str
     wallet_type: WalletType
     owner_name: str | None = None
     email: str | None = None
     balance: float = Field(..., description="Current credit balance.")
+    balance_exact: str | None = Field(
+        None, description="Exact current credit balance as a decimal string."
+    )
     lifetime_credits: float = Field(..., description="Total credits ever deposited.")
+    lifetime_credits_exact: str | None = None
     lifetime_debits: float = Field(..., description="Total credits ever consumed.")
+    lifetime_debits_exact: str | None = None
     status: WalletStatus
     kyc_status: KYCStatus = Field(default=KYCStatus.NOT_REQUIRED)
     daily_limit: float | None = None
+    daily_limit_exact: str | None = None
     auto_refill: bool = False
     auto_refill_threshold: float | None = None
+    auto_refill_threshold_exact: str | None = None
     auto_refill_amount: float | None = None
+    auto_refill_amount_exact: str | None = None
     sponsor_wallet_id: str | None = None
     agent_id: str | None = None
     child_agent_id: str | None = None
     max_spend: float | None = None
+    max_spend_exact: str | None = None
     task_description: str | None = None
     ttl_seconds: int | None = None
     created_at: datetime
@@ -289,8 +375,15 @@ class WalletListResponse(BaseModel):
 # Ledger Schemas
 # ---------------------------------------------------------------------------
 
-class LedgerEntry(BaseModel):
+class LedgerEntry(ExactDecimalFieldsMixin):
     """A single atomic transaction in the billing ledger."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "amount": "amount_exact",
+        "balance_after": "balance_after_exact",
+        "compute_cost": "compute_cost_exact",
+        "margin": "margin_exact",
+    }
+
     entry_id: str
     wallet_id: str
     action: LedgerAction
@@ -298,26 +391,41 @@ class LedgerEntry(BaseModel):
         ...,
         description="Credit amount (positive=credit, negative=debit).",
     )
+    amount_exact: str | None = Field(
+        None, description="Exact transaction amount as a decimal string."
+    )
     balance_after: float = Field(
         ...,
         description="Wallet balance after this transaction.",
+    )
+    balance_after_exact: str | None = Field(
+        None, description="Exact post-transaction balance as a decimal string."
     )
     service_category: ServiceCategory | None = None
     description: str = ""
     request_path: str | None = None
     compute_cost: float | None = None
+    compute_cost_exact: str | None = None
     margin: float | None = None
+    margin_exact: str | None = None
     timestamp: datetime
     metadata: dict = Field(default_factory=dict)
 
 
-class LedgerResponse(BaseModel):
+class LedgerResponse(ExactDecimalFieldsMixin):
     """Paginated ledger entries."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "period_credits": "period_credits_exact",
+        "period_debits": "period_debits_exact",
+    }
+
     entries: list[LedgerEntry]
     total: int
     wallet_id: str
     period_credits: float
+    period_credits_exact: str | None = None
     period_debits: float
+    period_debits_exact: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -336,24 +444,42 @@ class TopUpRequest(BaseModel):
     payment_token: str | None = Field(default=None, description="Payment method token.")
 
 
-class TopUpResponse(BaseModel):
+class TopUpResponse(ExactDecimalFieldsMixin):
     """Result of a top-up request."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "amount_fiat": "amount_fiat_exact",
+        "credits_added": "credits_added_exact",
+        "exchange_rate": "exchange_rate_exact",
+    }
+
     top_up_id: str
     wallet_id: str
     amount_fiat: float
+    amount_fiat_exact: str | None = None
     credits_added: float
+    credits_added_exact: str | None = None
     exchange_rate: float
+    exchange_rate_exact: str | None = None
     status: TopUpStatus
     payment_url: str | None = None
 
 
-class InsufficientFundsResponse(BaseModel):
+class InsufficientFundsResponse(ExactDecimalFieldsMixin):
     """Structured 402 Payment Required response."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "current_balance": "current_balance_exact",
+        "required_amount": "required_amount_exact",
+        "shortfall": "shortfall_exact",
+    }
+
     error: str = "insufficient_funds"
     wallet_id: str
     current_balance: float
+    current_balance_exact: str | None = None
     required_amount: float
+    required_amount_exact: str | None = None
     shortfall: float
+    shortfall_exact: str | None = None
     top_up_url: str
     message: str = "Wallet balance insufficient."
 
@@ -362,18 +488,28 @@ class InsufficientFundsResponse(BaseModel):
 # Metering & Pricing Schemas
 # ---------------------------------------------------------------------------
 
-class ServicePricing(BaseModel):
+class ServicePricing(ExactDecimalFieldsMixin):
     """Per-action pricing for a service category."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "credits_per_unit": "credits_per_unit_exact",
+    }
+
     service_category: ServiceCategory
     unit: str
     credits_per_unit: float
+    credits_per_unit_exact: str | None = None
     description: str = ""
 
 
-class PricingTableResponse(BaseModel):
+class PricingTableResponse(ExactDecimalFieldsMixin):
     """Full pricing table for all services."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "exchange_rate": "exchange_rate_exact",
+    }
+
     pricing: list[ServicePricing]
     exchange_rate: float
+    exchange_rate_exact: str | None = None
     last_updated: datetime
 
 
@@ -381,13 +517,24 @@ class PricingTableResponse(BaseModel):
 # Arbitrage / Margin Schemas
 # ---------------------------------------------------------------------------
 
-class ArbitrageReport(BaseModel):
+class ArbitrageReport(ExactDecimalFieldsMixin):
     """Swarm arbitrage profitability report."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "total_revenue": "total_revenue_exact",
+        "total_compute_cost": "total_compute_cost_exact",
+        "gross_margin": "gross_margin_exact",
+        "margin_percentage": "margin_percentage_exact",
+    }
+
     period: str
     total_revenue: float
+    total_revenue_exact: str | None = None
     total_compute_cost: float
+    total_compute_cost_exact: str | None = None
     gross_margin: float
+    gross_margin_exact: str | None = None
     margin_percentage: float
+    margin_percentage_exact: str | None = None
     by_service: dict[str, dict] = Field(default_factory=dict)
     top_profitable_actions: list[dict] = Field(default_factory=list)
 
@@ -396,14 +543,21 @@ class ArbitrageReport(BaseModel):
 # Alert Schemas
 # ---------------------------------------------------------------------------
 
-class BillingAlert(BaseModel):
+class BillingAlert(ExactDecimalFieldsMixin):
     """Billing alert for sponsors or agents."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "threshold_amount": "threshold_amount_exact",
+        "current_balance": "current_balance_exact",
+    }
+
     alert_id: str
     alert_type: AlertType
     wallet_id: str
     message: str
     threshold_amount: float | None = None
+    threshold_amount_exact: str | None = None
     current_balance: float | None = None
+    current_balance_exact: str | None = None
     severity: AlertSeverity = AlertSeverity.INFO
     acknowledged: bool = False
     created_at: datetime
@@ -425,28 +579,42 @@ class RegisterServiceRequest(BaseModel):
     mcp_manifest: dict | None = None
 
 
-class ServiceRegistration(BaseModel):
+class ServiceRegistration(ExactDecimalFieldsMixin):
     """A registered billable service in the marketplace."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "credits_per_unit": "credits_per_unit_exact",
+    }
+
     service_id: str
     name: str
     description: str
     owner_wallet_id: str
     category: ServiceCategory
     credits_per_unit: float
+    credits_per_unit_exact: str | None = None
     unit_name: str
     mcp_manifest: dict | None = None
     is_active: bool
     created_at: datetime
 
 
-class TransferResponse(BaseModel):
+class TransferResponse(ExactDecimalFieldsMixin):
     """Response for a wallet-to-wallet transfer."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "amount": "amount_exact",
+        "from_balance_after": "from_balance_after_exact",
+        "to_balance_after": "to_balance_after_exact",
+    }
+
     transfer_id: str
     from_wallet_id: str
     to_wallet_id: str
     amount: float
+    amount_exact: str | None = None
     from_balance_after: float
+    from_balance_after_exact: str | None = None
     to_balance_after: float
+    to_balance_after_exact: str | None = None
     status: str
 
 
@@ -617,14 +785,23 @@ class SandboxCommitRequest(BaseModel):
     session_id: str = Field(..., description="Sandbox session ID to commit.")
 
 
-class SandboxCommitResponse(BaseModel):
+class SandboxCommitResponse(ExactDecimalFieldsMixin):
     """Response after committing a sandbox session."""
+    _decimal_exact_fields: ClassVar[dict[str, str]] = {
+        "total_credits_deducted": "total_credits_deducted_exact",
+        "real_balance_before": "real_balance_before_exact",
+        "real_balance_after": "real_balance_after_exact",
+    }
+
     session_id: str
     wallet_id: str
     committed_charges: int
     total_credits_deducted: float
+    total_credits_deducted_exact: str | None = None
     real_balance_before: float
+    real_balance_before_exact: str | None = None
     real_balance_after: float
+    real_balance_after_exact: str | None = None
     ledger_entries: list[dict]
     success: bool
     message: str

--- a/app/services/agent_comms.py
+++ b/app/services/agent_comms.py
@@ -227,6 +227,14 @@ class MessageRouter:
         self._state = get_durable_state()
 
     @staticmethod
+    def _inbox_key(agent_id: str, message_id: str) -> str:
+        return f"comms.inbox.{agent_id}.{message_id}"
+
+    @staticmethod
+    def _outbox_key(message_id: str) -> str:
+        return f"comms.outbox.{message_id}"
+
+    @staticmethod
     def _message_from_dict(data: dict[str, Any]) -> AgentMessage:
         payload = dict(data)
         payload["message_type"] = MessageType(payload["message_type"])
@@ -275,23 +283,82 @@ class MessageRouter:
                         logger.exception("Skipping corrupt outbox message")
                 self._outbox = loaded_outbox
 
+            if self._state.enabled:
+                loaded_inbox = await self._load_all_inbox_messages()
+                if loaded_inbox:
+                    self._inbox = loaded_inbox
+
+                loaded_outbox = await self._load_outbox_messages()
+                if loaded_outbox:
+                    self._outbox = loaded_outbox
+
             self._hydrated = True
+
+    async def _load_agent_inbox(self, agent_id: str) -> list[AgentMessage]:
+        """Load a single agent inbox from row-keyed durable state."""
+        if not self._state.enabled:
+            return self._inbox.get(agent_id, [])
+
+        messages: list[AgentMessage] = []
+        for key in await self._state.list_keys(f"comms.inbox.{agent_id}."):
+            record = await self._state.load_json(key)
+            if not isinstance(record, dict):
+                continue
+            try:
+                messages.append(self._message_from_dict(record))
+            except Exception:
+                logger.exception("Skipping corrupt inbox message: %s", key)
+        return sorted(messages, key=lambda message: message.created_at)
+
+    async def _load_all_inbox_messages(self) -> dict[str, list[AgentMessage]]:
+        """Load all row-keyed inbox messages for process hydration."""
+        loaded: dict[str, list[AgentMessage]] = {}
+        for key in await self._state.list_keys("comms.inbox."):
+            record = await self._state.load_json(key)
+            if not isinstance(record, dict):
+                continue
+            try:
+                message = self._message_from_dict(record)
+                loaded.setdefault(message.to_agent, []).append(message)
+            except Exception:
+                logger.exception("Skipping corrupt inbox message: %s", key)
+        for messages in loaded.values():
+            messages.sort(key=lambda message: message.created_at)
+        return loaded
+
+    async def _load_outbox_messages(self) -> list[AgentMessage]:
+        """Load row-keyed outbox messages for process hydration."""
+        messages: list[AgentMessage] = []
+        for key in await self._state.list_keys("comms.outbox."):
+            record = await self._state.load_json(key)
+            if not isinstance(record, dict):
+                continue
+            try:
+                messages.append(self._message_from_dict(record))
+            except Exception:
+                logger.exception("Skipping corrupt outbox message: %s", key)
+        return sorted(messages, key=lambda message: message.created_at)
+
+    async def _persist_message_locked(self, message: AgentMessage) -> None:
+        """Persist one message without rewriting the global inbox."""
+        if not self._state.enabled:
+            return
+        await self._state.save_json(
+            self._inbox_key(message.to_agent, message.message_id),
+            asdict(message),
+        )
+        await self._state.save_json(
+            self._outbox_key(message.message_id),
+            asdict(message),
+        )
 
     async def _persist_locked(self):
         if not self._state.enabled:
             return
 
-        await self._state.save_json(
-            "comms.inbox",
-            {
-                agent_id: [asdict(message) for message in messages]
-                for agent_id, messages in self._inbox.items()
-            },
-        )
-        await self._state.save_json(
-            "comms.outbox",
-            [asdict(message) for message in self._outbox],
-        )
+        for messages in self._inbox.values():
+            for message in messages:
+                await self._persist_message_locked(message)
 
     async def persist(self):
         await self._hydrate_if_needed()
@@ -329,7 +396,8 @@ class MessageRouter:
             # No webhook — agent must poll
             message.delivery_status = DeliveryStatus.QUEUED
 
-        await self.persist()
+        async with self._lock:
+            await self._persist_message_locked(message)
 
         logger.info(
             f"Message routed: {message.from_agent} → {message.to_agent} "
@@ -340,6 +408,10 @@ class MessageRouter:
     async def poll(self, agent_id: str, limit: int = 50) -> list[AgentMessage]:
         """Poll for messages in an agent's inbox."""
         await self._hydrate_if_needed()
+        if self._state.enabled:
+            async with self._lock:
+                self._inbox[agent_id] = await self._load_agent_inbox(agent_id)
+
         changed = False
         async with self._lock:
             messages = self._inbox.get(agent_id, [])[:limit]
@@ -350,7 +422,9 @@ class MessageRouter:
                     msg.delivered_at = datetime.now(timezone.utc)
                     changed = True
         if changed:
-            await self.persist()
+            async with self._lock:
+                for msg in messages:
+                    await self._persist_message_locked(msg)
         return messages
 
     async def acknowledge(self, agent_id: str, message_id: str) -> bool:

--- a/app/services/awi_playwright_bridge.py
+++ b/app/services/awi_playwright_bridge.py
@@ -34,6 +34,10 @@ from uuid import uuid4
 logger = logging.getLogger(__name__)
 
 
+class BrowserSessionLimitExceeded(RuntimeError):
+    """Raised when DOM bridge session capacity is exhausted."""
+
+
 class TranslationMode(str, Enum):
     """Browser automation mode."""
 
@@ -323,6 +327,7 @@ class AWIPlaywrightBridge:
         headless: bool = True,
         browser_type: str = "chromium",
         default_timeout_ms: int = 30000,
+        max_sessions: int = 8,
     ):
         """
         Initialize the AWI Playwright Bridge.
@@ -337,6 +342,7 @@ class AWIPlaywrightBridge:
         self._headless = headless
         self._browser_type = browser_type
         self._default_timeout_ms = default_timeout_ms
+        self._max_sessions = max_sessions
 
         self._sessions: dict[str, BridgeSession] = {}
 
@@ -365,6 +371,11 @@ class AWIPlaywrightBridge:
         Returns:
             BridgeSession with session_id and initial state.
         """
+        if len(self._sessions) >= self._max_sessions:
+            raise BrowserSessionLimitExceeded(
+                f"DOM bridge session limit exceeded ({self._max_sessions})"
+            )
+
         session_id = str(uuid4())
 
         session = BridgeSession(
@@ -1857,5 +1868,13 @@ def get_playwright_bridge() -> AWIPlaywrightBridge:
     """Get or create the AWIPlaywrightBridge singleton."""
     global _bridge
     if _bridge is None:
-        _bridge = AWIPlaywrightBridge()
+        from ..core.config import get_settings
+
+        settings = get_settings()
+        _bridge = AWIPlaywrightBridge(
+            headless=settings.PLAYWRIGHT_HEADLESS,
+            browser_type=settings.PLAYWRIGHT_BROWSER_TYPE,
+            default_timeout_ms=settings.PLAYWRIGHT_TIMEOUT_MS,
+            max_sessions=settings.PLAYWRIGHT_MAX_SESSIONS,
+        )
     return _bridge

--- a/app/services/awi_rag_engine.py
+++ b/app/services/awi_rag_engine.py
@@ -786,15 +786,18 @@ class AWIRAGEngine:
         from ..core.config import get_settings
 
         settings = get_settings()
+        if not settings.LLM_API_KEY:
+            raise ValueError("LLM_API_KEY is not configured")
 
         client = AsyncOpenAI(api_key=settings.LLM_API_KEY)
-
-        response = await client.embeddings.create(
-            model=self._embedding_model,
-            input=text[:8192],
-        )
-
-        return response.data[0].embedding
+        try:
+            response = await client.embeddings.create(
+                model=self._embedding_model,
+                input=text[:8192],
+            )
+            return response.data[0].embedding
+        finally:
+            await client.close()
 
     def _generate_mock_embedding(self, text: str) -> list[float]:
         """Generate deterministic mock embedding from text."""

--- a/app/services/awi_session.py
+++ b/app/services/awi_session.py
@@ -66,6 +66,7 @@ class AWISessionManager:
         session = AWISession(
             session_id=session_id,
             target_url=request.target_url,
+            wallet_id=request.wallet_id,
             status=AWISessionStatus.CREATED,
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),

--- a/app/services/behavioral_sandbox.py
+++ b/app/services/behavioral_sandbox.py
@@ -2,10 +2,13 @@
 Behavioral Sandbox Engine — Phase 6
 ==================================
 Allows agents to test real tool execution (not just cost simulation) in
-isolated environments with subprocess isolation and resource limits.
+controlled environments. Host Python execution is disabled by default because
+a subprocess is not a production sandbox boundary.
 
 Supports:
-- Python subprocess execution with memory/CPU limits
+- Python dry-run simulation, container execution via Docker when configured,
+  and unsafe host subprocess execution only behind an explicit local-development
+  opt-in
 - MCP tool sandboxing with mocked responses
 - HTTP proxy mode for API testing
 - Redis-backed state isolation per environment
@@ -15,23 +18,20 @@ import asyncio
 import json
 import logging
 import resource
-import signal
-import subprocess
+import sys
 import tempfile
-import time
 import uuid
 from datetime import datetime, timezone
-from multiprocessing import Process
 from typing import Any
 
 import redis.asyncio as redis
 
+from ..core.config import get_settings
 from ..schemas.sandbox_behavioral import (
     ExecutionStatus,
     SandboxEnvironment,
     SandboxEnvironmentCreate,
     SandboxEnvironmentType,
-    SandboxMetrics,
     ToolExecutionRequest,
     ToolExecutionResponse,
 )
@@ -39,13 +39,28 @@ from ..schemas.sandbox_behavioral import (
 logger = logging.getLogger(__name__)
 
 
+def _limit_child_process(memory_limit_mb: int) -> None:
+    """Apply best-effort resource limits before executing opt-in host Python."""
+    memory_bytes = memory_limit_mb * 1024 * 1024
+    try:
+        resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+    except (ValueError, OSError, AttributeError):
+        logger.debug("Unable to apply address-space limit to sandbox subprocess")
+
+    try:
+        resource.setrlimit(resource.RLIMIT_CPU, (5, 5))
+    except (ValueError, OSError, AttributeError):
+        logger.debug("Unable to apply CPU limit to sandbox subprocess")
+
+
 class BehavioralSandboxEngine:
     """
     Core engine for behavioral sandbox execution.
 
-    Provides subprocess isolation for safe tool testing without affecting
-    production systems. Each environment gets its own Redis namespace
-    for state isolation.
+    Provides dry-run and mocked execution for tool testing without affecting
+    production systems. Each environment gets its own Redis namespace for state
+    isolation when Redis is available. Host Python execution is unsafe and
+    disabled unless a real backend such as Docker is explicitly configured.
     """
 
     def __init__(self, redis_url: str = "redis://localhost:6379"):
@@ -207,13 +222,71 @@ class BehavioralSandboxEngine:
         memory_limit_mb: int,
         env_vars: dict[str, str],
     ) -> dict[str, Any]:
-        """Execute Python code in a subprocess with resource limits."""
+        """Execute Python code through the configured sandbox backend."""
         code = tool_input.get("code", "print('Hello from sandbox')")
         context = tool_input.get("context", {})
+        sandbox_code = self._build_python_wrapper(code, context, dry_run)
 
-        sandbox_code = f"""
+        if dry_run:
+            return {
+                "success": True,
+                "output": {
+                    "sandboxed": True,
+                    "mode": "python_subprocess_dry_run",
+                    "code_provided": bool(code),
+                    "context_keys": sorted(context.keys()),
+                    "dry_run": True,
+                },
+                "cost_estimate": 0.001,
+            }
+
+        settings = get_settings()
+        backend = settings.BEHAVIORAL_SANDBOX_PYTHON_BACKEND.strip().lower()
+
+        if backend == "docker":
+            return await self._execute_python_docker(
+                sandbox_code=sandbox_code,
+                timeout_seconds=timeout_seconds,
+                memory_limit_mb=memory_limit_mb,
+                env_vars=env_vars,
+                image=settings.BEHAVIORAL_SANDBOX_DOCKER_IMAGE,
+            )
+
+        if backend in ("unsafe_host", "host") or settings.ALLOW_UNSAFE_HOST_PYTHON_SANDBOX:
+            return await self._execute_python_host(
+                sandbox_code=sandbox_code,
+                timeout_seconds=timeout_seconds,
+                memory_limit_mb=memory_limit_mb,
+                env_vars=env_vars,
+                unsafe_allowed=True,
+            )
+
+        if backend != "disabled":
+            logger.warning("Unknown Python sandbox backend configured: %s", backend)
+
+        logger.warning(
+            "Blocked Python sandbox execution. Configure "
+            "BEHAVIORAL_SANDBOX_PYTHON_BACKEND=docker for container isolation, "
+            "or unsafe_host only for local dev."
+        )
+        return {
+            "success": False,
+            "error": (
+                "Python execution is disabled. Configure "
+                "BEHAVIORAL_SANDBOX_PYTHON_BACKEND=docker for container isolation, "
+                "or unsafe_host only for local development."
+            ),
+            "resources": {
+                "blocked": True,
+                "reason": "python_execution_backend_disabled",
+            },
+        }
+
+    @staticmethod
+    def _build_python_wrapper(code: str, context: dict[str, Any], dry_run: bool) -> str:
+        """Build the small runner passed to the selected execution backend."""
+        return f"""
 import json
-import sys
 
 context = {json.dumps(context)}
 dry_run = {str(dry_run).lower()}
@@ -229,43 +302,172 @@ result = sandboxed_execute(context, dry_run)
 print(json.dumps(result))
 """
 
+    async def _execute_python_docker(
+        self,
+        sandbox_code: str,
+        timeout_seconds: int,
+        memory_limit_mb: int,
+        env_vars: dict[str, str],
+        image: str,
+    ) -> dict[str, Any]:
+        """Execute Python in an unprivileged Docker container."""
+        command = [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            "none",
+            "--memory",
+            f"{memory_limit_mb}m",
+            "--cpus",
+            "1",
+            "--pids-limit",
+            "64",
+            "--read-only",
+            "--tmpfs",
+            "/tmp:rw,noexec,nosuid,size=16m",
+            "--security-opt",
+            "no-new-privileges",
+            "--cap-drop",
+            "ALL",
+            "--user",
+            "65534:65534",
+            "--env",
+            "SANDBOX=true",
+            "--env",
+            "PYTHONDONTWRITEBYTECODE=1",
+        ]
+        for name, value in env_vars.items():
+            if name.isidentifier():
+                command.extend(["--env", f"{name}={value}"])
+        command.extend([image, "python", "-I", "-S", "-c", sandbox_code])
+
         try:
             proc = await asyncio.create_subprocess_exec(
-                sys.executable,
-                "-c",
-                sandbox_code,
+                *command,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env={**dict(env_vars), "SANDBOX": "true"},
             )
+        except FileNotFoundError:
+            return {
+                "success": False,
+                "error": "Docker executable not found for sandbox backend.",
+                "resources": {"blocked": True, "reason": "docker_unavailable"},
+            }
 
-            try:
-                stdout, stderr = await asyncio.wait_for(
-                    proc.communicate(), timeout=timeout_seconds
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=timeout_seconds
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            return {
+                "success": False,
+                "error": f"Timeout after {timeout_seconds}s",
+                "resources": {"timeout": True, "backend": "docker"},
+            }
+
+        return self._parse_python_execution_output(
+            stdout=stdout,
+            stderr=stderr,
+            backend="docker",
+        )
+
+    async def _execute_python_host(
+        self,
+        sandbox_code: str,
+        timeout_seconds: int,
+        memory_limit_mb: int,
+        env_vars: dict[str, str],
+        unsafe_allowed: bool,
+    ) -> dict[str, Any]:
+        """Execute Python on the host; unsafe and only for local development."""
+        if not unsafe_allowed:
+            logger.warning(
+                "Blocked host Python sandbox execution. Configure a real isolation "
+                "backend or set ALLOW_UNSAFE_HOST_PYTHON_SANDBOX=true only for local dev."
+            )
+            return {
+                "success": False,
+                "error": (
+                    "Python subprocess execution is disabled because host Python is "
+                    "not a production sandbox. Use an external isolation backend "
+                    "or set ALLOW_UNSAFE_HOST_PYTHON_SANDBOX=true only for local development."
+                ),
+                "resources": {
+                    "blocked": True,
+                    "reason": "unsafe_host_execution_disabled",
+                },
+            }
+
+        try:
+            with tempfile.TemporaryDirectory(prefix="bhe-python-") as tmpdir:
+                proc = await asyncio.create_subprocess_exec(
+                    sys.executable,
+                    "-I",
+                    "-S",
+                    "-c",
+                    sandbox_code,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env={**dict(env_vars), "SANDBOX": "true"},
+                    cwd=tmpdir,
+                    preexec_fn=lambda: _limit_child_process(memory_limit_mb),
                 )
-            except asyncio.TimeoutError:
-                proc.kill()
-                await proc.wait()
-                return {
-                    "success": False,
-                    "error": f"Timeout after {timeout_seconds}s",
-                    "resources": {"timeout": True},
-                }
 
-            output = stdout.decode().strip()
-            error = stderr.decode().strip()
+                try:
+                    stdout, stderr = await asyncio.wait_for(
+                        proc.communicate(), timeout=timeout_seconds
+                    )
+                except asyncio.TimeoutError:
+                    proc.kill()
+                    await proc.wait()
+                    return {
+                        "success": False,
+                        "error": f"Timeout after {timeout_seconds}s",
+                        "resources": {"timeout": True},
+                    }
 
-            if error and not output:
-                return {"success": False, "error": error}
-
-            try:
-                result = json.loads(output)
-                return result
-            except json.JSONDecodeError:
-                return {"success": True, "output": output}
+            return self._parse_python_execution_output(
+                stdout=stdout,
+                stderr=stderr,
+                backend="unsafe_host",
+            )
 
         except Exception as e:
             return {"success": False, "error": str(e)}
+
+    @staticmethod
+    def _parse_python_execution_output(
+        stdout: bytes,
+        stderr: bytes,
+        backend: str,
+    ) -> dict[str, Any]:
+        output = stdout.decode().strip()
+        error = stderr.decode().strip()
+
+        if error and not output:
+            return {
+                "success": False,
+                "error": error,
+                "resources": {"backend": backend},
+            }
+
+        try:
+            result = json.loads(output)
+            if isinstance(result, dict):
+                result.setdefault("resources", {})
+                result["resources"].setdefault("backend", backend)
+                return result
+        except json.JSONDecodeError:
+            pass
+
+        return {
+            "success": True,
+            "output": output,
+            "resources": {"backend": backend},
+        }
 
     async def _execute_mcp_sandbox(
         self,

--- a/app/services/stripe_integration.py
+++ b/app/services/stripe_integration.py
@@ -7,7 +7,7 @@ Architecture:
 2. Client completes payment via Stripe.js in browser
 3. Stripe sends webhook to /webhooks/stripe
 4. Webhook handler mints credits to the wallet
-5. If Stripe retries webhook, IntegrityError is caught for idempotency
+5. If Stripe retries webhook, only duplicate payment intents are treated as idempotent
 """
 
 import logging
@@ -40,6 +40,15 @@ class StripeIntegration:
 
     def __init__(self):
         self._session_factory = get_session_factory
+
+    @staticmethod
+    def _is_duplicate_payment_intent_error(exc: IntegrityError) -> bool:
+        """Return true only for the idempotency unique constraint."""
+        message = str(getattr(exc, "orig", exc)).lower()
+        return (
+            "payment_intent_id" in message
+            and ("unique" in message or "duplicate" in message)
+        )
 
     async def create_top_up_intent(
         self,
@@ -216,9 +225,9 @@ class StripeIntegration:
         """
         Mint credits to a wallet with idempotency.
 
-        The UNIQUE constraint on payment_intent_id ensures we never
-        double-mint. Catching IntegrityError returns 200 to Stripe
-        to stop their retry loop (hybrid Option A+B approach).
+        The UNIQUE constraint on payment_intent_id ensures we never double-mint.
+        Only that duplicate-key failure is swallowed to stop Stripe retries; other
+        integrity errors must surface so a real payment is not silently dropped.
         """
         try:
             async with self._session_factory()() as session:
@@ -250,7 +259,15 @@ class StripeIntegration:
 
                 await session.commit()
 
-        except IntegrityError:
+        except IntegrityError as exc:
+            if not self._is_duplicate_payment_intent_error(exc):
+                logger.exception(
+                    "Stripe credit mint failed with non-idempotency integrity error "
+                    "for PaymentIntent %s",
+                    payment_intent_id,
+                )
+                raise
+
             logger.info(
                 f"Idempotency catch: PaymentIntent {payment_intent_id} "
                 f"already processed. Swallowing error to return 200 OK."

--- a/app/services/webauthn_provider.py
+++ b/app/services/webauthn_provider.py
@@ -496,6 +496,10 @@ class WebAuthnProvider:
         """Get list of actions that require passkey verification."""
         return sorted(self.HIGH_RISK_ACTIONS)
 
+    def get_challenge(self, challenge_id: str) -> WebAuthnChallenge | None:
+        """Get a stored challenge for route-level ownership checks."""
+        return self._challenges.get(challenge_id)
+
     async def register_credential(
         self,
         user_id: str,

--- a/docs/agentmarket-listing.md
+++ b/docs/agentmarket-listing.md
@@ -21,7 +21,7 @@
 
 - First open-source platform to implement both MCP and a complete Agentic Web Interface (AWI), directly realizing the vision from arXiv:2506.10953 ("Build the web for agents, not agents for the web")
 - Fully self-hostable with zero vendor lock-in (unlike commercial control planes)
-- Production-hardened from day one: KYC, WebAuthn/passkey protection, circuit breakers, behavioral sandboxes, RAG memory, bidirectional Playwright DOM bridge, and more
+- Production-beta safety foundation: wallet-scoped keys, exact decimal billing fields, KYC, WebAuthn/passkey protection, simulation-mode visibility, authenticated behavioral sandbox routes with optional Docker isolation, row-keyed comms persistence, RAG memory, and a capped Playwright DOM bridge
 - Official wrappers for LangChain, CrewAI, and AutoGen — integrate in minutes
 - Designed for both agents and human developers
 
@@ -135,10 +135,10 @@ GET  /v1/awi/vocabulary                    - Action vocabulary
 
 ### Sandbox & Testing
 ```
-POST /v1/sandbox/environments               - Create sandbox
-POST /v1/sandbox/execute                   - Execute in sandbox
-GET  /v1/sandbox/metrics/{id}              - Sandbox metrics
-DELETE /v1/sandbox/environments/{id}        - Cleanup
+POST /v1/sandbox/behavioral/environments    - Create sandbox
+POST /v1/sandbox/behavioral/execute         - Execute dry-run/mocked tool or Docker-backed Python
+GET  /v1/sandbox/behavioral/environments/{id} - Read sandbox state
+DELETE /v1/sandbox/behavioral/environments/{id} - Cleanup
 ```
 
 ### Telemetry & Monitoring

--- a/tests/test_awi.py
+++ b/tests/test_awi.py
@@ -24,6 +24,8 @@ from app.services.awi_representation import get_awi_representation
 from app.services.awi_task_queue import AWITaskQueue, get_awi_task_queue
 from app.services.awi_session import AWISessionManager, get_awi_session_manager
 
+HEADERS = {"X-API-Key": "test-key"}
+
 
 class TestAWIActionVocabulary:
     """Test AWI action vocabulary."""
@@ -301,6 +303,7 @@ class TestAWIRouter:
                     "target_url": "https://example.com",
                     "max_steps": 100,
                 },
+                headers=HEADERS,
             )
 
             assert response.status_code == 201
@@ -317,10 +320,13 @@ class TestAWIRouter:
             create_response = await client.post(
                 "/v1/awi/sessions",
                 json={"target_url": "https://example.com"},
+                headers=HEADERS,
             )
             session_id = create_response.json()["session_id"]
 
-            response = await client.get(f"/v1/awi/sessions/{session_id}")
+            response = await client.get(
+                f"/v1/awi/sessions/{session_id}", headers=HEADERS
+            )
 
             assert response.status_code == 200
             data = response.json()
@@ -335,6 +341,7 @@ class TestAWIRouter:
             create_response = await client.post(
                 "/v1/awi/sessions",
                 json={"target_url": "https://example.com"},
+                headers=HEADERS,
             )
             session_id = create_response.json()["session_id"]
 
@@ -345,6 +352,7 @@ class TestAWIRouter:
                     "action": "navigate_to",
                     "parameters": {"url": "https://new-page.com"},
                 },
+                headers=HEADERS,
             )
 
             assert response.status_code == 200
@@ -379,6 +387,7 @@ class TestAWIRouter:
                     "action_sequence": [{"action": "navigate_to"}],
                     "priority": 5,
                 },
+                headers=HEADERS,
             )
 
             assert response.status_code == 201
@@ -392,9 +401,116 @@ class TestAWIRouter:
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as client:
-            response = await client.get("/v1/awi/queue/status")
+            response = await client.get("/v1/awi/queue/status", headers=HEADERS)
 
             assert response.status_code == 200
             data = response.json()
             assert "total_pending" in data
             assert "total_running" in data
+
+    @pytest.mark.anyio
+    async def test_session_endpoints_require_api_key(self):
+        """AWI session control is not publicly reachable."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/v1/awi/sessions",
+                json={"target_url": "https://example.com"},
+            )
+
+            assert response.status_code == 401
+
+    @pytest.mark.anyio
+    async def test_db_key_is_scoped_to_awi_session_wallet(self):
+        """DB API keys can only drive AWI sessions for their issuing wallet."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            wallet_a_resp = await client.post(
+                "/v1/billing/wallets/sponsor",
+                json={"sponsor_name": "AWI Tenant A", "email": "awi-a@test.com"},
+                headers=HEADERS,
+            )
+            wallet_b_resp = await client.post(
+                "/v1/billing/wallets/sponsor",
+                json={"sponsor_name": "AWI Tenant B", "email": "awi-b@test.com"},
+                headers=HEADERS,
+            )
+            wallet_a = wallet_a_resp.json()["wallet_id"]
+            wallet_b = wallet_b_resp.json()["wallet_id"]
+
+            key_resp = await client.post(
+                "/v1/api-keys",
+                json={"wallet_id": wallet_a, "key_name": "awi-tenant-key"},
+                headers=HEADERS,
+            )
+            db_headers = {"X-API-Key": key_resp.json()["api_key"]}
+
+            own_session_resp = await client.post(
+                "/v1/awi/sessions",
+                json={"target_url": "https://example.com", "wallet_id": wallet_a},
+                headers=db_headers,
+            )
+            assert own_session_resp.status_code == 201
+            own_session_id = own_session_resp.json()["session_id"]
+
+            own_get = await client.get(
+                f"/v1/awi/sessions/{own_session_id}", headers=db_headers
+            )
+            assert own_get.status_code == 200
+
+            other_session_resp = await client.post(
+                "/v1/awi/sessions",
+                json={"target_url": "https://example.com", "wallet_id": wallet_b},
+                headers=HEADERS,
+            )
+            other_session_id = other_session_resp.json()["session_id"]
+
+            blocked_get = await client.get(
+                f"/v1/awi/sessions/{other_session_id}", headers=db_headers
+            )
+            blocked_execute = await client.post(
+                "/v1/awi/execute",
+                json={
+                    "session_id": other_session_id,
+                    "action": "navigate_to",
+                    "parameters": {"url": "https://blocked.example.com"},
+                },
+                headers=db_headers,
+            )
+
+            assert blocked_get.status_code == 403
+            assert blocked_execute.status_code == 403
+
+    @pytest.mark.anyio
+    async def test_passkey_challenge_requires_session_owner(self):
+        """Login-window passkey challenges inherit AWI session ownership."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            wallet_resp = await client.post(
+                "/v1/billing/wallets/sponsor",
+                json={"sponsor_name": "AWI Passkey", "email": "awi-passkey@test.com"},
+                headers=HEADERS,
+            )
+            wallet_id = wallet_resp.json()["wallet_id"]
+            session_resp = await client.post(
+                "/v1/awi/sessions",
+                json={"target_url": "https://example.com", "wallet_id": wallet_id},
+                headers=HEADERS,
+            )
+            session_id = session_resp.json()["session_id"]
+
+            no_auth = await client.post(
+                "/v1/awi/passkey/challenge",
+                json={"session_id": session_id, "action": "checkout"},
+            )
+            with_auth = await client.post(
+                "/v1/awi/passkey/challenge",
+                json={"session_id": session_id, "action": "checkout"},
+                headers=HEADERS,
+            )
+
+            assert no_auth.status_code == 401
+            assert with_auth.status_code == 200

--- a/tests/test_awi_phase9.py
+++ b/tests/test_awi_phase9.py
@@ -14,8 +14,10 @@ from datetime import datetime, timedelta
 from app.services.webauthn_provider import WebAuthnProvider, ChallengeStatus
 from app.services.awi_playwright_bridge import (
     AWIPlaywrightBridge,
+    BrowserSessionLimitExceeded,
     PlaywrightCommand,
     CommandType,
+    TranslationMode,
 )
 from app.services.awi_rag_engine import AWIRAGEngine, SearchResult
 
@@ -270,7 +272,7 @@ class TestAWIPlaywrightBridge:
 
     @pytest.fixture
     def bridge(self):
-        return AWIPlaywrightBridge()
+        return AWIPlaywrightBridge(mode=TranslationMode.CDP_DIRECT)
 
     def test_semantic_patterns_exist(self, bridge):
         """Test that semantic patterns are defined."""
@@ -303,6 +305,17 @@ class TestAWIPlaywrightBridge:
         assert session.session_id is not None
         assert session.current_url == "https://example.com"
         assert session.created_at is not None
+
+        await bridge.destroy_session(session.session_id)
+
+    @pytest.mark.asyncio
+    async def test_create_session_enforces_max_sessions(self):
+        """DOM bridge refuses unbounded browser session creation."""
+        bridge = AWIPlaywrightBridge(mode=TranslationMode.CDP_DIRECT, max_sessions=1)
+        session = await bridge.create_session("https://example.com")
+
+        with pytest.raises(BrowserSessionLimitExceeded):
+            await bridge.create_session("https://example.org")
 
         await bridge.destroy_session(session.session_id)
 
@@ -446,14 +459,16 @@ class TestAWIPlaywrightBridge:
 
     @pytest.mark.asyncio
     async def test_execute_commands(self, bridge):
-        """Test executing commands (skipped if Playwright not installed)."""
-        # Check if Playwright is available
-        try:
-            from playwright.async_api import async_playwright
-        except ImportError:
-            pytest.skip("Playwright not installed")
+        """Test command execution without opening a real browser."""
+
+        class FakePage:
+            url = "https://example.com"
+
+            async def title(self):
+                return "Example"
 
         session = await bridge.create_session("https://example.com")
+        session._page = FakePage()
 
         commands = [
             PlaywrightCommand(

--- a/tests/test_behavioral_sandbox.py
+++ b/tests/test_behavioral_sandbox.py
@@ -2,6 +2,7 @@
 Tests for the Behavioral Sandbox Engine — Phase 6
 """
 
+import asyncio
 import pytest
 from datetime import datetime, timezone
 
@@ -147,7 +148,7 @@ class TestBehavioralSandboxEngine:
 
     @pytest.mark.anyio
     async def test_execute_with_real_code(self, engine, sample_env_request):
-        """Test execution with actual Python code."""
+        """Host Python execution is blocked unless explicitly enabled."""
         env = await engine.create_environment(sample_env_request)
 
         request = ToolExecutionRequest(
@@ -162,7 +163,53 @@ class TestBehavioralSandboxEngine:
 
         result = await engine.execute_tool(request)
 
-        assert result.status.value in ["success", "failed"]
+        assert result.status.value == "failed"
+        assert result.error is not None
+        assert "disabled" in result.error
+        assert result.resources_used["reason"] == "python_execution_backend_disabled"
+
+        await engine.destroy_environment(env.env_id)
+
+    @pytest.mark.anyio
+    async def test_docker_backend_reports_unavailable_without_falling_back_to_host(
+        self, engine, monkeypatch
+    ):
+        """Docker backend failures do not silently fall back to host execution."""
+
+        async def missing_docker(*args, **kwargs):
+            raise FileNotFoundError("docker")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", missing_docker)
+
+        result = await engine._execute_python_docker(
+            sandbox_code="print('should not run on host')",
+            timeout_seconds=1,
+            memory_limit_mb=64,
+            env_vars={},
+            image="python:3.12-slim",
+        )
+
+        assert result["success"] is False
+        assert result["resources"]["reason"] == "docker_unavailable"
+
+    @pytest.mark.anyio
+    async def test_dry_run_python_subprocess_does_not_execute_code(
+        self, engine, sample_env_request
+    ):
+        """Dry runs return a synthetic result without invoking host Python."""
+        env = await engine.create_environment(sample_env_request)
+
+        request = ToolExecutionRequest(
+            env_id=env.env_id,
+            tool_name="dry_run_probe",
+            tool_input={"code": "raise RuntimeError('would execute')"},
+            dry_run=True,
+        )
+
+        result = await engine.execute_tool(request)
+
+        assert result.status.value == "success"
+        assert result.output["mode"] == "python_subprocess_dry_run"
 
         await engine.destroy_environment(env.env_id)
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -5,6 +5,7 @@ micro-metering → 402 insufficient funds → top-ups → arbitrage reporting.
 """
 
 import pytest
+from decimal import Decimal
 from httpx import AsyncClient, ASGITransport
 from app.main import app
 
@@ -38,6 +39,7 @@ async def test_create_sponsor_wallet(client, api_headers):
     assert data["wallet_type"] == "sponsor"
     assert data["owner_name"] == "Acme Corp"
     assert data["balance"] == 50000.0
+    assert Decimal(data["balance_exact"]) == Decimal("50000")
     assert data["wallet_id"].startswith("spn-")
     assert data["status"] == "active"
 
@@ -139,7 +141,9 @@ async def test_charge_agent_wallet(client, api_headers):
     data = resp.json()
     assert data["action"] == "debit"
     assert data["amount"] == -20.0  # 10 units × 2 credits
+    assert Decimal(data["amount_exact"]) == Decimal("-20")
     assert data["balance_after"] == 4980.0
+    assert Decimal(data["balance_after_exact"]) == Decimal("4980")
     assert data["service_category"] == "iot_bridge"
     assert data["compute_cost"] is not None
     assert data["margin"] is not None
@@ -209,11 +213,13 @@ async def test_ledger_records_transactions(client, api_headers):
     assert data["wallet_id"] == agent_wallet_id
     assert data["total"] >= 2  # At least transfer in + debit
     assert data["period_debits"] > 0
+    assert "period_debits_exact" in data
 
     # Verify debit entry exists
     debits = [e for e in data["entries"] if e["action"] == "debit"]
     assert len(debits) >= 1
     assert debits[0]["service_category"] == "agent_comms"
+    assert debits[0]["amount_exact"].startswith("-")
 
 
 # --- Top-Up ---

--- a/tests/test_sqlite_backend.py
+++ b/tests/test_sqlite_backend.py
@@ -9,6 +9,14 @@ import pytest
 
 from app.core.durable_state import DurableStateStore
 from app.core.config import get_settings
+from app.services import agent_comms
+from app.services.agent_comms import (
+    AgentMessage,
+    AgentRegistry,
+    MessagePriority,
+    MessageRouter,
+    MessageType,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -110,3 +118,52 @@ async def test_sqlite_backend_multiple_keys(sqlite_store):
     for k, v in data.items():
         loaded = await sqlite_store.load_json(k)
         assert loaded == v
+
+
+@pytest.mark.asyncio
+async def test_sqlite_backend_list_keys_by_prefix(sqlite_store):
+    """State services can enumerate row-keyed records without a global blob."""
+    await sqlite_store._ensure_ready()
+
+    await sqlite_store.save_json("comms.inbox.agent-a.msg-1", {"message": 1})
+    await sqlite_store.save_json("comms.inbox.agent-a.msg-2", {"message": 2})
+    await sqlite_store.save_json("comms.inbox.agent-b.msg-3", {"message": 3})
+
+    keys = await sqlite_store.list_keys("comms.inbox.agent-a.")
+
+    assert keys == ["comms.inbox.agent-a.msg-1", "comms.inbox.agent-a.msg-2"]
+
+
+@pytest.mark.asyncio
+async def test_agent_comms_persists_messages_as_individual_rows(
+    sqlite_store, monkeypatch
+):
+    """Sending one message must not rewrite the global inbox for all agents."""
+    await sqlite_store._ensure_ready()
+    monkeypatch.setattr(agent_comms, "get_durable_state", lambda: sqlite_store)
+
+    registry = AgentRegistry()
+    router = MessageRouter(registry)
+    sender = await registry.register("sender", ["send"])
+    receiver = await registry.register("receiver", ["receive"])
+
+    message = AgentMessage(
+        message_id="msg-row-keyed",
+        from_agent=sender.agent_id,
+        to_agent=receiver.agent_id,
+        message_type=MessageType.REQUEST,
+        priority=MessagePriority.NORMAL,
+        subject="row keyed",
+        body={"ok": True},
+    )
+
+    await router.send(message)
+
+    inbox_keys = await sqlite_store.list_keys(f"comms.inbox.{receiver.agent_id}.")
+    assert inbox_keys == [f"comms.inbox.{receiver.agent_id}.msg-row-keyed"]
+    assert await sqlite_store.load_json("comms.inbox") is None
+
+    second_router = MessageRouter(registry)
+    polled = await second_router.poll(receiver.agent_id)
+
+    assert [msg.message_id for msg in polled] == ["msg-row-keyed"]

--- a/tests/test_stripe_integration.py
+++ b/tests/test_stripe_integration.py
@@ -10,8 +10,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from httpx import AsyncClient, ASGITransport
+from sqlalchemy.exc import IntegrityError
 
 from app.main import app
+from app.services.stripe_integration import StripeIntegration
 
 
 @pytest.fixture
@@ -113,6 +115,22 @@ async def test_webhook_missing_signature(client):
 
 class TestStripeWebhookIdempotency:
     """Tests for webhook idempotency via UNIQUE constraint."""
+
+    def test_only_payment_intent_unique_errors_are_idempotent(self):
+        """Non-idempotency integrity errors must not be swallowed."""
+        duplicate = IntegrityError(
+            "insert",
+            {},
+            Exception("UNIQUE constraint failed: ledger_entries.payment_intent_id"),
+        )
+        foreign_key = IntegrityError(
+            "insert",
+            {},
+            Exception("FOREIGN KEY constraint failed"),
+        )
+
+        assert StripeIntegration._is_duplicate_payment_intent_error(duplicate) is True
+        assert StripeIntegration._is_duplicate_payment_intent_error(foreign_key) is False
 
     @pytest.mark.anyio
     async def test_duplicate_webhook_returns_200(self, client, sponsor_wallet, api_headers):


### PR DESCRIPTION
## Summary

- harden AWI/passkey/DOM/RAG access with auth context and wallet ownership checks
- add exact decimal companion fields for billing responses while preserving legacy numeric fields
- add Docker-backed behavioral sandbox execution option and keep host execution disabled by default
- store agent comms messages as row-keyed durable records instead of one global inbox blob
- tighten Stripe webhook idempotency and docs around production-beta claims

## Verification

- ruff check app/ tests/ && mypy app/
- pytest -q

Full suite passed locally: 517 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security- and money-adjacent surfaces (AWI session authorization, billing response formats, Stripe webhook idempotency, and sandbox execution paths), so regressions could impact tenant isolation or payment processing behavior. Changes are largely additive/hardening with expanded tests, but they alter several request/response contracts and persistence behavior.
> 
> **Overview**
> **Hardens production-beta security boundaries and multi-tenant isolation.** AWI endpoints (including passkey/WebAuthn, DOM bridge, and RAG memory routes) now require auth context and enforce wallet ownership (or bootstrap-admin) before reading/mutating session state, and AWI sessions carry an explicit `wallet_id`.
> 
> **Improves billing correctness without breaking legacy clients.** Billing response models now add `*_exact` decimal string companions (via `ExactDecimalFieldsMixin`) alongside existing float fields, including dry-run session/charge responses.
> 
> **Tightens execution and persistence safety.** The behavioral sandbox defaults to Python dry-run, blocks host execution unless explicitly opted-in, and can run real Python in a locked-down Docker container via new settings; the Playwright DOM bridge caps concurrent sessions and returns 429 when exceeded. Agent comms durable storage shifts from a single global inbox blob to row-keyed per-message records (enabled by new durable-state `list_keys`), and Stripe top-up idempotency now only swallows unique `payment_intent_id` integrity errors while surfacing other DB integrity failures.
> 
> Docs and tests are updated to reflect the production-beta posture, new sandbox endpoints, and the tightened auth/limits (suite now reports 517 passing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1038244db46a8fd2526d20398589ee44d0cd983. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API status messaging from "production-ready" to "production beta" with clarified implementation status.
  * Revised behavioral sandbox endpoint documentation; endpoints now use `/v1/sandbox/behavioral/` prefix with updated request/response field names.

* **New Features**
  * Billing responses now include exact decimal string fields (`*_exact`) for precise agent-safe reconciliation.
  * Sessions now support wallet-scoped ownership and authorization.
  * Behavioral sandbox supports Docker container execution backend option.
  * Playwright DOM bridge enforces configurable session limits.

* **Bug Fixes**
  * Python sandbox execution now disabled by default; unsafe host execution requires explicit opt-in.
  * Webhook credit-minting idempotency now only applies to duplicate payment intents; other integrity errors propagate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->