### PR TITLE
feat: enforce wallet policy bundles

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -646,3 +646,26 @@ class ControlPlaneAuditEventModel(SQLModel, table=True):
     ok: bool = Field(default=True, index=True)
     error: Optional[str] = Field(default=None)
     metadata_json: Optional[str] = Field(default=None)
+
+
+class PolicyBundleModel(SQLModel, table=True):
+    """Wallet-scoped execution policy bundle."""
+
+    __tablename__ = "policy_bundles"
+
+    policy_id: str = Field(primary_key=True, max_length=64)
+    wallet_id: str = Field(max_length=50, foreign_key="wallets.wallet_id", index=True)
+    name: str = Field(max_length=255)
+    allowed_tools_json: Optional[str] = Field(default=None)
+    allowed_service_categories_json: Optional[str] = Field(default=None)
+    max_cost_per_action: Optional[Decimal] = Field(default=None, decimal_places=8)
+    daily_spend_limit: Optional[Decimal] = Field(default=None, decimal_places=8)
+    require_real_effects: bool = Field(default=False)
+    risk_tier: str = Field(default="medium", max_length=20)
+    human_approval_required: bool = Field(default=False)
+    is_active: bool = Field(default=True, index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/app/main.py
+++ b/app/main.py
@@ -63,6 +63,7 @@ from .routers import (
     well_known,
     static,
     planner,
+    policies,
 )
 
 settings = get_settings()
@@ -289,6 +290,7 @@ app.include_router(content_generation.router)
 app.include_router(red_team.router)
 app.include_router(oracle.router)
 app.include_router(audit.router)
+app.include_router(policies.router)
 app.include_router(billing.router)
 app.include_router(launch.router)
 app.include_router(protocol.router)

--- a/app/routers/billing.py
+++ b/app/routers/billing.py
@@ -17,12 +17,14 @@ from ..core.auth import AuthContext, get_auth_context, verify_api_key
 from ..core.dependencies import get_agent_money
 from ..services.agent_money import (
     AgentMoney,
+    DEFAULT_PRICING,
     EXCHANGE_RATE,
     InsufficientFundsError,
     WalletNotFoundError,
     KYCVerificationRequiredError,
 )
 from ..services.governance import record_governed_action
+from ..services.policies import evaluate_wallet_policy
 from ..services.velocity_monitor import WalletFrozenError
 from ..services.stripe_integration import get_stripe_integration
 from ..services.shadow_ledger import get_shadow_ledger
@@ -82,6 +84,52 @@ async def _record_billing_governance(
         error=error,
         metadata={"service_category": service_category, **(metadata or {})},
     )
+
+
+async def _enforce_billing_policy(
+    *,
+    auth: AuthContext,
+    wallet_id: str,
+    category: ServiceCategory,
+    units: float,
+    endpoint: str,
+    request_id: str | None,
+    money: AgentMoney,
+) -> tuple[float, str | None, dict]:
+    estimated_cost = float(Decimal(str(units)) * DEFAULT_PRICING[category][1])
+    policy = await evaluate_wallet_policy(
+        wallet_id=wallet_id,
+        tool_name="billing",
+        service_category=category.value,
+        estimated_cost=estimated_cost,
+        simulation=False,
+    )
+    if not policy.allowed:
+        await _record_billing_governance(
+            event="billing.charge",
+            auth=auth,
+            wallet_id=wallet_id,
+            service_category=category.value,
+            endpoint=endpoint,
+            request_id=request_id,
+            estimated_cost=estimated_cost,
+            ok=False,
+            error=policy.reason,
+            metadata={
+                "policy_id": policy.policy_id,
+                "evaluated_constraints": policy.evaluated_constraints,
+                "units": units,
+            },
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": policy.reason,
+                "policy_id": policy.policy_id,
+                "evaluated_constraints": policy.evaluated_constraints,
+            },
+        )
+    return estimated_cost, policy.policy_id, policy.evaluated_constraints
 
 
 router = APIRouter(
@@ -405,6 +453,20 @@ async def charge_wallet(
                 "message": "service_category is required",
             },
         )
+    request_id = request.headers.get("X-Request-ID")
+    (
+        policy_estimated_cost,
+        policy_id,
+        evaluated_constraints,
+    ) = await _enforce_billing_policy(
+        auth=auth,
+        wallet_id=wallet_id,
+        category=category,
+        units=units,
+        endpoint="/v1/billing/charge",
+        request_id=request_id,
+        money=money,
+    )
     try:
         result = await money.charge(
             wallet_id=wallet_id,
@@ -421,7 +483,7 @@ async def charge_wallet(
                 wallet_id=wallet_id,
                 service_category=category.value,
                 endpoint="/v1/billing/charge",
-                request_id=request.headers.get("X-Request-ID"),
+                request_id=request_id,
                 estimated_cost=float(result.required_amount),
                 ok=False,
                 error="insufficient_funds",
@@ -439,8 +501,8 @@ async def charge_wallet(
             wallet_id=wallet_id,
             service_category=category.value,
             endpoint="/v1/billing/charge",
-            request_id=request.headers.get("X-Request-ID"),
-            estimated_cost=abs(float(result.amount)),
+            request_id=request_id,
+            estimated_cost=policy_estimated_cost,
             committed_cost=abs(float(result.amount)),
             ok=True,
             metadata={
@@ -449,6 +511,8 @@ async def charge_wallet(
                 "ledger_entry_id": result.entry_id,
                 "amount_exact": result.amount_exact,
                 "balance_after_exact": result.balance_after_exact,
+                "policy_id": policy_id,
+                "evaluated_constraints": evaluated_constraints,
             },
         )
         return result
@@ -460,7 +524,7 @@ async def charge_wallet(
                 wallet_id=wallet_id,
                 service_category=category.value,
                 endpoint="/v1/billing/charge",
-                request_id=request.headers.get("X-Request-ID"),
+                request_id=request_id,
                 ok=False,
                 error="wallet_frozen",
                 metadata={"reason": e.reason, "units": units},

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -29,6 +29,7 @@ from ..core.auth import AuthContext, get_auth_context
 from ..policy.decisions import PolicyDecision, evaluate_tool_invocation
 from ..services.agent_money import DEFAULT_PRICING, AgentMoney, get_agent_money
 from ..services.audit_log import record_audit_event
+from ..services.policies import evaluate_wallet_policy
 from ..services.service_registry import get_service_registry
 from ..services.mcp_generator import get_mcp_generator
 from ..services.mcp_phase9_tools import (
@@ -273,6 +274,35 @@ async def _execute_registered_tool(
         )
         raise PermissionError(decision.reason)
 
+    simulation = False
+    try:
+        from ..core.runtime_mode import is_simulation
+
+        simulation = is_simulation(category.value)
+    except Exception:
+        simulation = False
+    policy = await evaluate_wallet_policy(
+        wallet_id=wallet_id,
+        tool_name=tool_name,
+        service_category=category.value,
+        estimated_cost=estimated_cost,
+        simulation=simulation,
+    )
+    policy_metadata = {
+        "policy_id": policy.policy_id,
+        "evaluated_constraints": policy.evaluated_constraints,
+    }
+    if not policy.allowed:
+        await _audit_mcp_invocation(
+            decision=decision,
+            endpoint=endpoint,
+            transport=transport,
+            ok=False,
+            error=policy.reason,
+            extra_metadata=policy_metadata,
+        )
+        raise PermissionError(policy.reason)
+
     description = f"MCP {transport} invoke {tool_name}"
     charge_result = await money.charge(
         wallet_id=wallet_id,
@@ -288,6 +318,7 @@ async def _execute_registered_tool(
             transport=transport,
             ok=False,
             error="insufficient_funds",
+            extra_metadata=policy_metadata,
         )
         raise ValueError("insufficient_funds")
 
@@ -319,6 +350,7 @@ async def _execute_registered_tool(
                     transport=transport,
                     ok=False,
                     error=error,
+                    extra_metadata=policy_metadata,
                 )
             except Exception as audit_exc:
                 error = f"{error}; audit_failed:{audit_exc}"
@@ -334,6 +366,7 @@ async def _execute_registered_tool(
             transport=transport,
             ok=False,
             error=str(exc),
+            extra_metadata=policy_metadata,
         )
         raise ToolExecutionError(str(exc)) from exc
 
@@ -343,6 +376,7 @@ async def _execute_registered_tool(
         transport=transport,
         ok=True,
         error=None,
+        extra_metadata=policy_metadata,
     )
     return {
         "content": [{"type": "text", "text": json.dumps(result, default=str)}],
@@ -385,6 +419,7 @@ async def _audit_mcp_invocation(
     transport: str,
     ok: bool,
     error: str | None,
+    extra_metadata: dict[str, Any] | None = None,
 ) -> None:
     record_audit(
         "mcp.invoke",
@@ -413,6 +448,7 @@ async def _audit_mcp_invocation(
             "transport": transport,
             "estimated_cost": decision.estimated_cost,
             "policy_reason": decision.reason,
+            **(extra_metadata or {}),
         },
     )
 

--- a/app/routers/planner.py
+++ b/app/routers/planner.py
@@ -9,6 +9,7 @@ from app.core.config import get_settings
 from app.policy.decisions import evaluate_governed_action
 from app.schemas.optimizer import OptimizerRequest, OptimizerResponse
 from app.services.audit_log import record_audit_event
+from app.services.policies import evaluate_wallet_policy
 
 router = APIRouter(prefix="/v1/planner", tags=["optimizer"])
 
@@ -30,7 +31,43 @@ def _planner_auth_context(request: Request) -> AuthContext | None:
 @router.post("/optimize", response_model=OptimizerResponse)
 async def optimize_endpoint(req: OptimizerRequest, request: Request) -> OptimizerResponse:
     candidates = get_candidate_actions(req.state)
-    plan = optimize_action_set(req.state, candidates, req)
+    policy_rejected: list[dict] = []
+    policy_ids: set[str] = set()
+    allowed_candidates: list[dict] = []
+    for action in candidates:
+        service = action.get("service")
+        evaluation = await evaluate_wallet_policy(
+            wallet_id=req.state.wallet_id,
+            tool_name=action.get("id"),
+            service_category=action.get("category") or service,
+            estimated_cost=action.get("credit_cost"),
+            daily_spend_used=req.state.daily_spend_used,
+            simulation=req.state.simulation_flags.get(service, False),
+            risk_tier=req.state.task_context.get("tier"),
+        )
+        if evaluation.policy_id:
+            policy_ids.add(evaluation.policy_id)
+        if evaluation.allowed:
+            allowed_candidates.append(action)
+        else:
+            policy_rejected.append(
+                {
+                    "id": action.get("id"),
+                    "reason": evaluation.reason,
+                    "policy_id": evaluation.policy_id,
+                }
+            )
+
+    plan = optimize_action_set(req.state, allowed_candidates, req)
+    if policy_rejected:
+        plan["rejected_actions"] = policy_rejected + plan["rejected_actions"]
+        plan["policy_reasons"].update(
+            {
+                item["id"]: item["reason"]
+                for item in policy_rejected
+                if item.get("id")
+            }
+        )
     request_id = request.headers.get("X-Request-ID") or req.state.request_id
     decision = evaluate_governed_action(
         auth=_planner_auth_context(request),
@@ -57,6 +94,7 @@ async def optimize_endpoint(req: OptimizerRequest, request: Request) -> Optimize
             "selected_count": len(plan["selected_actions"]),
             "rejected_count": len(plan["rejected_actions"]),
             "policy_reason": decision.reason,
+            "policy_ids": sorted(policy_ids),
             "simulation_flags": req.state.simulation_flags,
             "constraint_margins": plan["constraint_margins"],
         },
@@ -65,6 +103,7 @@ async def optimize_endpoint(req: OptimizerRequest, request: Request) -> Optimize
         "request_id": request_id,
         "wallet_id": req.state.wallet_id,
         "policy_decision_id": decision.decision_id,
+        "policy_ids": sorted(policy_ids),
         "audit_event_id": audit_event.event_id,
     }
     return OptimizerResponse(**plan)

--- a/app/routers/policies.py
+++ b/app/routers/policies.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.core.auth import AuthContext, get_auth_context
+from app.schemas.policies import (
+    PolicyBundleCreate,
+    PolicyBundleListResponse,
+    PolicyBundlePatch,
+    PolicyBundleResponse,
+)
+from app.services.policies import (
+    create_policy_bundle,
+    get_policy_bundle,
+    list_policy_bundles,
+    patch_policy_bundle,
+)
+
+router = APIRouter(prefix="/v1/policies", tags=["Policy Bundles"])
+
+
+@router.post("", response_model=PolicyBundleResponse, status_code=status.HTTP_201_CREATED)
+async def create_policy(
+    request: PolicyBundleCreate,
+    auth: AuthContext = Depends(get_auth_context),
+) -> PolicyBundleResponse:
+    auth.require_bootstrap_admin()
+    return await create_policy_bundle(request)
+
+
+@router.get("", response_model=PolicyBundleListResponse)
+async def list_policies(
+    wallet_id: str | None = Query(None),
+    auth: AuthContext = Depends(get_auth_context),
+) -> PolicyBundleListResponse:
+    auth.require_bootstrap_admin()
+    policies = await list_policy_bundles(wallet_id=wallet_id)
+    return PolicyBundleListResponse(policies=policies, total=len(policies))
+
+
+@router.get("/{policy_id}", response_model=PolicyBundleResponse)
+async def get_policy(
+    policy_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> PolicyBundleResponse:
+    auth.require_bootstrap_admin()
+    policy = await get_policy_bundle(policy_id)
+    if not policy:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    return policy
+
+
+@router.patch("/{policy_id}", response_model=PolicyBundleResponse)
+async def patch_policy(
+    policy_id: str,
+    request: PolicyBundlePatch,
+    auth: AuthContext = Depends(get_auth_context),
+) -> PolicyBundleResponse:
+    auth.require_bootstrap_admin()
+    policy = await patch_policy_bundle(policy_id, request)
+    if not policy:
+        raise HTTPException(status_code=404, detail="Policy not found")
+    return policy

--- a/app/schemas/policies.py
+++ b/app/schemas/policies.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class PolicyBundleCreate(BaseModel):
+    wallet_id: str
+    name: str = Field(..., min_length=1)
+    allowed_tools: list[str] | None = None
+    allowed_service_categories: list[str] | None = None
+    max_cost_per_action: float | None = Field(default=None, ge=0)
+    daily_spend_limit: float | None = Field(default=None, ge=0)
+    require_real_effects: bool = False
+    risk_tier: str = "medium"
+    human_approval_required: bool = False
+    is_active: bool = True
+
+
+class PolicyBundlePatch(BaseModel):
+    name: str | None = Field(default=None, min_length=1)
+    allowed_tools: list[str] | None = None
+    allowed_service_categories: list[str] | None = None
+    max_cost_per_action: float | None = Field(default=None, ge=0)
+    daily_spend_limit: float | None = Field(default=None, ge=0)
+    require_real_effects: bool | None = None
+    risk_tier: str | None = None
+    human_approval_required: bool | None = None
+    is_active: bool | None = None
+
+
+class PolicyBundleResponse(BaseModel):
+    policy_id: str
+    wallet_id: str
+    name: str
+    allowed_tools: list[str] | None
+    allowed_service_categories: list[str] | None
+    max_cost_per_action: float | None
+    daily_spend_limit: float | None
+    require_real_effects: bool
+    risk_tier: str
+    human_approval_required: bool
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+
+class PolicyBundleListResponse(BaseModel):
+    policies: list[PolicyBundleResponse]
+    total: int

--- a/app/services/policies.py
+++ b/app/services/policies.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+import json
+from typing import Any
+import uuid
+
+from sqlalchemy import select
+
+from app.db.database import get_session_factory
+from app.db.models import PolicyBundleModel
+from app.schemas.policies import PolicyBundleCreate, PolicyBundlePatch, PolicyBundleResponse
+
+
+@dataclass(frozen=True)
+class PolicyEvaluation:
+    allowed: bool
+    reason: str
+    policy_id: str | None
+    evaluated_constraints: dict[str, Any]
+
+
+def _decode_list(value: str | None) -> list[str] | None:
+    if value is None:
+        return None
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, list) else None
+
+
+def _encode_list(value: list[str] | None) -> str | None:
+    return json.dumps(value) if value is not None else None
+
+
+def _to_response(model: PolicyBundleModel) -> PolicyBundleResponse:
+    return PolicyBundleResponse(
+        policy_id=model.policy_id,
+        wallet_id=model.wallet_id,
+        name=model.name,
+        allowed_tools=_decode_list(model.allowed_tools_json),
+        allowed_service_categories=_decode_list(model.allowed_service_categories_json),
+        max_cost_per_action=(
+            float(model.max_cost_per_action)
+            if model.max_cost_per_action is not None
+            else None
+        ),
+        daily_spend_limit=(
+            float(model.daily_spend_limit)
+            if model.daily_spend_limit is not None
+            else None
+        ),
+        require_real_effects=model.require_real_effects,
+        risk_tier=model.risk_tier,
+        human_approval_required=model.human_approval_required,
+        is_active=model.is_active,
+        created_at=model.created_at,
+        updated_at=model.updated_at,
+    )
+
+
+async def create_policy_bundle(request: PolicyBundleCreate) -> PolicyBundleResponse:
+    model = PolicyBundleModel(
+        policy_id=f"polb-{uuid.uuid4().hex[:16]}",
+        wallet_id=request.wallet_id,
+        name=request.name,
+        allowed_tools_json=_encode_list(request.allowed_tools),
+        allowed_service_categories_json=_encode_list(request.allowed_service_categories),
+        max_cost_per_action=(
+            Decimal(str(request.max_cost_per_action))
+            if request.max_cost_per_action is not None
+            else None
+        ),
+        daily_spend_limit=(
+            Decimal(str(request.daily_spend_limit))
+            if request.daily_spend_limit is not None
+            else None
+        ),
+        require_real_effects=request.require_real_effects,
+        risk_tier=request.risk_tier,
+        human_approval_required=request.human_approval_required,
+        is_active=request.is_active,
+    )
+    factory = get_session_factory()
+    async with factory() as session:
+        session.add(model)
+        await session.commit()
+        await session.refresh(model)
+    return _to_response(model)
+
+
+async def list_policy_bundles(wallet_id: str | None = None) -> list[PolicyBundleResponse]:
+    stmt = select(PolicyBundleModel).order_by(PolicyBundleModel.created_at)
+    if wallet_id:
+        stmt = stmt.where(PolicyBundleModel.wallet_id == wallet_id)
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(stmt)
+        return [_to_response(row) for row in result.scalars().all()]
+
+
+async def get_policy_bundle(policy_id: str) -> PolicyBundleResponse | None:
+    factory = get_session_factory()
+    async with factory() as session:
+        row = await session.get(PolicyBundleModel, policy_id)
+        return _to_response(row) if row else None
+
+
+async def patch_policy_bundle(
+    policy_id: str,
+    patch: PolicyBundlePatch,
+) -> PolicyBundleResponse | None:
+    factory = get_session_factory()
+    async with factory() as session:
+        row = await session.get(PolicyBundleModel, policy_id)
+        if not row:
+            return None
+        update = patch.model_dump(exclude_unset=True)
+        for field, value in update.items():
+            if field == "allowed_tools":
+                row.allowed_tools_json = _encode_list(value)
+            elif field == "allowed_service_categories":
+                row.allowed_service_categories_json = _encode_list(value)
+            elif field in {"max_cost_per_action", "daily_spend_limit"}:
+                setattr(row, field, Decimal(str(value)) if value is not None else None)
+            else:
+                setattr(row, field, value)
+        row.updated_at = datetime.utcnow()
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+    return _to_response(row)
+
+
+async def evaluate_wallet_policy(
+    *,
+    wallet_id: str,
+    tool_name: str | None = None,
+    service_category: str | None = None,
+    estimated_cost: float | None = None,
+    daily_spend_used: float | None = None,
+    simulation: bool | None = None,
+    risk_tier: str | None = None,
+) -> PolicyEvaluation:
+    policies = [
+        policy
+        for policy in await list_policy_bundles(wallet_id=wallet_id)
+        if policy.is_active
+    ]
+    if not policies:
+        return PolicyEvaluation(True, "allowed", None, {"policy_count": 0})
+
+    evaluated: list[dict[str, Any]] = []
+    for policy in policies:
+        constraints = {
+            "policy_id": policy.policy_id,
+            "allowed_tools": policy.allowed_tools,
+            "allowed_service_categories": policy.allowed_service_categories,
+            "max_cost_per_action": policy.max_cost_per_action,
+            "daily_spend_limit": policy.daily_spend_limit,
+            "require_real_effects": policy.require_real_effects,
+            "risk_tier": policy.risk_tier,
+            "human_approval_required": policy.human_approval_required,
+        }
+        evaluated.append(constraints)
+        if policy.human_approval_required:
+            return PolicyEvaluation(False, "human_approval_required", policy.policy_id, {"evaluated": evaluated})
+        if policy.allowed_tools is not None and tool_name not in policy.allowed_tools:
+            return PolicyEvaluation(False, "tool_not_allowed", policy.policy_id, {"evaluated": evaluated})
+        if (
+            policy.allowed_service_categories is not None
+            and service_category not in policy.allowed_service_categories
+        ):
+            return PolicyEvaluation(False, "service_category_not_allowed", policy.policy_id, {"evaluated": evaluated})
+        if (
+            policy.max_cost_per_action is not None
+            and estimated_cost is not None
+            and estimated_cost > policy.max_cost_per_action
+        ):
+            return PolicyEvaluation(False, "max_cost_per_action_exceeded", policy.policy_id, {"evaluated": evaluated})
+        if (
+            policy.daily_spend_limit is not None
+            and daily_spend_used is not None
+            and estimated_cost is not None
+            and daily_spend_used + estimated_cost > policy.daily_spend_limit
+        ):
+            return PolicyEvaluation(False, "daily_spend_limit_exceeded", policy.policy_id, {"evaluated": evaluated})
+        if policy.require_real_effects and simulation:
+            return PolicyEvaluation(False, "real_effects_required", policy.policy_id, {"evaluated": evaluated})
+        if risk_tier is not None and policy.risk_tier != risk_tier:
+            constraints["requested_risk_tier"] = risk_tier
+
+    return PolicyEvaluation(True, "allowed", policies[0].policy_id, {"evaluated": evaluated})

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -131,6 +131,26 @@ curl -X POST "$API_URL/v1/billing/dry-run/charge" \
   }"
 ```
 
+## 6a. Optional: Attach A Wallet Policy
+
+Operators can constrain the agent wallet before execution:
+
+```bash
+curl -X POST "$API_URL/v1/policies" \
+  -H "X-API-Key: $BOOTSTRAP_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"wallet_id\": \"$AGENT_WALLET_ID\",
+    \"name\": \"golden-path-policy\",
+    \"allowed_service_categories\": [\"agent_comms\"],
+    \"max_cost_per_action\": 5
+  }"
+```
+
+If an MCP invocation, billing charge, or planner action violates the active
+wallet policy, it is denied before execution or charge and the audit event
+includes the `policy_id` and evaluated constraints.
+
 ## 7. Invoke Or Discover Tools
 
 Fetch the MCP manifest:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3147,6 +3147,206 @@
         }
       }
     },
+    "/v1/policies": {
+      "post": {
+        "tags": [
+          "Policy Bundles"
+        ],
+        "summary": "Create Policy",
+        "operationId": "create_policy_v1_policies_post",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyBundleCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyBundleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Policy Bundles"
+        ],
+        "summary": "List Policies",
+        "operationId": "list_policies_v1_policies_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "wallet_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Wallet Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyBundleListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/policies/{policy_id}": {
+      "get": {
+        "tags": [
+          "Policy Bundles"
+        ],
+        "summary": "Get Policy",
+        "operationId": "get_policy_v1_policies__policy_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Policy Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyBundleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Policy Bundles"
+        ],
+        "summary": "Patch Policy",
+        "operationId": "patch_policy_v1_policies__policy_id__patch",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Policy Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyBundlePatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PolicyBundleResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/billing/wallets/sponsor": {
       "post": {
         "tags": [
@@ -17397,6 +17597,341 @@
         ],
         "title": "PlatformAnalytics",
         "description": "Engagement analytics for a specific platform."
+      },
+      "PolicyBundleCreate": {
+        "properties": {
+          "wallet_id": {
+            "type": "string",
+            "title": "Wallet Id"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name"
+          },
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Tools"
+          },
+          "allowed_service_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Service Categories"
+          },
+          "max_cost_per_action": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Cost Per Action"
+          },
+          "daily_spend_limit": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Daily Spend Limit"
+          },
+          "require_real_effects": {
+            "type": "boolean",
+            "title": "Require Real Effects",
+            "default": false
+          },
+          "risk_tier": {
+            "type": "string",
+            "title": "Risk Tier",
+            "default": "medium"
+          },
+          "human_approval_required": {
+            "type": "boolean",
+            "title": "Human Approval Required",
+            "default": false
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "wallet_id",
+          "name"
+        ],
+        "title": "PolicyBundleCreate"
+      },
+      "PolicyBundleListResponse": {
+        "properties": {
+          "policies": {
+            "items": {
+              "$ref": "#/components/schemas/PolicyBundleResponse"
+            },
+            "type": "array",
+            "title": "Policies"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          }
+        },
+        "type": "object",
+        "required": [
+          "policies",
+          "total"
+        ],
+        "title": "PolicyBundleListResponse"
+      },
+      "PolicyBundlePatch": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Tools"
+          },
+          "allowed_service_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Service Categories"
+          },
+          "max_cost_per_action": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Cost Per Action"
+          },
+          "daily_spend_limit": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Daily Spend Limit"
+          },
+          "require_real_effects": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Require Real Effects"
+          },
+          "risk_tier": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Risk Tier"
+          },
+          "human_approval_required": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Human Approval Required"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
+          }
+        },
+        "type": "object",
+        "title": "PolicyBundlePatch"
+      },
+      "PolicyBundleResponse": {
+        "properties": {
+          "policy_id": {
+            "type": "string",
+            "title": "Policy Id"
+          },
+          "wallet_id": {
+            "type": "string",
+            "title": "Wallet Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Tools"
+          },
+          "allowed_service_categories": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Service Categories"
+          },
+          "max_cost_per_action": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Cost Per Action"
+          },
+          "daily_spend_limit": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Daily Spend Limit"
+          },
+          "require_real_effects": {
+            "type": "boolean",
+            "title": "Require Real Effects"
+          },
+          "risk_tier": {
+            "type": "string",
+            "title": "Risk Tier"
+          },
+          "human_approval_required": {
+            "type": "boolean",
+            "title": "Human Approval Required"
+          },
+          "is_active": {
+            "type": "boolean",
+            "title": "Is Active"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "policy_id",
+          "wallet_id",
+          "name",
+          "allowed_tools",
+          "allowed_service_categories",
+          "max_cost_per_action",
+          "daily_spend_limit",
+          "require_real_effects",
+          "risk_tier",
+          "human_approval_required",
+          "is_active",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "PolicyBundleResponse"
       },
       "PreflightCheckResult": {
         "properties": {

--- a/docs/production-beta-roadmap.md
+++ b/docs/production-beta-roadmap.md
@@ -92,6 +92,16 @@ wallet keys can list audit events only for their own `wallet_id`, while global
 audit queries, summaries, and cross-wallet inspection remain bootstrap/admin
 only.
 
+## Policy Bundle Enforcement Outcome
+
+Policy bundles make governance actively enforceable instead of only inspectable.
+Bootstrap/admin operators can create wallet-scoped policies at `/v1/policies`
+to constrain allowed tools, service categories, per-action cost, real-effects
+requirements, risk tier, and human-approval gates. MCP invocation, billing
+charges, and planner optimization now evaluate active wallet policies before
+execution or charge, and audit metadata records the matched `policy_id` and
+evaluated constraints.
+
 ## Recommended Milestones
 
 ### Milestone 1: Green And Trustworthy Mainline

--- a/migrations/versions/015_policy_bundles.py
+++ b/migrations/versions/015_policy_bundles.py
@@ -1,0 +1,45 @@
+"""Policy bundles.
+
+Revision ID: 015_policy_bundles
+Revises: 014_control_plane_audit
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "015_policy_bundles"
+down_revision: Union[str, None] = "014_control_plane_audit"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "policy_bundles",
+        sa.Column("policy_id", sa.String(length=64), primary_key=True),
+        sa.Column("wallet_id", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("allowed_tools_json", sa.Text(), nullable=True),
+        sa.Column("allowed_service_categories_json", sa.Text(), nullable=True),
+        sa.Column("max_cost_per_action", sa.Numeric(precision=18, scale=8), nullable=True),
+        sa.Column("daily_spend_limit", sa.Numeric(precision=18, scale=8), nullable=True),
+        sa.Column("require_real_effects", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("risk_tier", sa.String(length=20), nullable=False, server_default="medium"),
+        sa.Column("human_approval_required", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["wallet_id"], ["wallets.wallet_id"]),
+    )
+    op.create_index("ix_policy_bundles_wallet_id", "policy_bundles", ["wallet_id"])
+    op.create_index("ix_policy_bundles_is_active", "policy_bundles", ["is_active"])
+    op.create_index("ix_policy_bundles_created_at", "policy_bundles", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_policy_bundles_created_at", table_name="policy_bundles")
+    op.drop_index("ix_policy_bundles_is_active", table_name="policy_bundles")
+    op.drop_index("ix_policy_bundles_wallet_id", table_name="policy_bundles")
+    op.drop_table("policy_bundles")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ async def clean_database():
         await session.execute(text("DELETE FROM content_factory_generations"))
         await session.execute(text("DELETE FROM ledger_entries"))
         await session.execute(text("DELETE FROM billing_alerts"))
+        await session.execute(text("DELETE FROM policy_bundles"))
         await session.execute(text("DELETE FROM wallets"))
         await session.execute(text("DELETE FROM daily_balance_snapshots"))
         await session.execute(text("DELETE FROM kyc_verifications"))

--- a/tests/test_policy_bundles.py
+++ b/tests/test_policy_bundles.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.schemas.billing import ServiceCategory
+from app.services.audit_log import list_audit_events
+from app.services.service_registry import get_service_registry
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+async def _wallet(client: AsyncClient, agent_id: str = "policy-agent") -> str:
+    headers = {"X-API-Key": "test-key"}
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": f"{agent_id} sponsor",
+            "email": f"{agent_id}@example.com",
+            "initial_credits": 10000,
+            "require_kyc": False,
+        },
+        headers=headers,
+    )
+    assert sponsor.status_code == 201
+    agent = await client.post(
+        "/v1/billing/wallets/agent",
+        json={
+            "sponsor_wallet_id": sponsor.json()["wallet_id"],
+            "agent_id": agent_id,
+            "budget_credits": 1000,
+        },
+        headers=headers,
+    )
+    assert agent.status_code == 201
+    return agent.json()["wallet_id"]
+
+
+@pytest.mark.anyio
+async def test_policy_crud_requires_bootstrap_admin(client, clean_database):
+    wallet_id = await _wallet(client, "policy-crud")
+    created = await client.post(
+        "/v1/policies",
+        json={
+            "wallet_id": wallet_id,
+            "name": "Strict agent policy",
+            "allowed_tools": ["policy-echo"],
+            "allowed_service_categories": ["agent_comms"],
+            "max_cost_per_action": 3,
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert created.status_code == 201
+    policy = created.json()
+    assert policy["policy_id"].startswith("polb-")
+
+    listed = await client.get(
+        f"/v1/policies?wallet_id={wallet_id}",
+        headers={"X-API-Key": "test-key"},
+    )
+    assert listed.status_code == 200
+    assert listed.json()["total"] == 1
+
+    patched = await client.patch(
+        f"/v1/policies/{policy['policy_id']}",
+        json={"max_cost_per_action": 1, "is_active": False},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["max_cost_per_action"] == 1.0
+    assert patched.json()["is_active"] is False
+
+    key = await client.post(
+        "/v1/api-keys",
+        json={"wallet_id": wallet_id, "key_name": "runtime"},
+        headers={"X-API-Key": "test-key"},
+    )
+    assert key.status_code == 201
+    denied = await client.get(
+        f"/v1/policies?wallet_id={wallet_id}",
+        headers={"X-API-Key": key.json()["api_key"]},
+    )
+    assert denied.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_mcp_policy_denies_disallowed_tool_before_charge(client, clean_database):
+    registry = get_service_registry()
+
+    def blocked_tool() -> dict:
+        return {"ran": True}
+
+    registry.register_local(
+        service_id="policy-blocked-tool",
+        name="Policy Blocked Tool",
+        description="Should be blocked by policy",
+        category=ServiceCategory.AGENT_COMMS,
+        func=blocked_tool,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    try:
+        wallet_id = await _wallet(client, "policy-mcp")
+        policy = await client.post(
+            "/v1/policies",
+            json={
+                "wallet_id": wallet_id,
+                "name": "Only another tool",
+                "allowed_tools": ["some-other-tool"],
+            },
+            headers={"X-API-Key": "test-key"},
+        )
+        assert policy.status_code == 201
+
+        response = await client.post(
+            "/mcp/messages",
+            json={
+                "jsonrpc": "2.0",
+                "id": "policy-deny-1",
+                "method": "tools/call",
+                "params": {
+                    "name": "policy-blocked-tool",
+                    "arguments": {},
+                    "mcpContext": {"wallet_id": wallet_id},
+                },
+            },
+            headers={"X-API-Key": "test-key"},
+        )
+        assert response.status_code == 200
+        assert response.json()["error"]["message"] == "tool_not_allowed"
+
+        ledger = await client.get(
+            f"/v1/billing/ledger/{wallet_id}",
+            headers={"X-API-Key": "test-key"},
+        )
+        assert ledger.status_code == 200
+        assert all(
+            "policy-blocked-tool" not in entry.get("description", "")
+            for entry in ledger.json()["entries"]
+        )
+
+        events = await list_audit_events(wallet_id=wallet_id, tool="policy-blocked-tool")
+        assert len(events) == 1
+        assert events[0].ok is False
+        assert events[0].error == "tool_not_allowed"
+        assert events[0].metadata["policy_id"] == policy.json()["policy_id"]
+    finally:
+        registry.unregister_local("policy-blocked-tool")
+
+
+@pytest.mark.anyio
+async def test_billing_policy_denies_disallowed_category(client, clean_database):
+    wallet_id = await _wallet(client, "policy-billing")
+    policy = await client.post(
+        "/v1/policies",
+        json={
+            "wallet_id": wallet_id,
+            "name": "No IoT",
+            "allowed_service_categories": ["agent_comms"],
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert policy.status_code == 201
+
+    response = await client.post(
+        f"/v1/billing/charge?wallet_id={wallet_id}&service=iot_bridge&units=1",
+        headers={"X-API-Key": "test-key", "X-Request-ID": "policy-billing-deny"},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "service_category_not_allowed"
+
+    events = await list_audit_events(
+        wallet_id=wallet_id,
+        request_id="policy-billing-deny",
+    )
+    assert len(events) == 1
+    assert events[0].error == "service_category_not_allowed"
+    assert events[0].metadata["policy_id"] == policy.json()["policy_id"]
+
+
+@pytest.mark.anyio
+async def test_billing_policy_denies_over_cost_charge(client, clean_database):
+    wallet_id = await _wallet(client, "policy-billing-cost")
+    policy = await client.post(
+        "/v1/policies",
+        json={
+            "wallet_id": wallet_id,
+            "name": "Cheap actions only",
+            "allowed_service_categories": ["agent_comms"],
+            "max_cost_per_action": 1,
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert policy.status_code == 201
+
+    response = await client.post(
+        f"/v1/billing/charge?wallet_id={wallet_id}&service=agent_comms&units=2",
+        headers={"X-API-Key": "test-key", "X-Request-ID": "policy-cost-deny"},
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "max_cost_per_action_exceeded"
+
+
+@pytest.mark.anyio
+async def test_planner_policy_rejects_actions(client, clean_database):
+    wallet_id = await _wallet(client, "policy-planner")
+    policy = await client.post(
+        "/v1/policies",
+        json={
+            "wallet_id": wallet_id,
+            "name": "Only agent comms",
+            "allowed_service_categories": ["agent_comms"],
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert policy.status_code == 201
+
+    response = await client.post(
+        "/v1/planner/optimize",
+        json={
+            "state": {
+                "wallet_id": wallet_id,
+                "agent_id": "a1",
+                "task_id": "t1",
+                "request_id": "policy-planner-1",
+                "wallet_balance": 100,
+                "daily_spend_used": 0,
+                "daily_limit": 100,
+                "rate_limit_headroom": 1,
+                "service_health": {"iot_bridge": "healthy", "agent_comms": "healthy"},
+                "simulation_flags": {"iot_bridge": False, "agent_comms": False},
+                "auth_scope": ["invoke"],
+                "task_context": {
+                    "tier": "high",
+                    "candidate_actions": [
+                        {
+                            "id": "bad-iot",
+                            "service": "iot_bridge",
+                            "credit_cost": 1,
+                            "latency_ms": 10,
+                            "risk_score": 0.01,
+                            "expected_value": 10,
+                            "reliability": 1,
+                        },
+                        {
+                            "id": "good-comms",
+                            "service": "agent_comms",
+                            "credit_cost": 1,
+                            "latency_ms": 10,
+                            "risk_score": 0.01,
+                            "expected_value": 5,
+                            "reliability": 1,
+                        },
+                    ],
+                },
+                "remaining_budget": 10,
+                "slo_window_seconds": 1,
+            },
+            "max_actions": 2,
+        },
+        headers={"X-API-Key": "test-key", "X-Request-ID": "policy-planner-1"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["policy_reasons"]["bad-iot"] == "service_category_not_allowed"
+    assert body["rejected_actions"][0]["policy_id"] == policy.json()["policy_id"]
+    assert body["governance"]["policy_ids"] == [policy.json()["policy_id"]]


### PR DESCRIPTION
## Summary
- add wallet-scoped policy bundle CRUD APIs at /v1/policies
- enforce active wallet policies in MCP invocation, billing charges, and planner optimization
- record policy_id and evaluated constraints in governance/audit metadata
- add migration, OpenAPI update, docs, and policy bundle acceptance tests

## Verification
Clean temporary worktree with only this staged patch applied:
- pytest -q -> 595 passed
- pytest tests/test_policy_bundles.py tests/test_mcp_generator.py tests/test_billing.py tests/test_planner_constraints.py tests/test_audit_routes.py tests/test_golden_path.py tests/test_discovery_drift.py tests/test_migrations.py -q -> 86 passed
- ruff check changed files -> passed
- python3 -m py_compile changed Python files -> passed
- python3.12 scripts/export_openapi.py --check -> passed
- python3.12 scripts/generate_sim_inventory.py --check -> passed

## Notes
- This PR is stacked on #96 because wallet-scoped audit inspection is still open.
- Existing unrelated local trust-plane work and uv.lock changes were intentionally left out of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new DB-backed policy enforcement that can block MCP tool execution, billing charges, and planner candidates, so misconfigured policies or evaluation bugs could deny legitimate actions or change cost/governance metadata.
> 
> **Overview**
> Adds **wallet-scoped policy bundles** persisted in a new `policy_bundles` table (migration + `PolicyBundleModel`) and exposes bootstrap-admin CRUD endpoints at `POST/GET/PATCH /v1/policies`.
> 
> Enforces active wallet policies before execution/charge in **MCP tool calls**, **`/v1/billing/charge`**, and **planner `POST /v1/planner/optimize`** (filtering out disallowed candidate actions), and records `policy_id` plus evaluated constraints into audit/governance metadata and denial responses.
> 
> Updates OpenAPI/docs and adds acceptance tests covering CRUD permissions and enforcement behavior (deny-before-charge, audit entries, planner rejected actions), plus test DB cleanup for the new table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbcf797abdb59015599383223d1b20d06e0046c9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->