### PR TITLE
Promote runtime dependencies for trust plane

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ browser = ["playwright>=1.40.0"]
 webauthn = ["webauthn>=1.0.0"]
 chromadb = ["chromadb>=0.4.0"]
 rag = ["chromadb>=0.4.0"]
-observability = ["structlog>=24.0.0"]
+observability = ["structlog>=24.1.0"]
 resilience = ["tenacity>=8.0.0"]
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ uvicorn[standard]>=0.46.0
 pydantic>=2.13.4
 pydantic-settings>=2.14.0
 email-validator>=2.3.0  # Keep FastAPI/Pydantic OpenAPI email schema stable in CI
+structlog>=24.1.0       # Structured startup/runtime logging
 
 # --- IoT Protocol Bridge ---
 aiomqtt>=2.5.1          # Async MQTT client
@@ -23,6 +24,7 @@ python-dotenv>=1.2.2    # .env file loading
 cryptography>=46.0.0    # Ed25519 trust-plane signatures
 redis>=7.4.0            # Redis-backed rate limiting and runtime persistence
 asyncpg>=0.31.0         # PostgreSQL-backed runtime persistence
+greenlet>=3.0.0         # SQLAlchemy async engine support
 stripe>=15.1.0           # Stripe payment processing
 mcp>=1.0.0             # MCP (Model Context Protocol) SDK for tool servers
 

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ requires-dist = [
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.40.0" },
-    { name = "structlog", marker = "extra == 'observability'", specifier = ">=24.0.0" },
+    { name = "structlog", marker = "extra == 'observability'", specifier = ">=24.1.0" },
     { name = "tenacity", marker = "extra == 'resilience'", specifier = ">=8.0.0" },
     { name = "webauthn", marker = "extra == 'webauthn'", specifier = ">=1.0.0" },
 ]


### PR DESCRIPTION
## Summary
- Ports the mission-supporting Railway startup fix by adding `structlog` to base runtime requirements without downgrading current dependency floors.
- Adds explicit `greenlet` runtime dependency so SQLAlchemy async DB initialization works from a clean `requirements.txt` install.
- Keeps `pyproject.toml`/`uv.lock` observability metadata aligned with the promoted `structlog` floor.

## Branch triage
- `origin/railway/fix-deploy-192f1b` / `origin/master`: useful contribution was `structlog`; ported directly instead of merging stale dependency pins.
- `chore/safety-freeze`: patch-equivalent WebAuthn safety work is already present in `main`; not re-merged because the branch is based before the trust-plane PR.
- `origin/feat/health-dependency-checks`, `origin/feat/simulation-mode-flag`, `origin/opencode/curious-canyon`, `origin/claude/silly-neumann-5b320f`: either already represented in `main` or stale/destructive versus the current trust-plane code; left unmerged.

## Verification
- `uv run python -c "import greenlet, structlog; import app.main; print('import ok')"`
- `uv run pytest tests/test_v1_production.py tests/test_golden_path.py tests/test_mcp_trust.py -q --tb=short`
- `uv run pytest tests/test_permits.py tests/test_receipts.py tests/test_mcp_trust.py tests/test_audit_chain.py tests/test_key_management.py tests/test_idempotency.py tests/test_route_auth_inventory.py tests/test_migrations.py -q --tb=short`
- `uv run ruff check app/ tests/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change; main impact is deployment/runtime behavior if the new floors introduce incompatibilities in environments that previously relied on missing/older packages.
> 
> **Overview**
> Promotes `structlog` to a base runtime dependency (and bumps the `observability` extra floor to `>=24.1.0`) so structured logging is available without installing extras.
> 
> Adds `greenlet` as an explicit runtime dependency to support SQLAlchemy async engine initialization from a clean `requirements.txt` install, and aligns `uv.lock` metadata with the new `structlog` floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde6454e82c211b927836942cd604d4d7f1c83e4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->