### PR TITLE
feat: add wallet-scoped audit inspection

### DIFF
--- a/app/routers/audit.py
+++ b/app/routers/audit.py
@@ -20,6 +20,23 @@ from app.services.audit_log import (
 router = APIRouter(prefix="/v1/audit", tags=["Control Plane Audit"])
 
 
+def _authorize_audit_events_request(
+    *,
+    auth: AuthContext,
+    wallet_id: str | None,
+    key_id: str | None,
+    summary: bool,
+) -> tuple[str | None, str | None]:
+    if auth.is_bootstrap_admin:
+        return wallet_id, key_id
+
+    if summary or not wallet_id:
+        auth.require_bootstrap_admin()
+
+    auth.require_wallet_access(wallet_id)
+    return wallet_id, None
+
+
 @router.get("/events", response_model=AuditEventListResponse)
 async def get_audit_events(
     event: str | None = Query(None),
@@ -37,7 +54,12 @@ async def get_audit_events(
     offset: int = Query(0, ge=0),
     auth: AuthContext = Depends(get_auth_context),
 ) -> AuditEventListResponse:
-    auth.require_bootstrap_admin()
+    wallet_id, key_id = _authorize_audit_events_request(
+        auth=auth,
+        wallet_id=wallet_id,
+        key_id=key_id,
+        summary=summary,
+    )
     events = await list_audit_events(
         event=event,
         wallet_id=wallet_id,

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -167,6 +167,13 @@ curl "$API_URL/v1/audit/events?wallet_id=$AGENT_WALLET_ID" \
   -H "X-API-Key: $BOOTSTRAP_KEY"
 ```
 
+The scoped agent key can also inspect its own wallet's audit stream:
+
+```bash
+curl "$API_URL/v1/audit/events?wallet_id=$AGENT_WALLET_ID" \
+  -H "X-API-Key: $AGENT_API_KEY"
+```
+
 Each audit event should let an operator tie the action back to its wallet,
 credential source, tool, endpoint, policy decision, request ID or correlation
 ID, success flag, error, and metadata such as transport and estimated cost.

--- a/docs/production-beta-roadmap.md
+++ b/docs/production-beta-roadmap.md
@@ -87,6 +87,11 @@ audit event, ledger entry, and request or correlation ID for a scoped tool call.
 That makes the beta story auditable from discovery through invocation,
 metering, and governance.
 
+Wallet-scoped audit inspection is now additive to the operator view: DB-created
+wallet keys can list audit events only for their own `wallet_id`, while global
+audit queries, summaries, and cross-wallet inspection remain bootstrap/admin
+only.
+
 ## Recommended Milestones
 
 ### Milestone 1: Green And Trustworthy Mainline

--- a/tests/test_audit_routes.py
+++ b/tests/test_audit_routes.py
@@ -102,7 +102,7 @@ async def test_bootstrap_admin_can_filter_paginate_and_summarize_audit_events(
 
 
 @pytest.mark.anyio
-async def test_db_wallet_key_cannot_list_audit_events(client, clean_database):
+async def test_db_wallet_key_can_list_own_wallet_audit_events(client, clean_database):
     sponsor_response = await client.post(
         "/v1/billing/wallets/sponsor",
         json={
@@ -124,9 +124,147 @@ async def test_db_wallet_key_cannot_list_audit_events(client, clean_database):
     )
     assert key_response.status_code == 201
     wallet_api_key = key_response.json()["api_key"]
+    key_id = key_response.json()["key_id"]
+
+    await record_audit_event(
+        event="billing.charge",
+        wallet_id=wallet_id,
+        tool="billing",
+        endpoint="/v1/billing/charge",
+        auth_source="db",
+        key_id=key_id,
+        request_id="req-own-wallet-audit",
+        ok=True,
+    )
+    await record_audit_event(
+        event="mcp.invoke",
+        wallet_id=wallet_id,
+        tool="echo",
+        endpoint="/mcp/messages",
+        auth_source="bootstrap",
+        key_id=None,
+        request_id="req-own-wallet-admin-audit",
+        ok=True,
+    )
+    await record_audit_event(
+        event="billing.charge",
+        wallet_id="wallet-other",
+        tool="billing",
+        endpoint="/v1/billing/charge",
+        auth_source="db",
+        key_id="key-other",
+        request_id="req-other-wallet-audit",
+        ok=True,
+    )
+
+    response = await client.get(
+        f"/v1/audit/events?wallet_id={wallet_id}",
+        headers={"X-API-Key": wallet_api_key},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 2
+    assert {event["wallet_id"] for event in data["events"]} == {wallet_id}
+    assert {event["request_id"] for event in data["events"]} == {
+        "req-own-wallet-audit",
+        "req-own-wallet-admin-audit",
+    }
+
+
+@pytest.mark.anyio
+async def test_db_wallet_key_cannot_list_global_audit_events(client, clean_database):
+    sponsor_response = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": "Audit Route Test Corp",
+            "email": "audit-route-global@test.com",
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert sponsor_response.status_code == 201
+    wallet_id = sponsor_response.json()["wallet_id"]
+
+    key_response = await client.post(
+        "/v1/api-keys",
+        json={
+            "wallet_id": wallet_id,
+            "key_name": "audit-route-global-test-key",
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert key_response.status_code == 201
+    wallet_api_key = key_response.json()["api_key"]
 
     response = await client.get(
         "/v1/audit/events",
+        headers={"X-API-Key": wallet_api_key},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_db_wallet_key_cannot_list_other_wallet_audit_events(
+    client,
+    clean_database,
+):
+    sponsor_response = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": "Audit Route Test Corp",
+            "email": "audit-route-cross-wallet@test.com",
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert sponsor_response.status_code == 201
+    wallet_id = sponsor_response.json()["wallet_id"]
+
+    key_response = await client.post(
+        "/v1/api-keys",
+        json={
+            "wallet_id": wallet_id,
+            "key_name": "audit-route-cross-wallet-test-key",
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert key_response.status_code == 201
+    wallet_api_key = key_response.json()["api_key"]
+
+    response = await client.get(
+        "/v1/audit/events?wallet_id=wallet-other",
+        headers={"X-API-Key": wallet_api_key},
+    )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_db_wallet_key_cannot_request_audit_summary(client, clean_database):
+    sponsor_response = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": "Audit Route Test Corp",
+            "email": "audit-route-summary@test.com",
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert sponsor_response.status_code == 201
+    wallet_id = sponsor_response.json()["wallet_id"]
+
+    key_response = await client.post(
+        "/v1/api-keys",
+        json={
+            "wallet_id": wallet_id,
+            "key_name": "audit-route-summary-test-key",
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert key_response.status_code == 201
+    wallet_api_key = key_response.json()["api_key"]
+
+    response = await client.get(
+        f"/v1/audit/events?wallet_id={wallet_id}&summary=true",
         headers={"X-API-Key": wallet_api_key},
     )
 


### PR DESCRIPTION
## Summary
- allow DB-created wallet keys to list audit events for their own wallet_id
- keep global audit, summary, and cross-wallet inspection bootstrap/admin-only
- document scoped agent-key audit inspection in the golden path and roadmap

## Verification
- pytest -q -> 590 passed
- pytest tests/test_audit_routes.py tests/test_golden_path.py tests/test_discovery_drift.py -q -> 17 passed
- ruff check app/routers/audit.py tests/test_audit_routes.py -> passed
- python3 -m py_compile app/routers/audit.py -> passed
- python3.12 scripts/export_openapi.py --check -> passed
- python3.12 scripts/generate_sim_inventory.py --check -> passed

## Notes
- Existing unstaged uv.lock change was intentionally left out of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts authorization on the audit events endpoint, which is security-sensitive and could expose audit data if the scoping logic is incorrect. Changes are localized and covered by new route tests for global, cross-wallet, and summary denial cases.
> 
> **Overview**
> Enables **wallet-scoped audit inspection**: `GET /v1/audit/events` now allows non-admin (DB-backed) keys to list events only when a `wallet_id` is provided and matches the caller’s wallet, and it strips/ignores `key_id` filtering for non-admin callers.
> 
> Global audit listing (no `wallet_id`), cross-wallet queries, and `summary=true` remain **bootstrap/admin-only**, with expanded tests asserting the allowed/denied cases and docs updated to show scoped agent keys inspecting their own wallet’s audit stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7d4313ac7d42acd3d20418a43bec2cc0d66e9fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->