### PR TITLE
feat: add agent trust ledger demo pack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
             tests/test_route_auth_inventory.py \
             -v --tb=short
 
+      - name: Run trust-plane demo smoke test
+        run: python scripts/demo_trust_plane.py --assert
+
       - name: Validate OpenAPI spec generates
         run: |
           python -c "

--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -1,9 +1,21 @@
-# Killer Demo: Governed MCP Tool Call
+# Demo Script: Concrete Trust-Plane Proof
 
-This demo proves the narrow wedge: an agent tool call that is scoped, metered,
-receipted, auditable, replay-safe, and denied when out of scope.
+This is the design-partner demo for the current trust-plane proof. It shows one
+bounded agent tool call moving through the control plane:
+
+```text
+scoped signed permit -> governed MCP invoke -> wallet charge -> signed receipt
+-> ledger -> audit chain -> replay no double charge -> out-of-scope denial
+```
+
+The proof is intentionally narrow. It demonstrates that the governed MCP path
+can enforce scope, meter a call, produce verifiable artifacts, and reject misuse.
+It does not claim production readiness, settlement rails, or a complete
+autonomous economic actor infrastructure.
 
 ## Environment
+
+Run the API in trust mode:
 
 ```bash
 export VALID_API_KEYS=dev-bootstrap-key
@@ -13,14 +25,34 @@ export ALLOW_LEGACY_UNPERMITTED_MCP=false
 uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
-## Flow
+## One-Command Proof
+
+For a local proof that exercises the real FastAPI routers, a throwaway SQLite
+database, signed trust artifacts, and the governed MCP path without running a
+server:
+
+```bash
+make demo-trust-plane
+```
+
+For CI or pre-merge verification:
+
+```bash
+make demo-trust-plane-check
+```
+
+The proof artifact shape is captured in
+[`docs/demo-trust-plane-output.md`](docs/demo-trust-plane-output.md). Use the
+live demo flow below when walking a partner through the product story.
+
+## Live Demo Flow
 
 1. Fetch `/.well-known/agent.json` and `/mcp/tools.json`.
 2. Create a sponsor wallet with a bootstrap key.
 3. Create an agent wallet.
 4. Create an agent API key for the agent wallet.
 5. Register or use an MCP tool.
-6. Create a permit with:
+6. Create a signed permit with:
    - `allowed_tools: ["tool-name"]`
    - `scopes: ["tool:tool-name:invoke", "billing:charge"]`
    - `max_credits`
@@ -31,15 +63,47 @@ uvicorn app.main:app --host 0.0.0.0 --port 8000
    - `mcpContext.wallet_id`
    - `mcpContext.permit_id`
    - `mcpContext.idempotency_key`
-8. Verify `/v1/receipts/verify`.
-9. Verify `/v1/audit/verify-chain`.
-10. Replay the same MCP request and confirm the receipt ID is unchanged.
-11. Invoke a different tool under the same permit and confirm it is denied.
+8. Show the wallet charge in the billing ledger.
+9. Verify the signed receipt with `/v1/receipts/verify`.
+10. Inspect the signed receipt with `/v1/receipts` and
+    `/v1/permits/{permit_id}/receipts`.
+11. Inspect the permit with `/v1/permits/{permit_id}` and the active public
+    signing key with `/v1/signing-keys/active`.
+12. Verify the wallet audit chain with `/v1/audit/verify-chain`.
+13. Replay the same MCP request and confirm the receipt ID is unchanged and no
+    second ledger debit appears.
+14. Invoke a different tool under the same permit and confirm the request is
+    denied as out of scope.
+
+## Talk Track
+
+- "The permit is the bounded authority: wallet, tool, scope, budget, expiry,
+  nonce, and signature."
+- "The MCP invocation is not just authenticated. It is checked against the
+  permit before the tool is allowed to run."
+- "A successful governed invoke charges the wallet once, emits a signed receipt,
+  and ties that receipt back to the ledger entry and audit event."
+- "Replaying the same request returns the same receipt instead of charging
+  again."
+- "Trying a different tool with the same permit is denied, which is the core
+  governance behavior partners need to see."
 
 ## Proof Artifacts
 
 - Permit JSON with Ed25519 signature.
 - Receipt JSON with Ed25519 signature.
+- Public signing-key metadata, with no private key material.
 - Ledger entry ID referenced by the receipt.
 - Audit event ID referenced by the receipt.
+- Permit and receipt inspection responses filtered to the agent wallet.
 - Audit-chain verification response.
+- Replay response with the same receipt ID and no duplicate debit.
+- Out-of-scope denial response such as `permit_tool_not_allowed`.
+
+## Keep The Claim Narrow
+
+Say: "This proves a governed MCP trust-plane path for scoped, metered,
+replay-safe tool calls."
+
+Do not say: "This is production-grade agent banking," "full autonomous economic
+actor infrastructure," or "complete cross-framework governance."

--- a/DESIGN_PARTNER_GUIDE.md
+++ b/DESIGN_PARTNER_GUIDE.md
@@ -1,22 +1,55 @@
 # Design Partner Guide
 
+Use this guide to qualify design partners for the concrete trust-plane proof:
+scoped signed permit, governed MCP invoke, wallet charge, signed receipt,
+ledger entry, audit chain, replay safety, and out-of-scope denial.
+
 ## Best-Fit Partner
 
-An AI platform team with internal agents that call MCP-style tools and need
-budget controls, replay-safe retries, auditability, and proof of authorization.
+An AI platform, infrastructure, or security engineering team that already has
+internal agents calling MCP-style tools and needs a practical control point for:
+
+- Tool-level authorization.
+- Wallet or budget-backed metering.
+- Replay-safe retries.
+- Post-hoc receipt verification.
+- Audit evidence for who authorized what, what ran, and what it cost.
+
+This is best for teams that can bring one real internal tool call to the demo.
+It is not yet a fit for teams seeking production settlement, a full IAM
+replacement, or universal governance across every agent framework.
 
 ## Demo Path
 
-1. Create sponsor wallet.
-2. Create agent wallet.
-3. Issue DB-backed API key for the agent wallet.
-4. Issue a signed permit for one MCP tool.
-5. Invoke the tool with `permit_id` and `idempotency_key`.
-6. Show the ledger debit.
+Run the focused one-command proof first:
+
+```bash
+make demo-trust-plane
+```
+
+Then walk the partner through the live flow:
+
+1. Create a sponsor wallet.
+2. Create an agent wallet.
+3. Issue a DB-backed API key for the agent wallet.
+4. Issue a signed permit for one MCP tool with wallet binding, allowed tool,
+   `billing:charge`, budget, expiry, nonce, and idempotency.
+5. Invoke the tool through governed MCP with `permit_id` and
+   `idempotency_key`.
+6. Show the wallet charge in the ledger.
 7. Verify the signed receipt.
 8. Verify the wallet audit chain.
-9. Replay the same request and show no second debit.
-10. Attempt an out-of-scope tool and show denial.
+9. Replay the same request and show the same receipt ID with no second debit.
+10. Attempt a different tool under the same permit and show out-of-scope
+    denial.
+
+## What To Listen For
+
+- "Can this sit in front of one of our internal MCP tools?"
+- "Can we tune permit scopes, budgets, and expiry per agent or workflow?"
+- "Can our operators verify receipts without trusting application logs?"
+- "Can retries be safe when an agent or orchestrator repeats a request?"
+- "Can denial evidence be audited, not just returned to the caller?"
 
 ## Success Criteria
 
@@ -26,6 +59,22 @@ budget controls, replay-safe retries, auditability, and proof of authorization.
 - The partner can verify a receipt after the fact.
 - The partner can audit who authorized the action, what tool ran, and what it
   cost.
+- The partner can see an out-of-scope request denied with an explicit reason.
+
+## Positioning Language
+
+Use:
+
+- "Governed MCP trust plane for scoped, metered tool calls."
+- "Signed proof of authorization and execution for a single tool boundary."
+- "Replay-safe billing and audit artifacts for partner evaluation."
+
+Avoid:
+
+- "Production-ready agent payments."
+- "Autonomous economic actor infrastructure."
+- "Complete policy layer for all agent frameworks."
+- "Compliance-grade ledger or audit storage."
 
 ## Do Not Promise Yet
 
@@ -34,3 +83,4 @@ budget controls, replay-safe retries, auditability, and proof of authorization.
 - Full IAM replacement.
 - Production sandbox isolation.
 - Cross-protocol governance for every agent framework.
+- Key-management hardening beyond the current trust-plane proof.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: demo-trust-plane demo-trust-plane-check trust-release-gate
+
+demo-trust-plane:
+	uv run python scripts/demo_trust_plane.py
+
+demo-trust-plane-check:
+	uv run python scripts/demo_trust_plane.py --assert
+
+trust-release-gate:
+	scripts/trust_release_gate.sh

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ The governed MCP invocation path can now validate a signed permit, enforce idemp
 
 Everything else in this repository exists to strengthen that loop or prove it in realistic agent workflows.
 
+### Trust Plane Demo
+
+Run the concrete local proof:
+
+```bash
+make demo-trust-plane
+```
+
+This creates a sponsor wallet, provisions an agent wallet and API key, issues a
+signed permit for one MCP tool, invokes that tool through governed MCP, charges
+the wallet once, returns a signed receipt, verifies the audit chain, proves
+idempotent replay, and denies an out-of-scope tool with a denial receipt. The
+sample proof artifact is in
+[`docs/demo-trust-plane-output.md`](docs/demo-trust-plane-output.md).
+
 **Agent-first:** Autonomous clients are the primary audience. Machine-readable discovery and API contracts matter more than narrative docs. Human hosting concerns are in [Operators (deployment only)](#operators-deployment-only) below.
 
 ### Primary interface (autonomous clients)

--- a/WEDGE.md
+++ b/WEDGE.md
@@ -1,36 +1,55 @@
-# Wedge: MCP Governance Proxy
+# Wedge: MCP Trust Plane
 
 Agent Middleware API should not initially sell itself as a full platform for
 autonomous economic actors. The credible wedge is narrower:
 
-> MCP governance and metering for agent tool calls.
+> A governed trust plane for scoped, metered MCP tool calls.
 
 The core job is to put one enforceable boundary between autonomous agents and
 tools:
 
 ```text
-discover -> authenticate -> authorize -> invoke -> meter -> receipt -> audit -> govern
+scoped signed permit -> governed MCP invoke -> wallet charge -> signed receipt
+-> ledger -> audit chain -> replay no double charge -> out-of-scope denial
 ```
 
 ## Core User
 
 Platform engineering or AI infrastructure teams that already run internal
-agents against MCP-style tools.
+agents against MCP-style tools and need a control point before those tools are
+invoked.
 
 ## First Paid Use Case
 
 Govern and meter internal agent tool calls with wallet budgets, scoped permits,
 idempotent retries, signed receipts, and auditable denial.
 
+The first design-partner motion should be one real internal tool behind the
+proxy, not a broad migration of every agent workflow.
+
 ## What Is Core
 
 - Wallet-scoped API keys.
 - MCP discovery and invocation.
-- Signed permits for tool scope, wallet binding, budget, expiry, and nonce.
+- Signed permits for tool scope, wallet binding, key binding, budget, expiry,
+  and nonce.
 - Idempotency keys for permit issuance and governed invokes.
 - Ledger-backed wallet charging.
 - Signed receipts for governed tool attempts.
 - Tamper-evident wallet audit chains.
+- Explicit denial reasons for out-of-scope or invalid governed attempts.
+
+## What The Current Proof Shows
+
+- A permit can bind one agent wallet to one allowed MCP tool and budget.
+- A governed MCP invoke can validate that permit before the tool call proceeds.
+- A successful governed invoke can charge the wallet and write a ledger entry.
+- The response can include a signed receipt linked to permit, ledger, and audit
+  identifiers.
+- The audit chain can be verified after the fact.
+- Replaying the same governed invoke can return the same receipt without a
+  duplicate debit.
+- A request outside the permit scope can be denied with a concrete reason.
 
 ## What Is Proof Surface
 
@@ -39,3 +58,11 @@ IoT bridges, red-team services, RTaaS, telemetry auto-PR, and sandbox demos are
 proof surfaces. They may exercise the control plane, but they do not define the
 product until they consume the same permit, receipt, idempotency, and audit
 primitives.
+
+## What Not To Claim Yet
+
+- Production-ready payments or settlement.
+- Compliance-grade ledger storage.
+- Full autonomous economic actor infrastructure.
+- Universal policy enforcement across every agent framework.
+- A replacement for enterprise IAM, secrets management, or sandbox isolation.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -49,9 +49,10 @@ class Settings(BaseSettings):
     VALID_API_KEYS: str = ""
 
     # --- Trust Plane ---
-    # When enabled, governed MCP invokes require signed permits and
-    # idempotency. Legacy wallet-only MCP remains available for local/demo
-    # compatibility while TRUST_MODE_ENABLED is false.
+    # Strict trust mode requires both TRUST_MODE_ENABLED=true and
+    # ALLOW_LEGACY_UNPERMITTED_MCP=false. This lets local demos keep
+    # wallet-only MCP compatibility while production-like environments
+    # fail closed via app.core.trust_mode guardrails.
     TRUST_MODE_ENABLED: bool = False
     ALLOW_LEGACY_UNPERMITTED_MCP: bool = True
     TRUST_SIGNING_KEY_ID: str = "local-dev-ed25519"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     # --- Application ---
     APP_NAME: str = "Agent-Native Middleware API"
     APP_VERSION: str = "1.2.0"
+    ENVIRONMENT: str = "local"
     DEBUG: bool = False
 
     # --- Server ---

--- a/app/core/trust_mode.py
+++ b/app/core/trust_mode.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.core.config import Settings
+
+
+PRODUCTION_LIKE_ENVIRONMENTS = frozenset(
+    {
+        "prod",
+        "production",
+        "staging",
+        "stage",
+        "preprod",
+        "pre-production",
+        "preview",
+    }
+)
+
+LOCAL_COMPATIBLE_ENVIRONMENTS = frozenset(
+    {
+        "",
+        "ci",
+        "dev",
+        "development",
+        "local",
+        "localhost",
+        "test",
+        "testing",
+    }
+)
+
+
+class TrustModeGuardrailError(RuntimeError):
+    """Raised when trust mode is unsafe for a production-like deployment."""
+
+
+def normalize_environment(environment: str | None) -> str:
+    return (environment or "").strip().lower().replace("_", "-")
+
+
+def is_production_like_environment(environment: str | None) -> bool:
+    normalized = normalize_environment(environment)
+    if normalized in LOCAL_COMPATIBLE_ENVIRONMENTS:
+        return False
+    return (
+        normalized in PRODUCTION_LIKE_ENVIRONMENTS
+        or normalized.startswith(("prod-", "production-", "staging-", "stage-"))
+        or bool(normalized)
+    )
+
+
+def validate_trust_mode_config(
+    *,
+    environment: str | None,
+    trust_mode_enabled: bool,
+    signing_private_key_b64: str | None,
+    allow_legacy_unpermitted_mcp: bool,
+) -> None:
+    if not trust_mode_enabled or not is_production_like_environment(environment):
+        return
+
+    violations: list[str] = []
+    if not (signing_private_key_b64 or "").strip():
+        violations.append(
+            "TRUST_SIGNING_PRIVATE_KEY_B64 is required when "
+            "TRUST_MODE_ENABLED=true in production-like environments"
+        )
+    if allow_legacy_unpermitted_mcp:
+        violations.append(
+            "ALLOW_LEGACY_UNPERMITTED_MCP must be false when "
+            "TRUST_MODE_ENABLED=true in production-like environments"
+        )
+
+    if violations:
+        raise TrustModeGuardrailError("; ".join(violations))
+
+
+def validate_trust_mode_guardrails(settings: Settings) -> None:
+    validate_trust_mode_config(
+        environment=settings.ENVIRONMENT,
+        trust_mode_enabled=settings.TRUST_MODE_ENABLED,
+        signing_private_key_b64=settings.TRUST_SIGNING_PRIVATE_KEY_B64,
+        allow_legacy_unpermitted_mcp=settings.ALLOW_LEGACY_UNPERMITTED_MCP,
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from .core.config import get_settings
 from .core.durable_state import close_durable_state, get_durable_state
 from .core.health import gather_dependency_report
 from .core.rate_limiter import RateLimitMiddleware
+from .core.trust_mode import validate_trust_mode_guardrails
 from .db.database import init_db, close_db
 from .services.mcp_phase9_tools import (
     ensure_phase9_registered,
@@ -59,6 +60,7 @@ from .routers import (
     mcp,
     kyc,
     api_keys,
+    keys,
     awi,
     awi_enhanced,
     discover,
@@ -100,6 +102,8 @@ except ImportError:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    validate_trust_mode_guardrails(settings)
+
     cleanup_task: asyncio.Task | None = None
     startup_time = time.monotonic()
 
@@ -293,6 +297,7 @@ CORE_TRUST_ROUTERS = (
     mcp,
     kyc,
     api_keys,
+    keys,
     discover,
     planner,
     well_known,
@@ -358,6 +363,7 @@ async def root():
                 "receipts",
                 "mcp",
                 "api_keys",
+                "signing_keys",
                 "kyc",
                 "discover",
                 "planner",

--- a/app/routers/keys.py
+++ b/app/routers/keys.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.core.auth import AuthContext, get_auth_context
+from app.schemas.trust import SigningKeyResponse
+from app.services.signing_keys import get_signing_key_service
+
+router = APIRouter(prefix="/v1/signing-keys", tags=["Trust Signing Keys"])
+
+
+def _key_response(key) -> SigningKeyResponse:
+    return SigningKeyResponse(
+        key_id=key.key_id,
+        alg=key.alg,
+        public_key_b64=key.public_key_b64,
+        status=key.status,
+        created_at=key.created_at,
+        activated_at=key.activated_at,
+        retired_at=key.retired_at,
+    )
+
+
+@router.get("/active", response_model=SigningKeyResponse)
+async def get_active_signing_key(
+    auth: AuthContext = Depends(get_auth_context),
+) -> SigningKeyResponse:
+    """Return public metadata for the active trust-plane signing key."""
+
+    key = await get_signing_key_service().get_active_key()
+    return _key_response(key)
+
+
+@router.get("/{key_id}", response_model=SigningKeyResponse)
+async def get_signing_key(
+    key_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> SigningKeyResponse:
+    """Return public metadata for an active or retired signing key."""
+
+    key = await get_signing_key_service().get_public_key(key_id)
+    if not key:
+        raise HTTPException(status_code=404, detail="signing_key_not_found")
+    return _key_response(key)

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -71,6 +71,14 @@ class ToolExecutionError(RuntimeError):
     """Raised after a dispatched tool fails and compensation is complete."""
 
 
+class ToolPermissionDenied(PermissionError):
+    """Permission denial that may carry a signed receipt for governed calls."""
+
+    def __init__(self, reason: str, receipt: dict[str, Any] | None = None) -> None:
+        super().__init__(reason)
+        self.receipt = receipt
+
+
 class McpContext(BaseModel):
     """MCP execution context passed in tool calls."""
 
@@ -177,6 +185,20 @@ async def handle_messages(
                     "result": result,
                 }
             )
+        except ToolPermissionDenied as e:
+            error_payload: dict[str, Any] = {
+                "code": -32003,
+                "message": str(e),
+            }
+            if e.receipt:
+                error_payload["data"] = {"receipt": e.receipt}
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": error_payload,
+                }
+            )
         except PermissionError as e:
             return JSONResponse(
                 {
@@ -281,30 +303,6 @@ async def _execute_registered_tool(
     governed_call = bool(permit_id) or (
         settings.TRUST_MODE_ENABLED and not settings.ALLOW_LEGACY_UNPERMITTED_MCP
     )
-    if governed_call and not permit_id:
-        raise PermissionError("permit_required")
-    if governed_call and not idempotency_key:
-        raise ValueError("idempotency_key_required")
-
-    idem = get_idempotency_service()
-    if governed_call:
-        try:
-            replay = await idem.begin(
-                wallet_id=wallet_id,
-                endpoint=endpoint,
-                idempotency_key=idempotency_key or "",
-                request_payload=request_payload
-                or {
-                    "tool_name": tool_name,
-                    "arguments": arguments,
-                    "wallet_id": wallet_id,
-                    "permit_id": permit_id,
-                },
-            )
-        except IdempotencyConflictError as exc:
-            raise ValueError(str(exc))
-        if replay and replay.response_json:
-            return replay.response_json
 
     decision = evaluate_tool_invocation(
         auth=auth,
@@ -323,6 +321,65 @@ async def _execute_registered_tool(
         )
         raise PermissionError(decision.reason)
 
+    if governed_call and not permit_id:
+        await _audit_mcp_invocation(
+            decision=decision,
+            endpoint=endpoint,
+            transport=transport,
+            ok=False,
+            error="permit_required",
+            extra_metadata={
+                "idempotency_key": idempotency_key,
+                "request_hash": sha256_hex(request_payload or arguments),
+            },
+        )
+        raise PermissionError("permit_required")
+    if governed_call and not idempotency_key:
+        await _audit_mcp_invocation(
+            decision=decision,
+            endpoint=endpoint,
+            transport=transport,
+            ok=False,
+            error="idempotency_key_required",
+            extra_metadata={
+                "permit_id": permit_id,
+                "request_hash": sha256_hex(request_payload or arguments),
+            },
+        )
+        raise ValueError("idempotency_key_required")
+
+    idem = get_idempotency_service()
+    if governed_call:
+        try:
+            replay = await idem.begin(
+                wallet_id=wallet_id,
+                endpoint=endpoint,
+                idempotency_key=idempotency_key or "",
+                request_payload=request_payload
+                or {
+                    "tool_name": tool_name,
+                    "arguments": arguments,
+                    "wallet_id": wallet_id,
+                    "permit_id": permit_id,
+                },
+            )
+        except IdempotencyConflictError as exc:
+            await _audit_mcp_invocation(
+                decision=decision,
+                endpoint=endpoint,
+                transport=transport,
+                ok=False,
+                error=str(exc),
+                extra_metadata={
+                    "permit_id": permit_id,
+                    "idempotency_key": idempotency_key,
+                    "request_hash": sha256_hex(request_payload or arguments),
+                },
+            )
+            raise ValueError(str(exc))
+        if replay and replay.response_json:
+            return replay.response_json
+
     permit_model = None
     if governed_call:
         permit_validation = await get_permit_service().validate_for_action(
@@ -334,7 +391,7 @@ async def _execute_registered_tool(
         )
         permit_model = permit_validation.permit
         if not permit_validation.allowed:
-            await _audit_mcp_invocation(
+            audit_event = await _audit_mcp_invocation(
                 decision=decision,
                 endpoint=endpoint,
                 transport=transport,
@@ -346,7 +403,39 @@ async def _execute_registered_tool(
                     "request_hash": sha256_hex(request_payload or arguments),
                 },
             )
-            raise PermissionError(permit_validation.reason or "permit_denied")
+            receipt_payload = None
+            if permit_model:
+                reason = permit_validation.reason or "permit_denied"
+                receipt = await get_receipt_service().create_receipt(
+                    permit_id=permit_model.permit_id,
+                    wallet_id=wallet_id,
+                    key_id=auth.key_id,
+                    tool=tool_name,
+                    request_payload=request_payload or arguments,
+                    response_payload={"error": reason},
+                    ledger_entry_id=None,
+                    credits_authorized=registered_cost,
+                    credits_charged=Decimal("0"),
+                    outcome="denied",
+                    audit_event_id=audit_event.event_id,
+                )
+                receipt_payload = _receipt_response_payload(receipt)
+                await idem.complete(
+                    wallet_id=wallet_id,
+                    endpoint=endpoint,
+                    idempotency_key=idempotency_key or "",
+                    response_reference=receipt.receipt_id,
+                    response_json={
+                        "content": [],
+                        "isError": True,
+                        "receipt": receipt_payload,
+                    },
+                    status_code=403,
+                )
+            raise ToolPermissionDenied(
+                permit_validation.reason or "permit_denied",
+                receipt=receipt_payload,
+            )
 
     simulation = False
     try:
@@ -394,7 +483,7 @@ async def _execute_registered_tool(
                 endpoint=endpoint,
                 idempotency_key=idempotency_key or "",
                 response_reference=receipt.receipt_id,
-                response_json={"content": [], "isError": True, "receipt": receipt.model_dump(mode="json")},
+                response_json={"content": [], "isError": True, "receipt": _receipt_response_payload(receipt)},
                 status_code=403,
             )
         raise PermissionError(policy.reason)
@@ -442,7 +531,7 @@ async def _execute_registered_tool(
                 endpoint=endpoint,
                 idempotency_key=idempotency_key or "",
                 response_reference=receipt.receipt_id,
-                response_json={"content": [], "isError": True, "receipt": receipt.model_dump(mode="json")},
+                response_json={"content": [], "isError": True, "receipt": _receipt_response_payload(receipt)},
                 status_code=402,
             )
         raise ValueError("insufficient_funds")
@@ -522,7 +611,7 @@ async def _execute_registered_tool(
                 endpoint=endpoint,
                 idempotency_key=idempotency_key or "",
                 response_reference=receipt.receipt_id,
-                response_json={"content": [], "isError": True, "receipt": receipt.model_dump(mode="json")},
+                response_json={"content": [], "isError": True, "receipt": _receipt_response_payload(receipt)},
                 status_code=500,
             )
         raise ToolExecutionError(str(exc)) from exc
@@ -550,7 +639,7 @@ async def _execute_registered_tool(
             outcome="success",
             audit_event_id=audit_event.event_id,
         )
-        response_payload["receipt"] = receipt.model_dump(mode="json")
+        response_payload["receipt"] = _receipt_response_payload(receipt)
         await idem.complete(
             wallet_id=wallet_id,
             endpoint=endpoint,
@@ -576,6 +665,14 @@ def _charge_units_for_registered_cost(
 ) -> Decimal:
     default_price = DEFAULT_PRICING[category][1]
     return registered_cost / default_price
+
+
+def _receipt_response_payload(receipt: Any) -> dict[str, Any]:
+    payload = receipt.model_dump(mode="json")
+    charged = payload.get("credits_charged")
+    if charged is not None and Decimal(str(charged)) == Decimal("0"):
+        payload["credits_charged"] = "0"
+    return payload
 
 
 def _value_error_jsonrpc_code(message: str) -> int:
@@ -708,6 +805,11 @@ async def invoke_tool(
             request_payload=request.model_dump(mode="json"),
         )
         return ToolCallResponse(**result)
+    except ToolPermissionDenied as exc:
+        detail: dict[str, Any] = {"error": str(exc)}
+        if exc.receipt:
+            detail["receipt"] = exc.receipt
+        raise HTTPException(status_code=403, detail=detail)
     except PermissionError as exc:
         raise HTTPException(status_code=403, detail=str(exc))
     except ValueError as exc:

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -682,6 +682,8 @@ def _value_error_jsonrpc_code(message: str) -> int:
         return -32001
     if message.startswith("Tool not executable"):
         return -32002
+    if message == "idempotency_key_required":
+        return -32003
     if message == "insufficient_funds":
         return -32004
     return -32603

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -15,6 +15,7 @@ This enables agents to:
 3. Receive results in real-time via SSE
 """
 
+import inspect
 import json
 import logging
 from decimal import Decimal
@@ -71,12 +72,35 @@ class ToolExecutionError(RuntimeError):
     """Raised after a dispatched tool fails and compensation is complete."""
 
 
+class GovernedToolError(RuntimeError):
+    """Terminal governed-call error that can carry a signed receipt."""
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        receipt: dict[str, Any] | None = None,
+        status_code: int = 500,
+        jsonrpc_code: int = -32603,
+    ) -> None:
+        super().__init__(reason)
+        self.receipt = receipt
+        self.status_code = status_code
+        self.jsonrpc_code = jsonrpc_code
+
+
 class ToolPermissionDenied(PermissionError):
     """Permission denial that may carry a signed receipt for governed calls."""
 
-    def __init__(self, reason: str, receipt: dict[str, Any] | None = None) -> None:
+    def __init__(
+        self,
+        reason: str,
+        receipt: dict[str, Any] | None = None,
+    ) -> None:
         super().__init__(reason)
         self.receipt = receipt
+        self.status_code = 403
+        self.jsonrpc_code = -32003
 
 
 class McpContext(BaseModel):
@@ -199,6 +223,20 @@ async def handle_messages(
                     "error": error_payload,
                 }
             )
+        except GovernedToolError as e:
+            error_payload = {
+                "code": e.jsonrpc_code,
+                "message": str(e),
+            }
+            if e.receipt:
+                error_payload["data"] = {"receipt": e.receipt}
+            return JSONResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": error_payload,
+                }
+            )
         except PermissionError as e:
             return JSONResponse(
                 {
@@ -282,6 +320,33 @@ async def _execute_registered_tool(
     if not wallet_id:
         raise ValueError("Missing wallet_id in mcpContext")
 
+    governed_call = bool(permit_id) or (
+        settings.TRUST_MODE_ENABLED and not settings.ALLOW_LEGACY_UNPERMITTED_MCP
+    )
+    idem = get_idempotency_service()
+    replay = None
+    idem_started = False
+    if governed_call and idempotency_key:
+        try:
+            replay = await idem.begin(
+                wallet_id=wallet_id,
+                endpoint=endpoint,
+                idempotency_key=idempotency_key,
+                request_payload=request_payload
+                or {
+                    "tool_name": tool_name,
+                    "arguments": arguments,
+                    "wallet_id": wallet_id,
+                    "permit_id": permit_id,
+                },
+            )
+            idem_started = True
+        except IdempotencyConflictError as exc:
+            raise ValueError(str(exc)) from exc
+        if replay and replay.response_json:
+            _raise_replayed_error(replay)
+            return replay.response_json
+
     _ensure_local_mcp_tools_registered()
     registry = get_service_registry()
     service = registry.get_local(tool_name)
@@ -300,9 +365,6 @@ async def _execute_registered_tool(
     registered_cost = _registered_tool_cost(service, category)
     charge_units = _charge_units_for_registered_cost(registered_cost, category)
     estimated_cost = float(registered_cost)
-    governed_call = bool(permit_id) or (
-        settings.TRUST_MODE_ENABLED and not settings.ALLOW_LEGACY_UNPERMITTED_MCP
-    )
 
     decision = evaluate_tool_invocation(
         auth=auth,
@@ -348,13 +410,12 @@ async def _execute_registered_tool(
         )
         raise ValueError("idempotency_key_required")
 
-    idem = get_idempotency_service()
-    if governed_call:
+    if governed_call and idempotency_key and not idem_started:
         try:
             replay = await idem.begin(
                 wallet_id=wallet_id,
                 endpoint=endpoint,
-                idempotency_key=idempotency_key or "",
+                idempotency_key=idempotency_key,
                 request_payload=request_payload
                 or {
                     "tool_name": tool_name,
@@ -378,6 +439,7 @@ async def _execute_registered_tool(
             )
             raise ValueError(str(exc))
         if replay and replay.response_json:
+            _raise_replayed_error(replay)
             return replay.response_json
 
     permit_model = None
@@ -425,11 +487,7 @@ async def _execute_registered_tool(
                     endpoint=endpoint,
                     idempotency_key=idempotency_key or "",
                     response_reference=receipt.receipt_id,
-                    response_json={
-                        "content": [],
-                        "isError": True,
-                        "receipt": receipt_payload,
-                    },
+                    response_json=_governed_error_payload(reason, receipt_payload),
                     status_code=403,
                 )
             raise ToolPermissionDenied(
@@ -456,36 +514,47 @@ async def _execute_registered_tool(
         "evaluated_constraints": policy.evaluated_constraints,
     }
     if not policy.allowed:
+        trust_metadata = _trust_metadata(
+            permit_id=permit_id,
+            idempotency_key=idempotency_key,
+            request_payload=request_payload,
+            arguments=arguments,
+        )
         audit_event = await _audit_mcp_invocation(
             decision=decision,
             endpoint=endpoint,
             transport=transport,
             ok=False,
             error=policy.reason,
-            extra_metadata=policy_metadata,
+            extra_metadata={**policy_metadata, **trust_metadata},
         )
+        receipt_payload = None
         if governed_call and permit_model:
+            reason = policy.reason or "policy_denied"
             receipt = await get_receipt_service().create_receipt(
                 permit_id=permit_model.permit_id,
                 wallet_id=wallet_id,
                 key_id=auth.key_id,
                 tool=tool_name,
                 request_payload=request_payload or arguments,
-                response_payload={"error": policy.reason},
+                response_payload={"error": reason},
                 ledger_entry_id=None,
                 credits_authorized=registered_cost,
                 credits_charged=Decimal("0"),
                 outcome="denied",
                 audit_event_id=audit_event.event_id,
             )
+            receipt_payload = _receipt_response_payload(receipt)
             await idem.complete(
                 wallet_id=wallet_id,
                 endpoint=endpoint,
                 idempotency_key=idempotency_key or "",
                 response_reference=receipt.receipt_id,
-                response_json={"content": [], "isError": True, "receipt": _receipt_response_payload(receipt)},
+                response_json=_governed_error_payload(reason, receipt_payload),
                 status_code=403,
             )
+        if governed_call and permit_model:
+            raise ToolPermissionDenied(reason, receipt=receipt_payload)
         raise PermissionError(policy.reason)
 
     description = f"MCP {transport} invoke {tool_name}"
@@ -510,8 +579,17 @@ async def _execute_registered_tool(
             transport=transport,
             ok=False,
             error="insufficient_funds",
-            extra_metadata=policy_metadata,
+            extra_metadata={
+                **policy_metadata,
+                **_trust_metadata(
+                    permit_id=permit_id,
+                    idempotency_key=idempotency_key,
+                    request_payload=request_payload,
+                    arguments=arguments,
+                ),
+            },
         )
+        receipt_payload = None
         if governed_call and permit_model:
             receipt = await get_receipt_service().create_receipt(
                 permit_id=permit_model.permit_id,
@@ -526,20 +604,28 @@ async def _execute_registered_tool(
                 outcome="insufficient_funds",
                 audit_event_id=audit_event.event_id,
             )
+            receipt_payload = _receipt_response_payload(receipt)
             await idem.complete(
                 wallet_id=wallet_id,
                 endpoint=endpoint,
                 idempotency_key=idempotency_key or "",
                 response_reference=receipt.receipt_id,
-                response_json={"content": [], "isError": True, "receipt": _receipt_response_payload(receipt)},
+                response_json=_governed_error_payload(
+                    "insufficient_funds",
+                    receipt_payload,
+                ),
                 status_code=402,
+            )
+            raise GovernedToolError(
+                "insufficient_funds",
+                receipt=receipt_payload,
+                status_code=402,
+                jsonrpc_code=-32004,
             )
         raise ValueError("insufficient_funds")
 
-    import asyncio
-
     try:
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             result = await func(**arguments)
         else:
             result = func(**arguments)
@@ -590,8 +676,18 @@ async def _execute_registered_tool(
             transport=transport,
             ok=False,
             error=str(exc),
-            extra_metadata=policy_metadata,
+            extra_metadata={
+                **policy_metadata,
+                **_trust_metadata(
+                    permit_id=permit_id,
+                    idempotency_key=idempotency_key,
+                    request_payload=request_payload,
+                    arguments=arguments,
+                    ledger_entry_id=charge_result.entry_id,
+                ),
+            },
         )
+        receipt_payload = None
         if governed_call and permit_model:
             receipt = await get_receipt_service().create_receipt(
                 permit_id=permit_model.permit_id,
@@ -606,24 +702,43 @@ async def _execute_registered_tool(
                 outcome="failed_refunded",
                 audit_event_id=audit_event.event_id,
             )
+            receipt_payload = _receipt_response_payload(receipt)
             await idem.complete(
                 wallet_id=wallet_id,
                 endpoint=endpoint,
                 idempotency_key=idempotency_key or "",
                 response_reference=receipt.receipt_id,
-                response_json={"content": [], "isError": True, "receipt": _receipt_response_payload(receipt)},
+                response_json=_governed_error_payload(str(exc), receipt_payload),
                 status_code=500,
             )
+            raise GovernedToolError(
+                str(exc),
+                receipt=receipt_payload,
+                status_code=500,
+                jsonrpc_code=-32603,
+            ) from exc
         raise ToolExecutionError(str(exc)) from exc
 
-    response_payload = {"content": [{"type": "text", "text": json.dumps(result, default=str)}], "isError": False}
+    response_payload = {
+        "content": [{"type": "text", "text": json.dumps(result, default=str)}],
+        "isError": False,
+    }
     audit_event = await _audit_mcp_invocation(
         decision=decision,
         endpoint=endpoint,
         transport=transport,
         ok=True,
         error=None,
-        extra_metadata=policy_metadata,
+        extra_metadata={
+            **policy_metadata,
+            **_trust_metadata(
+                permit_id=permit_id,
+                idempotency_key=idempotency_key,
+                request_payload=request_payload,
+                arguments=arguments,
+                ledger_entry_id=charge_result.entry_id,
+            ),
+        },
     )
     if governed_call and permit_model:
         receipt = await get_receipt_service().create_receipt(
@@ -673,6 +788,61 @@ def _receipt_response_payload(receipt: Any) -> dict[str, Any]:
     if charged is not None and Decimal(str(charged)) == Decimal("0"):
         payload["credits_charged"] = "0"
     return payload
+
+
+def _governed_error_payload(
+    reason: str,
+    receipt: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "content": [],
+        "isError": True,
+        "error": reason,
+        "receipt": receipt,
+    }
+
+
+def _raise_replayed_error(replay: Any) -> None:
+    if replay.status_code < 400 or not replay.response_json:
+        return
+    reason = str(replay.response_json.get("error") or "governed_call_failed")
+    receipt = replay.response_json.get("receipt")
+    if replay.status_code == 403:
+        raise ToolPermissionDenied(reason, receipt=receipt)
+    raise GovernedToolError(
+        reason,
+        receipt=receipt,
+        status_code=replay.status_code,
+        jsonrpc_code=_status_to_jsonrpc_code(replay.status_code, reason),
+    )
+
+
+def _status_to_jsonrpc_code(status_code: int, reason: str) -> int:
+    if status_code == 402 or reason == "insufficient_funds":
+        return -32004
+    if status_code == 403:
+        return -32003
+    return -32603
+
+
+def _trust_metadata(
+    *,
+    permit_id: str | None,
+    idempotency_key: str | None,
+    request_payload: dict[str, Any] | None,
+    arguments: dict[str, Any],
+    ledger_entry_id: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "request_hash": sha256_hex(request_payload or arguments),
+    }
+    if permit_id:
+        metadata["permit_id"] = permit_id
+    if idempotency_key:
+        metadata["idempotency_key"] = idempotency_key
+    if ledger_entry_id:
+        metadata["ledger_entry_id"] = ledger_entry_id
+    return metadata
 
 
 def _value_error_jsonrpc_code(message: str) -> int:
@@ -812,6 +982,11 @@ async def invoke_tool(
         if exc.receipt:
             detail["receipt"] = exc.receipt
         raise HTTPException(status_code=403, detail=detail)
+    except GovernedToolError as exc:
+        detail = {"error": str(exc)}
+        if exc.receipt:
+            detail["receipt"] = exc.receipt
+        raise HTTPException(status_code=exc.status_code, detail=detail)
     except PermissionError as exc:
         raise HTTPException(status_code=403, detail=str(exc))
     except ValueError as exc:

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -33,6 +33,7 @@ from ..services.agent_money import DEFAULT_PRICING, AgentMoney, get_agent_money
 from ..services.audit_log import record_audit_event
 from ..services.idempotency import (
     IdempotencyConflictError,
+    IdempotencyInProgressError,
     get_idempotency_service,
 )
 from ..services.permits import get_permit_service
@@ -341,7 +342,7 @@ async def _execute_registered_tool(
                 },
             )
             idem_started = True
-        except IdempotencyConflictError as exc:
+        except (IdempotencyConflictError, IdempotencyInProgressError) as exc:
             raise ValueError(str(exc)) from exc
         if replay and replay.response_json:
             _raise_replayed_error(replay)
@@ -424,7 +425,7 @@ async def _execute_registered_tool(
                     "permit_id": permit_id,
                 },
             )
-        except IdempotencyConflictError as exc:
+        except (IdempotencyConflictError, IdempotencyInProgressError) as exc:
             await _audit_mcp_invocation(
                 decision=decision,
                 endpoint=endpoint,
@@ -853,6 +854,8 @@ def _value_error_jsonrpc_code(message: str) -> int:
     if message.startswith("Tool not executable"):
         return -32002
     if message == "idempotency_key_required":
+        return -32003
+    if message == "idempotency_in_progress":
         return -32003
     if message == "insufficient_funds":
         return -32004

--- a/app/routers/permits.py
+++ b/app/routers/permits.py
@@ -16,6 +16,7 @@ from app.schemas.trust import (
 )
 from app.services.idempotency import (
     IdempotencyConflictError,
+    IdempotencyInProgressError,
     get_idempotency_service,
 )
 from app.services.permits import (
@@ -96,7 +97,7 @@ async def create_permit(
             idempotency_key=idempotency_key,
             request_payload=request.model_dump(mode="json"),
         )
-    except IdempotencyConflictError as exc:
+    except (IdempotencyConflictError, IdempotencyInProgressError) as exc:
         raise HTTPException(status_code=409, detail=exc.args[0])
     if replay and replay.response_json:
         return PermitResponse(**replay.response_json)

--- a/app/routers/permits.py
+++ b/app/routers/permits.py
@@ -1,23 +1,84 @@
 from __future__ import annotations
 
+from datetime import datetime
 from decimal import Decimal
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 
 from app.core.auth import AuthContext, get_auth_context
 from app.schemas.trust import (
     PermitCreateRequest,
+    PermitListResponse,
     PermitResponse,
     PermitVerifyRequest,
     PermitVerifyResponse,
+    ReceiptListResponse,
 )
 from app.services.idempotency import (
     IdempotencyConflictError,
     get_idempotency_service,
 )
-from app.services.permits import PermitError, get_permit_service, permit_model_to_response
+from app.services.permits import (
+    PermitError,
+    get_permit_service,
+    permit_model_to_response,
+)
+from app.services.receipts import get_receipt_service
 
 router = APIRouter(prefix="/v1/permits", tags=["Trust Permits"])
+
+
+def _authorize_permit_inspection(
+    *,
+    auth: AuthContext,
+    issuer_wallet_id: str,
+    subject_wallet_id: str,
+) -> None:
+    if auth.is_bootstrap_admin:
+        return
+    if auth.wallet_id in {issuer_wallet_id, subject_wallet_id}:
+        return
+    auth.require_bootstrap_admin()
+
+
+@router.get("", response_model=PermitListResponse)
+async def list_permits(
+    wallet_id: str | None = Query(None),
+    status: str | None = Query(None),
+    subject_key_id: str | None = Query(None),
+    created_after: datetime | None = Query(None),
+    created_before: datetime | None = Query(None),
+    expires_after: datetime | None = Query(None),
+    expires_before: datetime | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    auth: AuthContext = Depends(get_auth_context),
+) -> PermitListResponse:
+    if wallet_id:
+        auth.require_wallet_access(wallet_id)
+    else:
+        auth.require_bootstrap_admin()
+
+    permits, total = await get_permit_service().list_permits(
+        wallet_id=wallet_id,
+        status=status,
+        subject_key_id=subject_key_id,
+        created_after=created_after,
+        created_before=created_before,
+        expires_after=expires_after,
+        expires_before=expires_before,
+        limit=limit,
+        offset=offset,
+    )
+    next_offset = offset + len(permits) if offset + len(permits) < total else None
+    return PermitListResponse(
+        permits=permits,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=next_offset is not None,
+        next_offset=next_offset,
+    )
 
 
 @router.post("", response_model=PermitResponse, status_code=status.HTTP_201_CREATED)
@@ -53,6 +114,57 @@ async def create_permit(
         status_code=201,
     )
     return permit
+
+
+@router.get("/{permit_id}", response_model=PermitResponse)
+async def get_permit(
+    permit_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> PermitResponse:
+    permit = await get_permit_service().get_permit(permit_id)
+    if not permit:
+        raise HTTPException(status_code=404, detail="permit_not_found")
+    _authorize_permit_inspection(
+        auth=auth,
+        issuer_wallet_id=permit.issuer_wallet_id,
+        subject_wallet_id=permit.subject_wallet_id,
+    )
+    return permit
+
+
+@router.get("/{permit_id}/receipts", response_model=ReceiptListResponse)
+async def list_permit_receipts(
+    permit_id: str,
+    tool: str | None = Query(None),
+    outcome: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    auth: AuthContext = Depends(get_auth_context),
+) -> ReceiptListResponse:
+    permit = await get_permit_service().get_permit(permit_id)
+    if not permit:
+        raise HTTPException(status_code=404, detail="permit_not_found")
+    _authorize_permit_inspection(
+        auth=auth,
+        issuer_wallet_id=permit.issuer_wallet_id,
+        subject_wallet_id=permit.subject_wallet_id,
+    )
+    receipts, total = await get_receipt_service().list_receipts(
+        permit_id=permit_id,
+        tool=tool,
+        outcome=outcome,
+        limit=limit,
+        offset=offset,
+    )
+    next_offset = offset + len(receipts) if offset + len(receipts) < total else None
+    return ReceiptListResponse(
+        receipts=receipts,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=next_offset is not None,
+        next_offset=next_offset,
+    )
 
 
 @router.post("/{permit_id}/revoke", response_model=PermitResponse)

--- a/app/routers/receipts.py
+++ b/app/routers/receipts.py
@@ -1,16 +1,119 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.core.auth import AuthContext, get_auth_context
 from app.schemas.trust import (
+    ReceiptListResponse,
     ReceiptResponse,
     ReceiptVerifyRequest,
     ReceiptVerifyResponse,
 )
+from app.services.permits import get_permit_service
 from app.services.receipts import get_receipt_service
 
 router = APIRouter(prefix="/v1/receipts", tags=["Trust Receipts"])
+
+
+async def _authorize_receipt_list(
+    *,
+    auth: AuthContext,
+    wallet_id: str | None,
+    permit_id: str | None,
+) -> None:
+    if permit_id:
+        permit = await get_permit_service().get_permit(permit_id)
+        if not permit:
+            raise HTTPException(status_code=404, detail="permit_not_found")
+        if wallet_id and wallet_id not in {
+            permit.issuer_wallet_id,
+            permit.subject_wallet_id,
+        }:
+            auth.require_bootstrap_admin()
+            return
+        if auth.is_bootstrap_admin:
+            return
+        if auth.wallet_id in {permit.issuer_wallet_id, permit.subject_wallet_id}:
+            return
+    if wallet_id:
+        auth.require_wallet_access(wallet_id)
+        return
+    auth.require_bootstrap_admin()
+
+
+async def _authorize_receipt_access(
+    *,
+    auth: AuthContext,
+    receipt: ReceiptResponse,
+) -> None:
+    if auth.is_bootstrap_admin:
+        return
+    if auth.wallet_id == receipt.wallet_id:
+        return
+    permit = await get_permit_service().get_permit(receipt.permit_id)
+    if permit and auth.wallet_id in {permit.issuer_wallet_id, permit.subject_wallet_id}:
+        return
+    auth.require_wallet_access(receipt.wallet_id)
+
+
+@router.get("", response_model=ReceiptListResponse)
+async def list_receipts(
+    permit_id: str | None = Query(None),
+    wallet_id: str | None = Query(None),
+    tool: str | None = Query(None),
+    outcome: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    auth: AuthContext = Depends(get_auth_context),
+) -> ReceiptListResponse:
+    await _authorize_receipt_list(auth=auth, wallet_id=wallet_id, permit_id=permit_id)
+    receipts, total = await get_receipt_service().list_receipts(
+        permit_id=permit_id,
+        wallet_id=wallet_id,
+        tool=tool,
+        outcome=outcome,
+        limit=limit,
+        offset=offset,
+    )
+    next_offset = offset + len(receipts) if offset + len(receipts) < total else None
+    return ReceiptListResponse(
+        receipts=receipts,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=next_offset is not None,
+        next_offset=next_offset,
+    )
+
+
+@router.get("/permit/{permit_id}", response_model=ReceiptListResponse)
+async def list_receipts_for_permit(
+    permit_id: str,
+    wallet_id: str | None = Query(None),
+    tool: str | None = Query(None),
+    outcome: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+    auth: AuthContext = Depends(get_auth_context),
+) -> ReceiptListResponse:
+    await _authorize_receipt_list(auth=auth, wallet_id=wallet_id, permit_id=permit_id)
+    receipts, total = await get_receipt_service().list_receipts(
+        permit_id=permit_id,
+        wallet_id=wallet_id,
+        tool=tool,
+        outcome=outcome,
+        limit=limit,
+        offset=offset,
+    )
+    next_offset = offset + len(receipts) if offset + len(receipts) < total else None
+    return ReceiptListResponse(
+        receipts=receipts,
+        total=total,
+        limit=limit,
+        offset=offset,
+        has_more=next_offset is not None,
+        next_offset=next_offset,
+    )
 
 
 @router.get("/{receipt_id}", response_model=ReceiptResponse)
@@ -21,7 +124,7 @@ async def get_receipt(
     receipt = await get_receipt_service().get_receipt(receipt_id)
     if not receipt:
         raise HTTPException(status_code=404, detail="receipt_not_found")
-    auth.require_wallet_access(receipt.wallet_id)
+    await _authorize_receipt_access(auth=auth, receipt=receipt)
     return receipt
 
 
@@ -34,7 +137,7 @@ async def verify_receipt(
         request.receipt_id
     )
     if receipt:
-        auth.require_wallet_access(receipt.wallet_id)
+        await _authorize_receipt_access(auth=auth, receipt=receipt)
     else:
         auth.require_bootstrap_admin()
     return ReceiptVerifyResponse(valid=valid, reason=reason, receipt=receipt)

--- a/app/schemas/trust.py
+++ b/app/schemas/trust.py
@@ -33,6 +33,16 @@ class PermitResponse(BaseModel):
     signature: str
     key_id: str
     issued_at: datetime
+    revoked_at: datetime | None = None
+
+
+class PermitListResponse(BaseModel):
+    permits: list[PermitResponse]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+    next_offset: int | None = None
 
 
 class PermitVerifyRequest(BaseModel):
@@ -66,6 +76,15 @@ class ReceiptResponse(BaseModel):
     signature_key_id: str
 
 
+class ReceiptListResponse(BaseModel):
+    receipts: list[ReceiptResponse]
+    total: int
+    limit: int
+    offset: int
+    has_more: bool
+    next_offset: int | None = None
+
+
 class ReceiptVerifyRequest(BaseModel):
     receipt_id: str
 
@@ -97,3 +116,16 @@ class TrustMcpMetadata(BaseModel):
     idempotency_key: str | None = None
     request_hash: str | None = None
     receipt: dict[str, Any] | None = None
+
+
+class SigningKeyMetadataResponse(BaseModel):
+    key_id: str
+    alg: str
+    public_key_b64: str
+    status: str
+    created_at: datetime
+    activated_at: datetime | None = None
+    retired_at: datetime | None = None
+
+
+SigningKeyResponse = SigningKeyMetadataResponse

--- a/app/services/idempotency.py
+++ b/app/services/idempotency.py
@@ -16,6 +16,10 @@ class IdempotencyConflictError(RuntimeError):
     """Raised when an idempotency key is reused for a different request."""
 
 
+class IdempotencyInProgressError(RuntimeError):
+    """Raised when an idempotency key is already executing without a result."""
+
+
 @dataclass(frozen=True)
 class IdempotencyReplay:
     response_reference: str | None
@@ -46,19 +50,18 @@ class IdempotencyService:
             if existing:
                 if existing.request_hash != request_hash:
                     raise IdempotencyConflictError("idempotency_key_reused")
-                response_json = None
                 if existing.response_json:
                     try:
                         decoded = json.loads(existing.response_json)
                     except json.JSONDecodeError:
                         decoded = None
                     if isinstance(decoded, dict):
-                        response_json = decoded
-                return IdempotencyReplay(
-                    response_reference=existing.response_reference,
-                    response_json=response_json,
-                    status_code=existing.status_code,
-                )
+                        return IdempotencyReplay(
+                            response_reference=existing.response_reference,
+                            response_json=decoded,
+                            status_code=existing.status_code,
+                        )
+                raise IdempotencyInProgressError("idempotency_in_progress")
 
             session.add(
                 IdempotencyRecordModel(

--- a/app/services/permits.py
+++ b/app/services/permits.py
@@ -213,7 +213,7 @@ class PermitService:
                 return PermitValidation(False, "permit_expired", model)
             if model.subject_wallet_id != wallet_id:
                 return PermitValidation(False, "permit_wallet_mismatch", model)
-            if model.subject_key_id and key_id and model.subject_key_id != key_id:
+            if model.subject_key_id and model.subject_key_id != key_id:
                 return PermitValidation(False, "permit_key_mismatch", model)
             allowed_tools = _loads_list(model.allowed_tools_json)
             if allowed_tools and tool_name not in allowed_tools:

--- a/app/services/permits.py
+++ b/app/services/permits.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 
 from app.db.database import get_session_factory
 from app.db.models import PermitModel, WalletModel
@@ -52,6 +52,7 @@ def permit_model_to_response(model: PermitModel) -> PermitResponse:
         signature=model.signature,
         key_id=model.key_id,
         issued_at=model.issued_at,
+        revoked_at=model.revoked_at,
     )
 
 
@@ -61,6 +62,56 @@ class PermitService:
         async with factory() as session:
             model = await session.get(PermitModel, permit_id)
             return permit_model_to_response(model) if model else None
+
+    async def list_permits(
+        self,
+        *,
+        wallet_id: str | None = None,
+        status: str | None = None,
+        subject_key_id: str | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
+        expires_after: datetime | None = None,
+        expires_before: datetime | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[PermitResponse], int]:
+        stmt = select(PermitModel)
+        count_stmt = select(func.count()).select_from(PermitModel)
+
+        filters = []
+        if wallet_id:
+            filters.append(
+                or_(
+                    PermitModel.issuer_wallet_id == wallet_id,
+                    PermitModel.subject_wallet_id == wallet_id,
+                )
+            )
+        if status:
+            filters.append(PermitModel.status == status)
+        if subject_key_id:
+            filters.append(PermitModel.subject_key_id == subject_key_id)
+        if created_after:
+            filters.append(PermitModel.issued_at >= created_after)
+        if created_before:
+            filters.append(PermitModel.issued_at <= created_before)
+        if expires_after:
+            filters.append(PermitModel.expires_at >= expires_after)
+        if expires_before:
+            filters.append(PermitModel.expires_at <= expires_before)
+
+        if filters:
+            stmt = stmt.where(*filters)
+            count_stmt = count_stmt.where(*filters)
+
+        stmt = stmt.order_by(PermitModel.issued_at.desc()).limit(limit).offset(offset)
+
+        factory = get_session_factory()
+        async with factory() as session:
+            result = await session.execute(stmt)
+            total = await session.scalar(count_stmt)
+            permits = [permit_model_to_response(model) for model in result.scalars()]
+            return permits, int(total or 0)
 
     async def create_permit(self, request: PermitCreateRequest) -> PermitResponse:
         if request.max_credits <= Decimal("0"):

--- a/app/services/receipts.py
+++ b/app/services/receipts.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Any
 
+from sqlalchemy import func, select
+
 from app.db.database import get_session_factory
 from app.db.models import ReceiptModel
 from app.schemas.trust import ReceiptResponse
@@ -55,7 +57,9 @@ class ReceiptService:
     ) -> ReceiptResponse:
         created_at = datetime.now(timezone.utc)
         request_hash = sha256_hex(request_payload)
-        response_hash = sha256_hex(response_payload) if response_payload is not None else None
+        response_hash = (
+            sha256_hex(response_payload) if response_payload is not None else None
+        )
         receipt_id = f"rcpt-{uuid.uuid4().hex[:16]}"
         payload = {
             "receipt_id": receipt_id,
@@ -72,7 +76,9 @@ class ReceiptService:
             "audit_event_id": audit_event_id,
             "created_at": created_at,
         }
-        signature, signature_key_id, _ = await get_signing_key_service().sign_payload(payload)
+        signature, signature_key_id, _ = await get_signing_key_service().sign_payload(
+            payload
+        )
         model = ReceiptModel(
             receipt_id=receipt_id,
             permit_id=permit_id,
@@ -103,7 +109,48 @@ class ReceiptService:
             model = await session.get(ReceiptModel, receipt_id)
             return receipt_model_to_response(model) if model else None
 
-    async def verify_receipt(self, receipt_id: str) -> tuple[bool, str | None, ReceiptResponse | None]:
+    async def list_receipts(
+        self,
+        *,
+        permit_id: str | None = None,
+        wallet_id: str | None = None,
+        tool: str | None = None,
+        outcome: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[ReceiptResponse], int]:
+        stmt = select(ReceiptModel)
+        count_stmt = select(func.count()).select_from(ReceiptModel)
+
+        filters = []
+        if permit_id:
+            filters.append(ReceiptModel.permit_id == permit_id)
+        if wallet_id:
+            filters.append(ReceiptModel.wallet_id == wallet_id)
+        if tool:
+            filters.append(ReceiptModel.tool == tool)
+        if outcome:
+            filters.append(ReceiptModel.outcome == outcome)
+
+        if filters:
+            stmt = stmt.where(*filters)
+            count_stmt = count_stmt.where(*filters)
+
+        stmt = stmt.order_by(ReceiptModel.created_at.desc()).limit(limit).offset(offset)
+
+        factory = get_session_factory()
+        async with factory() as session:
+            result = await session.execute(stmt)
+            total = await session.scalar(count_stmt)
+            receipts = [
+                receipt_model_to_response(model) for model in result.scalars()
+            ]
+            return receipts, int(total or 0)
+
+    async def verify_receipt(
+        self,
+        receipt_id: str,
+    ) -> tuple[bool, str | None, ReceiptResponse | None]:
         factory = get_session_factory()
         async with factory() as session:
             model = await session.get(ReceiptModel, receipt_id)

--- a/app/services/signing_keys.py
+++ b/app/services/signing_keys.py
@@ -101,8 +101,9 @@ class SigningKeyService:
             if key:
                 if key.public_key_b64 != public_key_b64:
                     key.public_key_b64 = public_key_b64
-                    key.status = "active"
                     key.activated_at = datetime.now(timezone.utc)
+                key.status = "active"
+                key.retired_at = None
                 session.add(key)
             else:
                 key = SigningKeyModel(
@@ -115,6 +116,11 @@ class SigningKeyService:
             await session.commit()
             return key
 
+    async def get_active_key(self) -> SigningKeyModel:
+        """Return the current active public metadata, creating it if needed."""
+
+        return await self.ensure_active_key()
+
     async def get_public_key(self, key_id: str) -> SigningKeyModel | None:
         factory = get_session_factory()
         async with factory() as session:
@@ -122,6 +128,68 @@ class SigningKeyService:
                 select(SigningKeyModel).where(SigningKeyModel.key_id == key_id)
             )
             return result.scalar_one_or_none()
+
+    async def retire_key_metadata(self, key_id: str) -> SigningKeyModel:
+        """Retire public-key metadata without disabling historical verification."""
+
+        factory = get_session_factory()
+        async with factory() as session:
+            key = await session.get(SigningKeyModel, key_id)
+            if not key:
+                raise SigningKeyError("signing_key_not_found")
+            if key.status != "disabled":
+                key.status = "retired"
+                key.retired_at = datetime.now(timezone.utc)
+            session.add(key)
+            await session.commit()
+            await session.refresh(key)
+            return key
+
+    async def rotate_active_key_metadata(self, new_key_id: str) -> SigningKeyModel:
+        """
+        Move future signatures to a new key id while preserving old public metadata.
+
+        This intentionally rotates metadata only. Operators can still perform
+        private-key rotation via environment configuration; tests and local
+        control-plane flows can exercise key lifecycle without exposing private
+        key material or invalidating existing signatures.
+        """
+
+        if not new_key_id.strip():
+            raise SigningKeyError("signing_key_id_required")
+
+        old_key = await self.ensure_active_key()
+        new_key_id = new_key_id.strip()
+        now = datetime.now(timezone.utc)
+        public_key_b64 = self._public_key_b64()
+        factory = get_session_factory()
+        async with factory() as session:
+            if old_key.key_id != new_key_id:
+                old = await session.get(SigningKeyModel, old_key.key_id)
+                if old and old.status != "disabled":
+                    old.status = "retired"
+                    old.retired_at = now
+                    session.add(old)
+
+            key = await session.get(SigningKeyModel, new_key_id)
+            if key:
+                key.public_key_b64 = public_key_b64
+                key.status = "active"
+                key.activated_at = now
+                key.retired_at = None
+            else:
+                key = SigningKeyModel(
+                    key_id=new_key_id,
+                    public_key_b64=public_key_b64,
+                    status="active",
+                    activated_at=now,
+                )
+            session.add(key)
+            await session.commit()
+            await session.refresh(key)
+
+        self._key_id = new_key_id
+        return key
 
     async def sign_payload(self, payload: dict[str, Any]) -> tuple[str, str, str]:
         key = await self.ensure_active_key()

--- a/docs/demo-trust-plane-output.md
+++ b/docs/demo-trust-plane-output.md
@@ -1,0 +1,47 @@
+# Trust Plane Demo Output
+
+Generated with:
+
+```bash
+make demo-trust-plane-check
+```
+
+The exact IDs are intentionally different on every run because the demo uses a
+fresh throwaway SQLite database and signs new permits/receipts.
+
+Example proof artifact:
+
+```json
+{
+  "agent_key_id": "key_cd84a4595f5b",
+  "agent_wallet_id": "agt-4b8ae3c2cbe9",
+  "audit_chain_checked_events": 1,
+  "cross_wallet_status": 403,
+  "denial_reason": "permit_tool_not_allowed",
+  "denial_replay_receipt_id": "rcpt-5c957b40350e4b3a",
+  "denial_receipt_id": "rcpt-5c957b40350e4b3a",
+  "inspected_audit_events": 1,
+  "inspected_receipts": 1,
+  "ledger_entry_id": "543e21a1-5056-4df8-8773-fbf6ba9c720c",
+  "permit_id": "permit-0f62fdfee59640e4",
+  "replay_receipt_id": "rcpt-26e46941ba4a4bb6",
+  "signing_key_id": "demo-ed25519",
+  "sponsor_wallet_id": "spn-54322a836193",
+  "success_receipt_id": "rcpt-26e46941ba4a4bb6"
+}
+```
+
+What this proves:
+
+- The permit is scoped to one MCP tool.
+- The successful MCP invocation produces a signed receipt tied to a ledger entry.
+- Replaying the same idempotency key returns the same receipt and does not
+  create a second debit.
+- An out-of-scope MCP tool is denied and produces a denial receipt.
+- Replaying that denial returns the same denial receipt and response semantics.
+- The agent API key cannot read the sponsor wallet.
+- The wallet-scoped audit chain verifies after the governed action, and the
+  audit event links back to permit, idempotency key, request hash, and ledger
+  entry.
+- Public signing-key metadata can be inspected without exposing private key
+  material.

--- a/docs/golden-path.md
+++ b/docs/golden-path.md
@@ -188,30 +188,84 @@ curl "$API_URL/mcp/tools.json" \
   -H "X-API-Key: $AGENT_API_KEY"
 ```
 
-For a registered local or persistent MCP service, invoke with wallet context:
+For a registered local or persistent MCP service, invoke through JSON-RPC with
+wallet, permit, and replay context:
 
 ```bash
 INVOKE_JSON=$(
-  curl -s -X POST "$API_URL/mcp/tools/golden-path-echo/invoke" \
+  curl -s -X POST "$API_URL/mcp/messages" \
   -H "X-API-Key: $AGENT_API_KEY" \
-  -H "Idempotency-Key: golden-path-invoke-001" \
   -H "Content-Type: application/json" \
   -d "{
-    \"name\": \"golden-path-echo\",
-    \"arguments\": {},
-    \"mcp_context\": {
-      \"wallet_id\": \"$AGENT_WALLET_ID\",
-      \"request_path\": \"/golden-path/demo\",
-      \"permit_id\": \"$PERMIT_ID\"
+    \"jsonrpc\": \"2.0\",
+    \"id\": \"golden-call-1\",
+    \"method\": \"tools/call\",
+    \"params\": {
+      \"name\": \"golden-path-echo\",
+      \"arguments\": {\"message\": \"hello\"},
+      \"mcpContext\": {
+        \"wallet_id\": \"$AGENT_WALLET_ID\",
+        \"permit_id\": \"$PERMIT_ID\",
+        \"idempotency_key\": \"golden-path-invoke-001\"
+      }
     }
   }"
 )
 
-export RECEIPT_ID=$(echo "$INVOKE_JSON" | jq -r '.receipt.receipt_id')
+export RECEIPT_ID=$(echo "$INVOKE_JSON" | jq -r '.result.receipt.receipt_id')
 echo "$RECEIPT_ID"
 ```
 
 Replace `golden-path-echo` with a tool from `/mcp/tools.json`.
+
+Replay the exact same request and confirm the receipt ID is unchanged:
+
+```bash
+REPLAY_JSON=$(
+  curl -s -X POST "$API_URL/mcp/messages" \
+  -H "X-API-Key: $AGENT_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"id\": \"golden-call-1\",
+    \"method\": \"tools/call\",
+    \"params\": {
+      \"name\": \"golden-path-echo\",
+      \"arguments\": {\"message\": \"hello\"},
+      \"mcpContext\": {
+        \"wallet_id\": \"$AGENT_WALLET_ID\",
+        \"permit_id\": \"$PERMIT_ID\",
+        \"idempotency_key\": \"golden-path-invoke-001\"
+      }
+    }
+  }"
+)
+
+echo "$REPLAY_JSON" | jq -r '.result.receipt.receipt_id'
+```
+
+Try a different registered tool under the same permit and confirm the response
+is denied with a signed denial receipt:
+
+```bash
+curl -s -X POST "$API_URL/mcp/messages" \
+  -H "X-API-Key: $AGENT_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"jsonrpc\": \"2.0\",
+    \"id\": \"golden-denial-1\",
+    \"method\": \"tools/call\",
+    \"params\": {
+      \"name\": \"another-registered-tool\",
+      \"arguments\": {},
+      \"mcpContext\": {
+        \"wallet_id\": \"$AGENT_WALLET_ID\",
+        \"permit_id\": \"$PERMIT_ID\",
+        \"idempotency_key\": \"golden-path-denial-001\"
+      }
+    }
+  }" | jq '.error'
+```
 
 ## 8. Inspect The Operation Record
 
@@ -231,7 +285,8 @@ curl "$API_URL/v1/audit/events?wallet_id=$AGENT_WALLET_ID" \
 
 Each audit event should let an operator tie the action back to its wallet,
 credential source, tool, endpoint, policy decision, request ID or correlation
-ID, success flag, error, and metadata such as transport and estimated cost.
+ID, success flag, error, and metadata such as transport, estimated cost,
+`permit_id`, `idempotency_key`, `request_hash`, and `ledger_entry_id`.
 Use the policy decision ID to confirm why the action was allowed or denied.
 
 Verify the signed receipt:
@@ -241,6 +296,27 @@ curl -X POST "$API_URL/v1/receipts/verify" \
   -H "X-API-Key: $AGENT_API_KEY" \
   -H "Content-Type: application/json" \
   -d "{\"receipt_id\": \"$RECEIPT_ID\"}"
+```
+
+Inspect the permit and receipt ledger from the trust surfaces:
+
+```bash
+curl "$API_URL/v1/permits/$PERMIT_ID" \
+  -H "X-API-Key: $AGENT_API_KEY"
+
+curl "$API_URL/v1/permits/$PERMIT_ID/receipts" \
+  -H "X-API-Key: $AGENT_API_KEY"
+
+curl "$API_URL/v1/receipts?permit_id=$PERMIT_ID&wallet_id=$AGENT_WALLET_ID" \
+  -H "X-API-Key: $AGENT_API_KEY"
+```
+
+Operators can also inspect public signing-key metadata without receiving
+private key material:
+
+```bash
+curl "$API_URL/v1/signing-keys/active" \
+  -H "X-API-Key: $BOOTSTRAP_KEY"
 ```
 
 Verify the wallet audit chain:
@@ -270,6 +346,12 @@ curl "$API_URL/v1/billing/wallets/$AGENT_WALLET_ID/velocity" \
 - Agent API key can access only its own wallet.
 - Dry-run simulation returns a cost estimate.
 - MCP manifest is available.
+- Signed permit creation binds wallet, key, tool, budget, and expiry.
+- Governed MCP invocation returns a signed receipt.
+- Receipt verification and audit-chain verification succeed.
+- Replaying the same governed invoke returns the same receipt without a second
+  ledger debit.
+- Out-of-scope governed invocation is denied with a signed denial receipt.
 - Control-plane audit records are inspectable with the bootstrap key.
 - Operators can inspect the policy decision, audit event, ledger entry, and
   request/correlation ID for the scoped tool call.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -8681,6 +8681,181 @@
       }
     },
     "/v1/permits": {
+      "get": {
+        "tags": [
+          "Trust Permits"
+        ],
+        "summary": "List Permits",
+        "operationId": "list_permits_v1_permits_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "wallet_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Wallet Id"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "name": "subject_key_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Subject Key Id"
+            }
+          },
+          {
+            "name": "created_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created After"
+            }
+          },
+          {
+            "name": "created_before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Created Before"
+            }
+          },
+          {
+            "name": "expires_after",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Expires After"
+            }
+          },
+          {
+            "name": "expires_before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Expires Before"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermitListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "tags": [
           "Trust Permits"
@@ -8720,6 +8895,155 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PermitResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/permits/{permit_id}": {
+      "get": {
+        "tags": [
+          "Trust Permits"
+        ],
+        "summary": "Get Permit",
+        "operationId": "get_permit_v1_permits__permit_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "permit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Permit Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermitResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/permits/{permit_id}/receipts": {
+      "get": {
+        "tags": [
+          "Trust Permits"
+        ],
+        "summary": "List Permit Receipts",
+        "operationId": "list_permit_receipts_v1_permits__permit_id__receipts_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "permit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Permit Id"
+            }
+          },
+          {
+            "name": "tool",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tool"
+            }
+          },
+          {
+            "name": "outcome",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Outcome"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptListResponse"
                 }
               }
             }
@@ -8828,6 +9152,249 @@
             "APIKeyHeader": []
           }
         ]
+      }
+    },
+    "/v1/receipts": {
+      "get": {
+        "tags": [
+          "Trust Receipts"
+        ],
+        "summary": "List Receipts",
+        "operationId": "list_receipts_v1_receipts_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "permit_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Permit Id"
+            }
+          },
+          {
+            "name": "wallet_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Wallet Id"
+            }
+          },
+          {
+            "name": "tool",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tool"
+            }
+          },
+          {
+            "name": "outcome",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Outcome"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/receipts/permit/{permit_id}": {
+      "get": {
+        "tags": [
+          "Trust Receipts"
+        ],
+        "summary": "List Receipts For Permit",
+        "operationId": "list_receipts_for_permit_v1_receipts_permit__permit_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "permit_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Permit Id"
+            }
+          },
+          {
+            "name": "wallet_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Wallet Id"
+            }
+          },
+          {
+            "name": "tool",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Tool"
+            }
+          },
+          {
+            "name": "outcome",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Outcome"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "default": 50,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0,
+              "title": "Offset"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/receipts/{receipt_id}": {
@@ -9710,6 +10277,81 @@
           },
           "403": {
             "description": "Insufficient permissions"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/signing-keys/active": {
+      "get": {
+        "tags": [
+          "Trust Signing Keys"
+        ],
+        "summary": "Get Active Signing Key",
+        "description": "Return public metadata for the active trust-plane signing key.",
+        "operationId": "get_active_signing_key_v1_signing_keys_active_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SigningKeyMetadataResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
+    "/v1/signing-keys/{key_id}": {
+      "get": {
+        "tags": [
+          "Trust Signing Keys"
+        ],
+        "summary": "Get Signing Key",
+        "description": "Return public metadata for an active or retired signing key.",
+        "operationId": "get_signing_key_v1_signing_keys__key_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Key Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SigningKeyMetadataResponse"
+                }
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
@@ -17951,6 +18593,53 @@
         ],
         "title": "PermitCreateRequest"
       },
+      "PermitListResponse": {
+        "properties": {
+          "permits": {
+            "items": {
+              "$ref": "#/components/schemas/PermitResponse"
+            },
+            "type": "array",
+            "title": "Permits"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          },
+          "next_offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "permits",
+          "total",
+          "limit",
+          "offset",
+          "has_more"
+        ],
+        "title": "PermitListResponse"
+      },
       "PermitResponse": {
         "properties": {
           "permit_id": {
@@ -18025,6 +18714,18 @@
             "type": "string",
             "format": "date-time",
             "title": "Issued At"
+          },
+          "revoked_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revoked At"
           }
         },
         "type": "object",
@@ -19058,6 +19759,53 @@
         ],
         "title": "RecallRequest",
         "description": "Recall memories for an agent."
+      },
+      "ReceiptListResponse": {
+        "properties": {
+          "receipts": {
+            "items": {
+              "$ref": "#/components/schemas/ReceiptResponse"
+            },
+            "type": "array",
+            "title": "Receipts"
+          },
+          "total": {
+            "type": "integer",
+            "title": "Total"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit"
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset"
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More"
+          },
+          "next_offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Offset"
+          }
+        },
+        "type": "object",
+        "required": [
+          "receipts",
+          "total",
+          "limit",
+          "offset",
+          "has_more"
+        ],
+        "title": "ReceiptListResponse"
       },
       "ReceiptResponse": {
         "properties": {
@@ -20467,6 +21215,64 @@
         ],
         "title": "SessionContextResponse",
         "description": "Context from past sessions."
+      },
+      "SigningKeyMetadataResponse": {
+        "properties": {
+          "key_id": {
+            "type": "string",
+            "title": "Key Id"
+          },
+          "alg": {
+            "type": "string",
+            "title": "Alg"
+          },
+          "public_key_b64": {
+            "type": "string",
+            "title": "Public Key B64"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "activated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Activated At"
+          },
+          "retired_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Retired At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "key_id",
+          "alg",
+          "public_key_b64",
+          "status",
+          "created_at"
+        ],
+        "title": "SigningKeyMetadataResponse"
       },
       "SimulatedChargeRequest": {
         "properties": {

--- a/docs/production-beta-roadmap.md
+++ b/docs/production-beta-roadmap.md
@@ -78,9 +78,9 @@ compete with it in product positioning.
 
 The Governance Spine Sprint tightened the production-beta release gate around
 the core control-plane loop. A release candidate is not ready until the single
-gate command above passes full pytest coverage, the canonical golden path,
-discovery drift checks, committed OpenAPI parity, and the generated simulation
-inventory check.
+gate command above passes the focused trust-plane pytest suite, the canonical
+golden path, the executable trust-plane demo proof, discovery drift checks,
+committed OpenAPI parity, and the generated simulation inventory check.
 
 ## Agent Trust Ledger Outcome
 

--- a/docs/production-beta-roadmap.md
+++ b/docs/production-beta-roadmap.md
@@ -67,7 +67,7 @@ compete with it in product positioning.
 
 - `/health`, `/ready`, and preflight checks are documented.
 - Release candidates pass one local release-gate command before tagging:
-  `PYTHON=${PYTHON:-python3.12}; pytest && pytest tests/test_golden_path.py tests/test_discovery_drift.py && "$PYTHON" scripts/export_openapi.py --check && "$PYTHON" scripts/generate_sim_inventory.py --check`
+  `scripts/trust_release_gate.sh`
 - Production env vars have a complete reference.
 - Migrations upgrade an empty database and the latest known production schema.
 - CI is green on `master`.
@@ -81,6 +81,22 @@ the core control-plane loop. A release candidate is not ready until the single
 gate command above passes full pytest coverage, the canonical golden path,
 discovery drift checks, committed OpenAPI parity, and the generated simulation
 inventory check.
+
+## Agent Trust Ledger Outcome
+
+The Agent Trust Ledger makes the governed MCP proof inspectable by operators
+without adding a dashboard surface. Admin operators can list permits and
+receipts globally; wallet keys can inspect only wallet-scoped permit, receipt,
+audit, and ledger records. The one-command demo now proves scoped permit,
+strict governed invoke, ledger debit, signed receipt, receipt and audit
+inspection, signing-key metadata discovery, replay safety, out-of-scope denial,
+and cross-wallet isolation.
+
+Production-like trust mode is now fail-closed: `TRUST_MODE_ENABLED=true`
+requires configured signing key material and rejects legacy unpermitted MCP in
+production-like environments. Retired public signing-key metadata remains
+available so historical permits, receipts, and audit-chain signatures continue
+to verify.
 
 The golden path now explicitly tells operators to inspect the policy decision,
 audit event, ledger entry, and request or correlation ID for a scoped tool call.

--- a/docs/superpowers/plans/2026-05-19-agent-ops-war-room.md
+++ b/docs/superpowers/plans/2026-05-19-agent-ops-war-room.md
@@ -1,0 +1,390 @@
+# Agent Ops War Room Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a one-command Agent Ops War Room proof that shows a wallet-scoped agent discovering the platform, receiving bounded authority, invoking a governed MCP tool, producing billing/audit/receipt evidence, replaying safely, and getting denied when it exceeds scope.
+
+**Architecture:** Build on the current trust-plane branch instead of adding a broad new product surface. The proof is an executable Python demo plus tests and docs: it drives the existing FastAPI app in-process for reliability, uses existing wallet/key/permit/MCP/receipt/audit endpoints, and prints an operator timeline that can be shown to a reviewer without hand-waving.
+
+**Tech Stack:** FastAPI ASGI app, httpx `ASGITransport`, SQLModel/SQLite test database, existing `ServiceRegistry`, permit/receipt/audit-chain services, pytest/anyio, Markdown docs.
+
+---
+
+## Current Worktree Context
+
+The branch may already contain uncommitted trust-plane changes in these files:
+
+- `DEMO_SCRIPT.md`
+- `DESIGN_PARTNER_GUIDE.md`
+- `WEDGE.md`
+- `app/core/config.py`
+- `app/core/trust_mode.py`
+- `app/main.py`
+- `app/routers/mcp.py`
+- `app/routers/permits.py`
+- `app/routers/receipts.py`
+- `app/routers/keys.py`
+- `app/schemas/trust.py`
+- `app/services/permits.py`
+- `app/services/receipts.py`
+- `app/services/signing_keys.py`
+- `tests/test_mcp_trust.py`
+- `tests/test_mcp_trust_mode.py`
+- `tests/test_signing_key_lifecycle.py`
+- `tests/test_trust_mode_guardrails.py`
+- `tests/test_trust_operator_inspection.py`
+
+Treat those as relevant in-progress work. Do not revert them. Do not stage unrelated files by wildcard. Every task must stage exact files it owns.
+
+## File Structure
+
+- `scripts/agent_ops_war_room_demo.py`: one-command demo runner and reusable `run_war_room()` function.
+- `tests/test_agent_ops_war_room_demo.py`: regression test for the executable proof contract.
+- `DEMO_SCRIPT.md`: short partner-facing runbook pointing to the new command and proof artifacts.
+- `README.md`, `docs/golden-path.md`, `static/llm.txt`: public narrative surfaces that should say "agent operations control plane" and make the War Room proof obvious.
+- `app/routers/well_known.py`, `app/routers/discover.py`, `app/main.py`: only touch if the discovery payloads still contain generic marketplace/plugin wording after the current dirty branch is stabilized.
+- `docs/openapi.json`: regenerate only if FastAPI route metadata/docstrings change.
+
+---
+
+### Task 1: Stabilize Existing Trust-Plane Baseline
+
+**Files:**
+- Modify/commit existing dirty trust-plane files listed in "Current Worktree Context" only after review.
+- Test: `tests/test_mcp_trust.py`
+- Test: `tests/test_mcp_trust_mode.py`
+- Test: `tests/test_permits.py`
+- Test: `tests/test_receipts.py`
+- Test: `tests/test_audit_chain.py`
+- Test: `tests/test_signing_key_lifecycle.py`
+- Test: `tests/test_trust_mode_guardrails.py`
+- Test: `tests/test_trust_operator_inspection.py`
+
+- [ ] **Step 1: Inspect current dirty trust-plane diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+git diff -- app/routers/mcp.py app/routers/permits.py app/routers/receipts.py app/services/permits.py app/services/receipts.py app/services/signing_keys.py app/schemas/trust.py
+```
+
+Expected: changes are scoped to trust mode, permits, receipts, governed MCP invoke, signing keys, and operator inspection.
+
+- [ ] **Step 2: Run focused trust-plane tests**
+
+Run:
+
+```bash
+pytest tests/test_mcp_trust.py tests/test_mcp_trust_mode.py tests/test_permits.py tests/test_receipts.py tests/test_audit_chain.py tests/test_signing_key_lifecycle.py tests/test_trust_mode_guardrails.py tests/test_trust_operator_inspection.py -q
+```
+
+Expected: all pass. If failures are present, fix only the trust-plane files required by the failing tests.
+
+- [ ] **Step 3: Check public trust-mode guardrails**
+
+Verify these properties in code and tests:
+
+- `TRUST_MODE_ENABLED=true` with `ALLOW_LEGACY_UNPERMITTED_MCP=false` requires permit-backed MCP calls.
+- Missing permit produces `permit_required` and an audit denial.
+- Missing idempotency key produces `idempotency_key_required` and an audit denial.
+- Wrong key, wrong wallet, or wrong tool produces a permit denial with audit evidence.
+- Successful governed call returns a signed receipt that references permit, ledger entry, and audit event.
+- Replay returns the same receipt and does not double-charge.
+
+- [ ] **Step 4: Commit stabilized trust-plane baseline**
+
+Stage exact files from the trust-plane baseline, not new War Room files:
+
+```bash
+git add DEMO_SCRIPT.md DESIGN_PARTNER_GUIDE.md WEDGE.md \
+  app/core/config.py app/core/trust_mode.py app/main.py \
+  app/routers/mcp.py app/routers/permits.py app/routers/receipts.py app/routers/keys.py \
+  app/schemas/trust.py app/services/permits.py app/services/receipts.py app/services/signing_keys.py \
+  tests/test_mcp_trust.py tests/test_mcp_trust_mode.py tests/test_signing_key_lifecycle.py \
+  tests/test_trust_mode_guardrails.py tests/test_trust_operator_inspection.py
+git commit -m "feat: add governed MCP trust mode"
+```
+
+---
+
+### Task 2: Add One-Command War Room Demo
+
+**Files:**
+- Create: `scripts/agent_ops_war_room_demo.py`
+- Test: `tests/test_agent_ops_war_room_demo.py`
+
+- [ ] **Step 1: Write failing test for the War Room proof**
+
+Create `tests/test_agent_ops_war_room_demo.py` with a test that imports `run_war_room` and asserts:
+
+```python
+@pytest.mark.anyio
+async def test_agent_ops_war_room_demo_proves_control_plane_loop(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    result = await run_war_room(
+        client=client,
+        bootstrap_api_key="test-key",
+        emit=False,
+    )
+
+    assert result["status"] == "pass"
+    assert result["agent"]["wallet_id"].startswith("wallet-")
+    assert result["permit"]["permit_id"].startswith("permit-")
+    assert result["invoke"]["receipt"]["outcome"] == "success"
+    assert result["replay"]["same_receipt"] is True
+    assert result["ledger"]["matching_debits"] == 1
+    assert result["audit"]["chain"]["valid"] is True
+    assert result["denial"]["reason"] == "permit_tool_not_allowed"
+    assert result["denial"]["ledger_debits_after"] == result["ledger"]["matching_debits"]
+```
+
+The fixture may reuse the strict trust-mode setup pattern from `tests/test_mcp_trust_mode.py`.
+
+- [ ] **Step 2: Run the failing test**
+
+Run:
+
+```bash
+pytest tests/test_agent_ops_war_room_demo.py -q
+```
+
+Expected: fail because `scripts.agent_ops_war_room_demo` does not exist.
+
+- [ ] **Step 3: Implement `scripts/agent_ops_war_room_demo.py`**
+
+Implement a script with these public functions:
+
+```python
+async def run_war_room(
+    *,
+    client: httpx.AsyncClient,
+    bootstrap_api_key: str,
+    emit: bool = True,
+) -> dict[str, Any]:
+    ...
+
+async def run_in_process(
+    *,
+    database_url: str | None = None,
+    bootstrap_api_key: str = "war-room-bootstrap-key",
+) -> dict[str, Any]:
+    ...
+```
+
+`run_war_room()` must:
+
+1. Fetch `/.well-known/agent.json`, `/mcp/tools.json`, and `/openapi.json`.
+2. Create a sponsor wallet through `/v1/billing/wallets/sponsor`.
+3. Create an agent wallet through `/v1/billing/wallets/agent`.
+4. Create an agent API key through `/v1/api-keys`.
+5. Register two local tools through `get_service_registry()`:
+   - `war-room-echo`
+   - `war-room-denied`
+6. Create a signed permit for `war-room-echo` through `/v1/permits` using an ISO UTC expiration generated in Python.
+7. Invoke `/mcp/messages` with:
+   - `mcpContext.wallet_id`
+   - `mcpContext.permit_id`
+   - `mcpContext.idempotency_key`
+8. Replay the same request and confirm the same receipt ID is returned.
+9. Fetch `/v1/billing/ledger/{wallet_id}` and count matching debits for `war-room-echo`.
+10. Verify the receipt through `/v1/receipts/verify`.
+11. Fetch `/v1/audit/events?wallet_id=...&tool=war-room-echo`.
+12. Verify `/v1/audit/verify-chain`.
+13. Attempt `war-room-denied` with the same permit and assert the response error is `permit_tool_not_allowed`.
+14. Fetch the ledger again and confirm no extra `war-room-echo` debit was created by replay or denial.
+15. Unregister both local tools in a `finally` block.
+
+`run_in_process()` must:
+
+- set safe local defaults before importing/running the app when used as `python scripts/agent_ops_war_room_demo.py`;
+- use a temporary SQLite database by default;
+- initialize the database with existing app DB helpers;
+- use `httpx.ASGITransport(app=app)` so no external server or `jq` is required;
+- print a compact operator timeline and a final `AGENT OPS WAR ROOM: PASS` line.
+
+- [ ] **Step 4: Run the War Room test**
+
+Run:
+
+```bash
+pytest tests/test_agent_ops_war_room_demo.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Run the script manually**
+
+Run:
+
+```bash
+python scripts/agent_ops_war_room_demo.py
+```
+
+Expected output includes:
+
+```text
+AGENT OPS WAR ROOM: PASS
+```
+
+- [ ] **Step 6: Commit demo script**
+
+```bash
+git add scripts/agent_ops_war_room_demo.py tests/test_agent_ops_war_room_demo.py
+git commit -m "feat: add agent ops war room demo"
+```
+
+---
+
+### Task 3: Red-Line War Room Docs And Agent-Facing Narrative
+
+**Files:**
+- Modify: `DEMO_SCRIPT.md`
+- Modify: `README.md`
+- Modify: `docs/golden-path.md`
+- Modify: `static/llm.txt`
+- Modify if needed: `app/routers/well_known.py`
+- Modify if needed: `app/routers/discover.py`
+- Modify if route metadata changes: `docs/openapi.json`
+- Test: `tests/test_discovery.py`
+- Test: `tests/test_discovery_drift.py`
+
+- [ ] **Step 1: Add failing discovery/narrative assertions**
+
+Add compact tests asserting:
+
+- `GET /llm.txt` contains `Agent Ops War Room` or `agent operations control plane`.
+- `GET /.well-known/agent.json` description is about an operational control plane, not plugin directories.
+- `GET /v1/discover` shares the same `agent_first` contract and includes control-plane language.
+
+Run:
+
+```bash
+pytest tests/test_discovery.py tests/test_discovery_drift.py -q
+```
+
+Expected: fail on stale wording if docs/routes have not yet been updated.
+
+- [ ] **Step 2: Update docs**
+
+Update docs so the first impression is:
+
+```text
+Agent Ops War Room proves the control plane loop:
+discover -> authorize -> invoke -> meter -> receipt -> audit -> verify
+```
+
+Keep these claims explicit:
+
+- The demo is a proof, not a claim of complete production agent banking.
+- Trust artifacts are signed permits and signed receipts.
+- Replay is safe and does not double charge.
+- Out-of-scope actions are denied and audited.
+- Audit-chain verification gives operators tamper evidence.
+
+Remove or demote generic copy:
+
+- "plugin registry"
+- "directories"
+- "free tier"
+- "unlimited everything"
+- public "Phase 7/8/9" labels
+- feature-list language that makes AWI or marketplace tools sound like the core product.
+
+- [ ] **Step 3: Regenerate OpenAPI only if source route metadata changed**
+
+If `app/main.py`, `app/routers/well_known.py`, or `app/routers/discover.py` changed route metadata:
+
+```bash
+uv run --with-requirements requirements.txt python scripts/export_openapi.py
+```
+
+Expected: `docs/openapi.json` reflects current app metadata.
+
+- [ ] **Step 4: Run docs/discovery tests**
+
+```bash
+pytest tests/test_discovery.py tests/test_discovery_drift.py tests/test_discovery_consistency.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit docs and discovery narrative**
+
+Stage exact changed docs/tests/source files:
+
+```bash
+git add DEMO_SCRIPT.md README.md docs/golden-path.md static/llm.txt \
+  tests/test_discovery.py tests/test_discovery_drift.py tests/test_discovery_consistency.py
+git add app/routers/well_known.py app/routers/discover.py app/main.py docs/openapi.json
+git commit -m "docs: frame agent ops war room proof"
+```
+
+If a listed file was not changed, omit it from `git add`.
+
+---
+
+### Task 4: Final Verification And Release Readiness
+
+**Files:**
+- Modify if needed: `DEMO_SCRIPT.md`
+- No app behavior changes unless a verification failure requires a small fix.
+
+- [ ] **Step 1: Run targeted proof suite**
+
+```bash
+pytest tests/test_agent_ops_war_room_demo.py tests/test_mcp_trust.py tests/test_mcp_trust_mode.py tests/test_permits.py tests/test_receipts.py tests/test_audit_chain.py tests/test_trust_operator_inspection.py tests/test_golden_path.py tests/test_discovery.py tests/test_discovery_drift.py -q
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+pytest -q
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run executable demo one more time**
+
+```bash
+python scripts/agent_ops_war_room_demo.py
+```
+
+Expected: final line `AGENT OPS WAR ROOM: PASS`.
+
+- [ ] **Step 4: Review final diff**
+
+```bash
+git status --short
+git log --oneline -8
+```
+
+Expected: only intentional committed changes remain. If any unrelated dirty files remain from before the plan, report them explicitly and do not stage them.
+
+- [ ] **Step 5: Final code review**
+
+Dispatch one final reviewer to inspect the whole War Room proof for:
+
+- false claims;
+- demo fragility;
+- trust-mode bypasses;
+- double-charge regressions;
+- stale generic docs;
+- route/contract drift.
+
+Fix any findings before finishing.
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: The tasks create a one-command proof, test it, red-line narrative docs, and verify the full branch.
+- Scope control: No new dashboard UI or broad marketplace expansion is included.
+- Type consistency: The plan consistently uses `permit_id`, `idempotency_key`, `receipt_id`, `ledger_entry_id`, `audit_event_id`, and `policy_decision_id`.
+- Risk handling: Existing dirty trust-plane files are treated as relevant work but must be staged explicitly.

--- a/scripts/demo_trust_plane.py
+++ b/scripts/demo_trust_plane.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""One-command proof for the MCP governance trust plane.
+
+The demo uses a throwaway local SQLite database and the real FastAPI routers.
+It proves a governed MCP call can be scoped, charged, receipted, audited,
+replayed safely, and denied when outside permit scope.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEMO_DB = ROOT / "data" / "demo_trust_plane.db"
+ADMIN_KEY = "demo-admin-key"
+DEMO_PRIVATE_KEY_B64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+ALLOWED_TOOL = "trust-plane-echo"
+BLOCKED_TOOL = "trust-plane-admin-ledger"
+PRINT_STEPS = True
+
+
+def configure_environment() -> None:
+    """Set demo-safe defaults before importing the app."""
+    DEMO_DB.parent.mkdir(parents=True, exist_ok=True)
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{DEMO_DB}"
+    os.environ["VALID_API_KEYS"] = ADMIN_KEY
+    os.environ["TRUST_MODE_ENABLED"] = "true"
+    os.environ["ALLOW_LEGACY_UNPERMITTED_MCP"] = "false"
+    os.environ["TRUST_SIGNING_KEY_ID"] = "demo-ed25519"
+    os.environ["TRUST_SIGNING_PRIVATE_KEY_B64"] = DEMO_PRIVATE_KEY_B64
+
+
+configure_environment()
+sys.path.insert(0, str(ROOT))
+
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+
+from app.db.database import close_db, init_db  # noqa: E402
+from app.main import app  # noqa: E402
+from app.schemas.billing import ServiceCategory  # noqa: E402
+from app.services.service_registry import get_service_registry  # noqa: E402
+
+
+def remove_demo_db() -> None:
+    for suffix in ("", "-shm", "-wal"):
+        path = Path(f"{DEMO_DB}{suffix}")
+        if path.exists():
+            path.unlink()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def step(message: str) -> None:
+    if PRINT_STEPS:
+        print(f"[trust-demo] {message}")
+
+
+def first_jsonrpc_result(response: dict[str, Any]) -> dict[str, Any]:
+    require("result" in response, f"expected JSON-RPC result, got: {response}")
+    return response["result"]
+
+
+def first_jsonrpc_error(response: dict[str, Any]) -> dict[str, Any]:
+    require("error" in response, f"expected JSON-RPC error, got: {response}")
+    return response["error"]
+
+
+async def post_json(
+    client: AsyncClient,
+    path: str,
+    *,
+    headers: dict[str, str],
+    json_body: dict[str, Any],
+    expected_status: int,
+) -> dict[str, Any]:
+    response = await client.post(path, headers=headers, json=json_body)
+    require(
+        response.status_code == expected_status,
+        f"{path} returned {response.status_code}: {response.text}",
+    )
+    return response.json()
+
+
+async def get_json(
+    client: AsyncClient,
+    path: str,
+    *,
+    headers: dict[str, str],
+    expected_status: int,
+) -> dict[str, Any]:
+    response = await client.get(path, headers=headers)
+    require(
+        response.status_code == expected_status,
+        f"{path} returned {response.status_code}: {response.text}",
+    )
+    return response.json()
+
+
+def register_demo_tools() -> None:
+    registry = get_service_registry()
+
+    def echo(message: str = "ok") -> dict[str, str]:
+        return {"message": message, "governed": "true"}
+
+    def admin_ledger_probe() -> dict[str, str]:
+        return {"should_not_execute": "true"}
+
+    registry.register_local(
+        service_id=ALLOWED_TOOL,
+        name="Trust Plane Echo",
+        description="Demo tool allowed by the signed permit",
+        category=ServiceCategory.AGENT_COMMS,
+        func=echo,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    registry.register_local(
+        service_id=BLOCKED_TOOL,
+        name="Trust Plane Blocked Admin Tool",
+        description="Demo tool intentionally outside the signed permit",
+        category=ServiceCategory.AGENT_COMMS,
+        func=admin_ledger_probe,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+
+
+def unregister_demo_tools() -> None:
+    registry = get_service_registry()
+    registry.unregister_local(ALLOWED_TOOL)
+    registry.unregister_local(BLOCKED_TOOL)
+
+
+def build_mcp_call(
+    *,
+    request_id: str,
+    tool: str,
+    wallet_id: str,
+    permit_id: str,
+    idempotency_key: str,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": tool,
+            "arguments": arguments or {},
+            "mcpContext": {
+                "wallet_id": wallet_id,
+                "permit_id": permit_id,
+                "idempotency_key": idempotency_key,
+            },
+        },
+    }
+
+
+async def run_demo(json_output: bool = False) -> dict[str, Any]:
+    global PRINT_STEPS
+
+    PRINT_STEPS = not json_output
+    await close_db()
+    remove_demo_db()
+    await init_db()
+    register_demo_tools()
+
+    admin_headers = {"X-API-Key": ADMIN_KEY}
+    summary: dict[str, Any] = {}
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://demo") as client:
+            step("creating sponsor wallet")
+            sponsor = await post_json(
+                client,
+                "/v1/billing/wallets/sponsor",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "sponsor_name": "Demo Sponsor",
+                    "email": "demo-sponsor@example.com",
+                    "initial_credits": 10000,
+                    "require_kyc": False,
+                },
+            )
+            sponsor_wallet_id = sponsor["wallet_id"]
+
+            step("creating agent wallet")
+            agent = await post_json(
+                client,
+                "/v1/billing/wallets/agent",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "sponsor_wallet_id": sponsor_wallet_id,
+                    "agent_id": "trust-plane-demo-agent",
+                    "budget_credits": 1000,
+                    "daily_limit": 500,
+                },
+            )
+            agent_wallet_id = agent["wallet_id"]
+
+            step("creating wallet-bound API key")
+            key = await post_json(
+                client,
+                "/v1/api-keys",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "wallet_id": agent_wallet_id,
+                    "key_name": "trust-plane-demo-runtime",
+                    "expires_in_days": 30,
+                },
+            )
+            agent_headers = {"X-API-Key": key["api_key"]}
+
+            step("discovering MCP tools")
+            tools = await get_json(
+                client,
+                "/mcp/tools.json",
+                headers=agent_headers,
+                expected_status=200,
+            )
+            require(
+                any(tool["name"] == ALLOWED_TOOL for tool in tools["tools"]),
+                "allowed demo tool missing from MCP discovery",
+            )
+
+            step("issuing signed permit scoped to one MCP tool")
+            permit = await post_json(
+                client,
+                "/v1/permits",
+                headers={**admin_headers, "Idempotency-Key": "demo-permit-1"},
+                expected_status=201,
+                json_body={
+                    "issuer_wallet_id": agent_wallet_id,
+                    "subject_wallet_id": agent_wallet_id,
+                    "subject_key_id": key["key_id"],
+                    "allowed_tools": [ALLOWED_TOOL],
+                    "scopes": [f"tool:{ALLOWED_TOOL}:invoke", "billing:charge"],
+                    "max_credits": 25,
+                    "expires_at": (
+                        datetime.now(timezone.utc) + timedelta(minutes=30)
+                    ).isoformat(),
+                },
+            )
+
+            step("verifying signed permit")
+            permit_check = await post_json(
+                client,
+                "/v1/permits/verify",
+                headers=agent_headers,
+                expected_status=200,
+                json_body={
+                    "permit_id": permit["permit_id"],
+                    "wallet_id": agent_wallet_id,
+                    "tool": ALLOWED_TOOL,
+                    "estimated_credits": 2,
+                },
+            )
+            require(permit_check["valid"] is True, f"permit invalid: {permit_check}")
+
+            step("inspecting permit and active signing key metadata")
+            permit_lookup = await get_json(
+                client,
+                f"/v1/permits/{permit['permit_id']}",
+                headers=agent_headers,
+                expected_status=200,
+            )
+            require(
+                permit_lookup["subject_key_id"] == key["key_id"],
+                f"permit lookup missing key binding: {permit_lookup}",
+            )
+            active_signing_key = await get_json(
+                client,
+                "/v1/signing-keys/active",
+                headers=admin_headers,
+                expected_status=200,
+            )
+            require(
+                active_signing_key["key_id"] == permit["key_id"],
+                f"active signing key mismatch: {active_signing_key}",
+            )
+            require(
+                "private_key" not in active_signing_key
+                and "private_key_b64" not in active_signing_key,
+                "signing key metadata leaked private material",
+            )
+
+            call_body = build_mcp_call(
+                request_id="demo-call-1",
+                tool=ALLOWED_TOOL,
+                wallet_id=agent_wallet_id,
+                permit_id=permit["permit_id"],
+                idempotency_key="demo-invoke-1",
+                arguments={"message": "hello trust plane"},
+            )
+
+            step("invoking governed MCP tool")
+            first_call = await post_json(
+                client,
+                "/mcp/messages",
+                headers=agent_headers,
+                expected_status=200,
+                json_body=call_body,
+            )
+            result = first_jsonrpc_result(first_call)
+            require(result["isError"] is False, f"tool call failed: {result}")
+            receipt = result["receipt"]
+            require(receipt["outcome"] == "success", "success receipt missing")
+            require(receipt["ledger_entry_id"], "receipt missing ledger entry")
+
+            step("verifying signed receipt")
+            receipt_check = await post_json(
+                client,
+                "/v1/receipts/verify",
+                headers=agent_headers,
+                expected_status=200,
+                json_body={"receipt_id": receipt["receipt_id"]},
+            )
+            require(receipt_check["valid"] is True, f"receipt invalid: {receipt_check}")
+
+            step("inspecting receipt through operator filters")
+            receipt_list = await get_json(
+                client,
+                (
+                    "/v1/receipts"
+                    f"?permit_id={permit['permit_id']}"
+                    f"&wallet_id={agent_wallet_id}"
+                    f"&tool={ALLOWED_TOOL}"
+                    "&outcome=success"
+                ),
+                headers=agent_headers,
+                expected_status=200,
+            )
+            require(receipt_list["total"] == 1, f"receipt filter failed: {receipt_list}")
+            permit_receipts = await get_json(
+                client,
+                f"/v1/permits/{permit['permit_id']}/receipts",
+                headers=agent_headers,
+                expected_status=200,
+            )
+            require(
+                permit_receipts["receipts"][0]["receipt_id"] == receipt["receipt_id"],
+                f"permit receipt drilldown failed: {permit_receipts}",
+            )
+
+            step("showing ledger debit")
+            ledger = await get_json(
+                client,
+                f"/v1/billing/ledger/{agent_wallet_id}",
+                headers=agent_headers,
+                expected_status=200,
+            )
+            echo_debits = [
+                entry for entry in ledger["entries"]
+                if entry["service_category"] == "agent_comms"
+                and ALLOWED_TOOL in entry.get("description", "")
+            ]
+            require(len(echo_debits) == 1, f"expected one debit, got {echo_debits}")
+
+            step("verifying audit chain")
+            audit_check = await post_json(
+                client,
+                "/v1/audit/verify-chain",
+                headers=agent_headers,
+                expected_status=200,
+                json_body={"wallet_id": agent_wallet_id},
+            )
+            require(audit_check["valid"] is True, f"audit invalid: {audit_check}")
+            require(audit_check["checked_events"] >= 1, "audit chain checked no events")
+
+            step("inspecting wallet audit event")
+            audit_events = await get_json(
+                client,
+                (
+                    "/v1/audit/events"
+                    f"?wallet_id={agent_wallet_id}"
+                    "&event=mcp.invoke"
+                    f"&tool={ALLOWED_TOOL}"
+                    "&ok=true"
+                ),
+                headers=agent_headers,
+                expected_status=200,
+            )
+            require(audit_events["total"] >= 1, f"audit filter failed: {audit_events}")
+            audit_metadata = audit_events["events"][0]["metadata"]
+            require(
+                audit_metadata["permit_id"] == permit["permit_id"],
+                f"audit missing permit linkage: {audit_metadata}",
+            )
+            require(
+                audit_metadata["idempotency_key"] == "demo-invoke-1",
+                f"audit missing idempotency linkage: {audit_metadata}",
+            )
+            require(
+                audit_metadata["ledger_entry_id"] == receipt["ledger_entry_id"],
+                f"audit missing ledger linkage: {audit_metadata}",
+            )
+            require(
+                audit_metadata["request_hash"],
+                f"audit missing request hash: {audit_metadata}",
+            )
+
+            step("replaying same idempotency key")
+            replay = await post_json(
+                client,
+                "/mcp/messages",
+                headers=agent_headers,
+                expected_status=200,
+                json_body=call_body,
+            )
+            replay_receipt = first_jsonrpc_result(replay)["receipt"]
+            require(
+                replay_receipt["receipt_id"] == receipt["receipt_id"],
+                "replay did not return original receipt",
+            )
+            ledger_after_replay = await get_json(
+                client,
+                f"/v1/billing/ledger/{agent_wallet_id}",
+                headers=agent_headers,
+                expected_status=200,
+            )
+            echo_debits_after_replay = [
+                entry for entry in ledger_after_replay["entries"]
+                if entry["service_category"] == "agent_comms"
+                and ALLOWED_TOOL in entry.get("description", "")
+            ]
+            require(
+                len(echo_debits_after_replay) == 1,
+                "replay created a duplicate ledger debit",
+            )
+
+            step("attempting out-of-scope MCP tool")
+            denial_body = build_mcp_call(
+                request_id="demo-denial-1",
+                tool=BLOCKED_TOOL,
+                wallet_id=agent_wallet_id,
+                permit_id=permit["permit_id"],
+                idempotency_key="demo-denial-1",
+            )
+            denial_call = await post_json(
+                client,
+                "/mcp/messages",
+                headers=agent_headers,
+                expected_status=200,
+                json_body=denial_body,
+            )
+            denial_error = first_jsonrpc_error(denial_call)
+            require(
+                denial_error["message"] == "permit_tool_not_allowed",
+                f"unexpected denial: {denial_error}",
+            )
+            denial_receipt = denial_error["data"]["receipt"]
+            require(denial_receipt["outcome"] == "denied", "denial receipt missing")
+            require(
+                denial_receipt["ledger_entry_id"] is None,
+                "denied call should not have a ledger debit",
+            )
+
+            denial_replay = await post_json(
+                client,
+                "/mcp/messages",
+                headers=agent_headers,
+                expected_status=200,
+                json_body=denial_body,
+            )
+            denial_replay_error = first_jsonrpc_error(denial_replay)
+            require(
+                denial_replay_error["data"]["receipt"]["receipt_id"]
+                == denial_receipt["receipt_id"],
+                "denied replay did not return original denial receipt",
+            )
+
+            step("proving tenant isolation")
+            cross_wallet = await client.get(
+                f"/v1/billing/wallets/{sponsor_wallet_id}",
+                headers=agent_headers,
+            )
+            require(
+                cross_wallet.status_code == 403,
+                f"cross-wallet read was not denied: {cross_wallet.text}",
+            )
+
+            summary = {
+                "sponsor_wallet_id": sponsor_wallet_id,
+                "agent_wallet_id": agent_wallet_id,
+                "agent_key_id": key["key_id"],
+                "permit_id": permit["permit_id"],
+                "success_receipt_id": receipt["receipt_id"],
+                "ledger_entry_id": receipt["ledger_entry_id"],
+                "signing_key_id": active_signing_key["key_id"],
+                "inspected_receipts": receipt_list["total"],
+                "inspected_audit_events": audit_events["total"],
+                "audit_chain_checked_events": audit_check["checked_events"],
+                "replay_receipt_id": replay_receipt["receipt_id"],
+                "denial_receipt_id": denial_receipt["receipt_id"],
+                "denial_replay_receipt_id": denial_replay_error["data"]["receipt"][
+                    "receipt_id"
+                ],
+                "denial_reason": denial_error["message"],
+                "cross_wallet_status": cross_wallet.status_code,
+            }
+
+        if json_output:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        else:
+            step("trust-plane proof complete")
+            for key_name, value in summary.items():
+                print(f"  {key_name}: {value}")
+        return summary
+    finally:
+        unregister_demo_tools()
+        await close_db()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print only the final proof artifact as JSON.",
+    )
+    parser.add_argument(
+        "--assert",
+        dest="assert_mode",
+        action="store_true",
+        help="Compatibility flag: the script always asserts invariants.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(run_demo(json_output=args.json))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trust_release_gate.sh
+++ b/scripts/trust_release_gate.sh
@@ -5,22 +5,33 @@ PYTHON_BIN="${PYTHON:-python3.12}"
 if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
   PYTHON_BIN="python"
 fi
+if [[ -n "${PYTEST:-}" ]]; then
+  PYTEST_CMD=("$PYTEST")
+else
+  PYTEST_CMD=("$PYTHON_BIN" -m pytest)
+fi
+TRUST_TESTS=(
+  tests/test_golden_path.py
+  tests/test_demo_trust_plane.py
+  tests/test_mcp_trust.py
+  tests/test_mcp_trust_mode.py
+  tests/test_trust_operator_inspection.py
+  tests/test_signing_key_lifecycle.py
+  tests/test_trust_mode_guardrails.py
+  tests/test_permits.py
+  tests/test_receipts.py
+  tests/test_audit_chain.py
+  tests/test_idempotency.py
+)
 
-echo "[trust-gate] full pytest suite"
-"$PYTHON_BIN" -m pytest -q
+echo "[trust-gate] focused trust-plane pytest suite"
+"${PYTEST_CMD[@]}" -q "${TRUST_TESTS[@]}"
 
 echo "[trust-gate] trust-plane demo proof"
 "$PYTHON_BIN" scripts/demo_trust_plane.py --assert
 
-echo "[trust-gate] golden path and drift checks"
-"$PYTHON_BIN" -m pytest -q \
-  tests/test_golden_path.py \
-  tests/test_discovery_drift.py \
-  tests/test_demo_trust_plane.py \
-  tests/test_trust_operator_inspection.py \
-  tests/test_mcp_trust_mode.py \
-  tests/test_signing_key_lifecycle.py \
-  tests/test_trust_mode_guardrails.py
+echo "[trust-gate] discovery drift checks"
+"${PYTEST_CMD[@]}" -q tests/test_discovery_drift.py
 
 echo "[trust-gate] OpenAPI parity"
 "$PYTHON_BIN" scripts/export_openapi.py --check

--- a/scripts/trust_release_gate.sh
+++ b/scripts/trust_release_gate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON:-python3.12}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+echo "[trust-gate] full pytest suite"
+"$PYTHON_BIN" -m pytest -q
+
+echo "[trust-gate] trust-plane demo proof"
+"$PYTHON_BIN" scripts/demo_trust_plane.py --assert
+
+echo "[trust-gate] golden path and drift checks"
+"$PYTHON_BIN" -m pytest -q \
+  tests/test_golden_path.py \
+  tests/test_discovery_drift.py \
+  tests/test_demo_trust_plane.py \
+  tests/test_trust_operator_inspection.py \
+  tests/test_mcp_trust_mode.py \
+  tests/test_signing_key_lifecycle.py \
+  tests/test_trust_mode_guardrails.py
+
+echo "[trust-gate] OpenAPI parity"
+"$PYTHON_BIN" scripts/export_openapi.py --check
+
+echo "[trust-gate] simulation inventory parity"
+"$PYTHON_BIN" scripts/generate_sim_inventory.py --check
+
+echo "[trust-gate] trust release gate passed"

--- a/tests/test_demo_trust_plane.py
+++ b/tests/test_demo_trust_plane.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_demo_trust_plane_script_proves_core_loop():
+    result = subprocess.run(
+        [sys.executable, "scripts/demo_trust_plane.py", "--json"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    proof = json.loads(result.stdout)
+    assert proof["permit_id"].startswith("permit-")
+    assert proof["success_receipt_id"].startswith("rcpt-")
+    assert proof["signing_key_id"] == "demo-ed25519"
+    assert proof["inspected_receipts"] == 1
+    assert proof["inspected_audit_events"] >= 1
+    assert proof["replay_receipt_id"] == proof["success_receipt_id"]
+    assert proof["denial_receipt_id"].startswith("rcpt-")
+    assert proof["denial_replay_receipt_id"] == proof["denial_receipt_id"]
+    assert proof["denial_reason"] == "permit_tool_not_allowed"
+    assert proof["cross_wallet_status"] == 403
+    assert proof["audit_chain_checked_events"] >= 1

--- a/tests/test_golden_path.py
+++ b/tests/test_golden_path.py
@@ -5,6 +5,8 @@ This mirrors docs/golden-path.md: bootstrap provisioning, wallet-scoped runtime
 key, ownership denial, dry-run cost estimation, discovery, and inspection.
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -66,6 +68,7 @@ async def test_wallet_scoped_agent_golden_path(client, clean_database):
     )
     assert key_resp.status_code == 201
     agent_api_key = key_resp.json()["api_key"]
+    agent_key_id = key_resp.json()["key_id"]
     agent_headers = {"X-API-Key": agent_api_key}
 
     own_wallet_resp = await client.get(
@@ -120,6 +123,15 @@ async def test_wallet_scoped_agent_golden_path(client, clean_database):
         credits_per_unit=2.0,
         unit_name="call",
     )
+    registry.register_local(
+        service_id="golden-path-denied",
+        name="Golden Path Denied",
+        description="Out-of-scope tool for golden path denial proof",
+        category=ServiceCategory.AGENT_COMMS,
+        func=lambda: {"message": "should not run"},
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
 
     try:
         mcp_resp = await client.get("/mcp/tools.json", headers=agent_headers)
@@ -131,29 +143,107 @@ async def test_wallet_scoped_agent_golden_path(client, clean_database):
             for tool in mcp_payload["tools"]
         )
 
-        invoke_resp = await client.post(
-            "/mcp/messages",
+        permit_resp = await client.post(
+            "/v1/permits",
             json={
-                "jsonrpc": "2.0",
-                "id": "golden-call-1",
-                "method": "tools/call",
-                "params": {
-                    "name": "golden-path-echo",
-                    "arguments": {"message": "hello"},
-                    "mcpContext": {
-                        "wallet_id": agent_wallet_id,
-                        "request_path": "POST /mcp/messages",
-                    },
+                "issuer_wallet_id": agent_wallet_id,
+                "subject_wallet_id": agent_wallet_id,
+                "subject_key_id": agent_key_id,
+                "allowed_tools": ["golden-path-echo"],
+                "scopes": ["tool:golden-path-echo:invoke", "billing:charge"],
+                "max_credits": 50,
+                "expires_at": (
+                    datetime.now(timezone.utc) + timedelta(minutes=30)
+                ).isoformat(),
+            },
+            headers={**bootstrap_headers, "Idempotency-Key": "golden-permit-1"},
+        )
+        assert permit_resp.status_code == 201
+        permit = permit_resp.json()
+
+        invoke_body = {
+            "jsonrpc": "2.0",
+            "id": "golden-call-1",
+            "method": "tools/call",
+            "params": {
+                "name": "golden-path-echo",
+                "arguments": {"message": "hello"},
+                "mcpContext": {
+                    "wallet_id": agent_wallet_id,
+                    "request_path": "POST /mcp/messages",
+                    "permit_id": permit["permit_id"],
+                    "idempotency_key": "golden-invoke-1",
                 },
             },
+        }
+        invoke_resp = await client.post(
+            "/mcp/messages",
+            json=invoke_body,
             headers=agent_headers,
         )
         assert invoke_resp.status_code == 200
         invoke_payload = invoke_resp.json()
         assert "result" in invoke_payload
         assert invoke_payload["result"]["isError"] is False
+        receipt = invoke_payload["result"]["receipt"]
+        assert receipt["permit_id"] == permit["permit_id"]
+        assert receipt["outcome"] == "success"
+        assert receipt["ledger_entry_id"]
+
+        verify_receipt_resp = await client.post(
+            "/v1/receipts/verify",
+            json={"receipt_id": receipt["receipt_id"]},
+            headers=agent_headers,
+        )
+        assert verify_receipt_resp.status_code == 200
+        assert verify_receipt_resp.json()["valid"] is True
+
+        replay_resp = await client.post(
+            "/mcp/messages",
+            json=invoke_body,
+            headers=agent_headers,
+        )
+        assert replay_resp.status_code == 200
+        assert (
+            replay_resp.json()["result"]["receipt"]["receipt_id"]
+            == receipt["receipt_id"]
+        )
+
+        denied_resp = await client.post(
+            "/mcp/messages",
+            json={
+                "jsonrpc": "2.0",
+                "id": "golden-denial-1",
+                "method": "tools/call",
+                "params": {
+                    "name": "golden-path-denied",
+                    "arguments": {},
+                    "mcpContext": {
+                        "wallet_id": agent_wallet_id,
+                        "permit_id": permit["permit_id"],
+                        "idempotency_key": "golden-denial-1",
+                    },
+                },
+            },
+            headers=agent_headers,
+        )
+        assert denied_resp.status_code == 200
+        denied_payload = denied_resp.json()
+        assert denied_payload["error"]["message"] == "permit_tool_not_allowed"
+        denied_receipt = denied_payload["error"]["data"]["receipt"]
+        assert denied_receipt["outcome"] == "denied"
+        assert denied_receipt["credits_charged"] == "0"
+
+        audit_chain_resp = await client.post(
+            "/v1/audit/verify-chain",
+            json={"wallet_id": agent_wallet_id},
+            headers=agent_headers,
+        )
+        assert audit_chain_resp.status_code == 200
+        assert audit_chain_resp.json()["valid"] is True
     finally:
         registry.unregister_local("golden-path-echo")
+        registry.unregister_local("golden-path-denied")
 
     ledger_resp = await client.get(
         f"/v1/billing/ledger/{agent_wallet_id}",
@@ -167,6 +257,13 @@ async def test_wallet_scoped_agent_golden_path(client, clean_database):
         and "golden-path-echo" in entry.get("description", "")
         for entry in ledger_entries
     )
+    golden_debits = [
+        entry
+        for entry in ledger_entries
+        if entry["service_category"] == "agent_comms"
+        and "golden-path-echo" in entry.get("description", "")
+    ]
+    assert len(golden_debits) == 1
 
     audit_resp = await client.get(
         f"/v1/audit/events?wallet_id={agent_wallet_id}&tool=golden-path-echo",
@@ -176,7 +273,12 @@ async def test_wallet_scoped_agent_golden_path(client, clean_database):
     audit_events = audit_resp.json()["events"]
     assert len(audit_events) == 1
     assert audit_events[0]["policy_decision_id"].startswith("pol-")
-    assert audit_events[0]["metadata"]["transport"] == "jsonrpc"
+    audit_metadata = audit_events[0]["metadata"]
+    assert audit_metadata["transport"] == "jsonrpc"
+    assert audit_metadata["permit_id"] == permit["permit_id"]
+    assert audit_metadata["idempotency_key"] == "golden-invoke-1"
+    assert audit_metadata["ledger_entry_id"] == golden_debits[0]["entry_id"]
+    assert audit_metadata["request_hash"]
 
     velocity_resp = await client.get(
         f"/v1/billing/wallets/{agent_wallet_id}/velocity",

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.services.idempotency import (
     IdempotencyConflictError,
+    IdempotencyInProgressError,
     get_idempotency_service,
 )
 from app.services.agent_money import get_agent_money
@@ -50,3 +51,28 @@ async def test_idempotency_replays_same_payload_and_rejects_different_payload(
             idempotency_key="same-key",
             request_payload={"amount": 2},
         )
+
+
+@pytest.mark.anyio
+async def test_idempotency_fails_closed_for_in_progress_record(clean_database):
+    service = get_idempotency_service()
+    wallet = await get_agent_money().create_sponsor_wallet(
+        sponsor_name="In Progress Idempotency Sponsor",
+        email="idem-in-progress@example.com",
+    )
+    first = await service.begin(
+        wallet_id=wallet.wallet_id,
+        endpoint="/v1/test",
+        idempotency_key="in-progress-key",
+        request_payload={"amount": 1},
+    )
+    assert first is None
+
+    with pytest.raises(IdempotencyInProgressError) as exc_info:
+        await service.begin(
+            wallet_id=wallet.wallet_id,
+            endpoint="/v1/test",
+            idempotency_key="in-progress-key",
+            request_payload={"amount": 1},
+        )
+    assert str(exc_info.value) == "idempotency_in_progress"

--- a/tests/test_mcp_trust.py
+++ b/tests/test_mcp_trust.py
@@ -5,6 +5,7 @@ from httpx import ASGITransport, AsyncClient
 
 from app.main import app
 from app.schemas.billing import ServiceCategory
+from app.services.idempotency import get_idempotency_service
 from app.services.service_registry import get_service_registry
 from tests.test_trust_helpers import create_tool_permit, provision_agent_wallet
 
@@ -132,6 +133,82 @@ async def test_governed_mcp_requires_idempotency_key(client, clean_database):
         registry.unregister_local("missing-idem-tool")
     assert resp.status_code == 200
     assert resp.json()["error"]["message"] == "idempotency_key_required"
+
+
+@pytest.mark.anyio
+async def test_governed_mcp_rejects_in_progress_idempotency_without_charge(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    calls = {"count": 0}
+    registry = get_service_registry()
+
+    def in_progress_tool() -> dict:
+        calls["count"] += 1
+        return {"ok": True}
+
+    registry.register_local(
+        service_id="in-progress-idem-tool",
+        name="In Progress Idempotency Tool",
+        description="Governed idempotency in-progress test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=in_progress_tool,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name="in-progress-idem-tool",
+        idem_key="in-progress-mcp-permit-create-1",
+    )
+    body = {
+        "jsonrpc": "2.0",
+        "id": "in-progress-idem-call",
+        "method": "tools/call",
+        "params": {
+            "name": "in-progress-idem-tool",
+            "arguments": {},
+            "mcpContext": {
+                "wallet_id": provisioned["agent_wallet_id"],
+                "permit_id": permit["permit_id"],
+                "idempotency_key": "in-progress-mcp-key",
+            },
+        },
+    }
+    await get_idempotency_service().begin(
+        wallet_id=provisioned["agent_wallet_id"],
+        endpoint="/mcp/messages",
+        idempotency_key="in-progress-mcp-key",
+        request_payload=body,
+    )
+    try:
+        resp = await client.post(
+            "/mcp/messages",
+            json=body,
+            headers=provisioned["agent_headers"],
+        )
+    finally:
+        registry.unregister_local("in-progress-idem-tool")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["error"]["code"] == -32003
+    assert payload["error"]["message"] == "idempotency_in_progress"
+    assert calls["count"] == 0
+    ledger_resp = await client.get(
+        f"/v1/billing/ledger/{provisioned['agent_wallet_id']}",
+        headers=provisioned["agent_headers"],
+    )
+    debits = [
+        entry
+        for entry in ledger_resp.json()["entries"]
+        if entry["service_category"] == "agent_comms"
+        and "in-progress-idem-tool" in entry["description"]
+    ]
+    assert debits == []
 
 
 @pytest.mark.anyio

--- a/tests/test_mcp_trust.py
+++ b/tests/test_mcp_trust.py
@@ -132,3 +132,58 @@ async def test_governed_mcp_requires_idempotency_key(client, clean_database):
         registry.unregister_local("missing-idem-tool")
     assert resp.status_code == 200
     assert resp.json()["error"]["message"] == "idempotency_key_required"
+
+
+@pytest.mark.anyio
+async def test_out_of_scope_governed_mcp_denial_returns_receipt(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    registry = get_service_registry()
+    registry.register_local(
+        service_id="blocked-trust-tool",
+        name="Blocked Trust Tool",
+        description="Governed trust denial test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=lambda: {"ok": True},
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name="allowed-trust-tool",
+        idem_key="permit-denial-create-1",
+    )
+    try:
+        resp = await client.post(
+            "/mcp/messages",
+            json={
+                "jsonrpc": "2.0",
+                "id": "trust-denial-1",
+                "method": "tools/call",
+                "params": {
+                    "name": "blocked-trust-tool",
+                    "arguments": {},
+                    "mcpContext": {
+                        "wallet_id": provisioned["agent_wallet_id"],
+                        "permit_id": permit["permit_id"],
+                        "idempotency_key": "trust-denial-invoke-1",
+                    },
+                },
+            },
+            headers=provisioned["agent_headers"],
+        )
+    finally:
+        registry.unregister_local("blocked-trust-tool")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["error"]["message"] == "permit_tool_not_allowed"
+    receipt = payload["error"]["data"]["receipt"]
+    assert receipt["permit_id"] == permit["permit_id"]
+    assert receipt["outcome"] == "denied"
+    assert receipt["ledger_entry_id"] is None
+    assert receipt["credits_charged"] == "0"

--- a/tests/test_mcp_trust.py
+++ b/tests/test_mcp_trust.py
@@ -176,6 +176,25 @@ async def test_out_of_scope_governed_mcp_denial_returns_receipt(
             },
             headers=provisioned["agent_headers"],
         )
+
+        replay = await client.post(
+            "/mcp/messages",
+            json={
+                "jsonrpc": "2.0",
+                "id": "trust-denial-1",
+                "method": "tools/call",
+                "params": {
+                    "name": "blocked-trust-tool",
+                    "arguments": {},
+                    "mcpContext": {
+                        "wallet_id": provisioned["agent_wallet_id"],
+                        "permit_id": permit["permit_id"],
+                        "idempotency_key": "trust-denial-invoke-1",
+                    },
+                },
+            },
+            headers=provisioned["agent_headers"],
+        )
     finally:
         registry.unregister_local("blocked-trust-tool")
 
@@ -186,4 +205,137 @@ async def test_out_of_scope_governed_mcp_denial_returns_receipt(
     assert receipt["permit_id"] == permit["permit_id"]
     assert receipt["outcome"] == "denied"
     assert receipt["ledger_entry_id"] is None
+    assert receipt["credits_charged"] == "0"
+
+    assert replay.status_code == 200
+    replay_payload = replay.json()
+    assert "result" not in replay_payload
+    assert replay_payload["error"]["message"] == "permit_tool_not_allowed"
+    assert (
+        replay_payload["error"]["data"]["receipt"]["receipt_id"]
+        == receipt["receipt_id"]
+    )
+
+
+@pytest.mark.anyio
+async def test_governed_policy_denial_returns_receipt(client, clean_database):
+    provisioned = await provision_agent_wallet(client)
+    registry = get_service_registry()
+    registry.register_local(
+        service_id="policy-denied-trust-tool",
+        name="Policy Denied Trust Tool",
+        description="Governed trust policy denial test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=lambda: {"ok": True},
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name="policy-denied-trust-tool",
+        idem_key="policy-denial-permit-create-1",
+    )
+    policy_resp = await client.post(
+        "/v1/policies",
+        json={
+            "wallet_id": provisioned["agent_wallet_id"],
+            "name": "Governed deny one tool",
+            "allowed_tools": ["some-other-tool"],
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert policy_resp.status_code == 201
+    body = {
+        "jsonrpc": "2.0",
+        "id": "policy-denial-trust-call",
+        "method": "tools/call",
+        "params": {
+            "name": "policy-denied-trust-tool",
+            "arguments": {},
+            "mcpContext": {
+                "wallet_id": provisioned["agent_wallet_id"],
+                "permit_id": permit["permit_id"],
+                "idempotency_key": "policy-denial-trust-invoke-1",
+            },
+        },
+    }
+    try:
+        resp = await client.post(
+            "/mcp/messages",
+            json=body,
+            headers=provisioned["agent_headers"],
+        )
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["error"]["message"] == "tool_not_allowed"
+        receipt = payload["error"]["data"]["receipt"]
+        assert receipt["outcome"] == "denied"
+        assert receipt["credits_charged"] == "0"
+
+        replay = await client.post(
+            "/mcp/messages",
+            json=body,
+            headers=provisioned["agent_headers"],
+        )
+        assert replay.json()["error"]["data"]["receipt"]["receipt_id"] == receipt[
+            "receipt_id"
+        ]
+    finally:
+        registry.unregister_local("policy-denied-trust-tool")
+
+
+@pytest.mark.anyio
+async def test_governed_tool_failure_returns_refunded_receipt(client, clean_database):
+    provisioned = await provision_agent_wallet(client)
+    registry = get_service_registry()
+
+    def failing_tool() -> dict:
+        raise RuntimeError("tool exploded")
+
+    registry.register_local(
+        service_id="failing-trust-tool",
+        name="Failing Trust Tool",
+        description="Governed trust failure receipt test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=failing_tool,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name="failing-trust-tool",
+        idem_key="failing-trust-permit-create-1",
+    )
+    try:
+        resp = await client.post(
+            "/mcp/messages",
+            json={
+                "jsonrpc": "2.0",
+                "id": "failing-trust-call",
+                "method": "tools/call",
+                "params": {
+                    "name": "failing-trust-tool",
+                    "arguments": {},
+                    "mcpContext": {
+                        "wallet_id": provisioned["agent_wallet_id"],
+                        "permit_id": permit["permit_id"],
+                        "idempotency_key": "failing-trust-invoke-1",
+                    },
+                },
+            },
+            headers=provisioned["agent_headers"],
+        )
+    finally:
+        registry.unregister_local("failing-trust-tool")
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["error"]["message"] == "tool exploded"
+    receipt = payload["error"]["data"]["receipt"]
+    assert receipt["outcome"] == "failed_refunded"
+    assert receipt["ledger_entry_id"]
     assert receipt["credits_charged"] == "0"

--- a/tests/test_mcp_trust_mode.py
+++ b/tests/test_mcp_trust_mode.py
@@ -178,6 +178,7 @@ async def test_strict_mode_denies_missing_idempotency_and_audits(
         )
         payload = resp.json()
         assert resp.status_code == 200
+        assert payload["error"]["code"] == -32003
         assert payload["error"]["message"] == "idempotency_key_required"
         await _assert_denial_audited(
             wallet_id=provisioned["agent_wallet_id"],
@@ -232,6 +233,24 @@ async def test_strict_mode_denies_wrong_permit_key_wallet_and_tool_with_audit(
             headers={"X-API-Key": second_key},
         )
         assert wrong_key_resp.json()["error"]["message"] == "permit_key_mismatch"
+        await _assert_denial_audited(
+            wallet_id=provisioned["agent_wallet_id"],
+            tool_name=allowed_tool,
+            reason="permit_key_mismatch",
+        )
+
+        bootstrap_key_resp = await client.post(
+            "/mcp/messages",
+            json=_jsonrpc_body(
+                tool_name=allowed_tool,
+                wallet_id=provisioned["agent_wallet_id"],
+                request_id="strict-bootstrap-bound-key-call",
+                permit_id=permit["permit_id"],
+                idempotency_key="strict-bootstrap-bound-key-idem",
+            ),
+            headers=BOOTSTRAP_HEADERS,
+        )
+        assert bootstrap_key_resp.json()["error"]["message"] == "permit_key_mismatch"
         await _assert_denial_audited(
             wallet_id=provisioned["agent_wallet_id"],
             tool_name=allowed_tool,

--- a/tests/test_mcp_trust_mode.py
+++ b/tests/test_mcp_trust_mode.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import base64
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.routers import mcp as mcp_router
+from app.schemas.billing import ServiceCategory
+from app.services.audit_log import list_audit_events
+from app.services.signing_keys import get_signing_key_service
+from app.services.service_registry import get_service_registry
+from tests.test_trust_helpers import (
+    BOOTSTRAP_HEADERS,
+    create_tool_permit,
+    provision_agent_wallet,
+)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def strict_trust_mode(monkeypatch):
+    raw_private_key = Ed25519PrivateKey.generate().private_bytes(
+        Encoding.Raw,
+        PrivateFormat.Raw,
+        NoEncryption(),
+    )
+    monkeypatch.setattr(mcp_router.settings, "TRUST_MODE_ENABLED", True)
+    monkeypatch.setattr(mcp_router.settings, "ALLOW_LEGACY_UNPERMITTED_MCP", False)
+    monkeypatch.setattr(
+        mcp_router.settings,
+        "TRUST_SIGNING_PRIVATE_KEY_B64",
+        base64.b64encode(raw_private_key).decode(),
+    )
+    signing_keys = get_signing_key_service()
+    signing_keys._private_key = None
+
+
+@pytest.fixture
+def legacy_trust_mode(monkeypatch):
+    monkeypatch.setattr(mcp_router.settings, "TRUST_MODE_ENABLED", False)
+    monkeypatch.setattr(mcp_router.settings, "ALLOW_LEGACY_UNPERMITTED_MCP", True)
+
+
+def _register_echo_tool(tool_name: str) -> None:
+    registry = get_service_registry()
+
+    def trust_mode_echo(message: str = "ok") -> dict:
+        return {"message": message}
+
+    registry.register_local(
+        service_id=tool_name,
+        name=f"{tool_name} Echo",
+        description="Trust mode enforcement test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=trust_mode_echo,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+
+
+def _jsonrpc_body(
+    *,
+    tool_name: str,
+    wallet_id: str,
+    request_id: str,
+    permit_id: str | None = None,
+    idempotency_key: str | None = None,
+) -> dict:
+    mcp_context = {"wallet_id": wallet_id}
+    if permit_id is not None:
+        mcp_context["permit_id"] = permit_id
+    if idempotency_key is not None:
+        mcp_context["idempotency_key"] = idempotency_key
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": tool_name,
+            "arguments": {"message": "hello"},
+            "mcpContext": mcp_context,
+        },
+    }
+
+
+async def _assert_denial_audited(
+    *,
+    wallet_id: str,
+    tool_name: str,
+    reason: str,
+) -> None:
+    events = await list_audit_events(
+        event="mcp.invoke",
+        wallet_id=wallet_id,
+        tool=tool_name,
+        ok=False,
+        limit=5,
+    )
+    assert events
+    assert events[0].error == reason
+    assert events[0].policy_decision_id.startswith("pol-")
+    assert events[0].metadata["transport"] == "jsonrpc"
+    assert events[0].metadata.get("request_hash")
+
+
+@pytest.mark.anyio
+async def test_strict_mode_denies_unpermitted_mcp_invoke_and_audits(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "strict-unpermitted-tool"
+    registry = get_service_registry()
+    _register_echo_tool(tool_name)
+    try:
+        resp = await client.post(
+            "/mcp/messages",
+            json=_jsonrpc_body(
+                tool_name=tool_name,
+                wallet_id=provisioned["agent_wallet_id"],
+                request_id="strict-unpermitted-call",
+            ),
+            headers=provisioned["agent_headers"],
+        )
+        payload = resp.json()
+        assert resp.status_code == 200
+        assert payload["error"]["message"] == "permit_required"
+        await _assert_denial_audited(
+            wallet_id=provisioned["agent_wallet_id"],
+            tool_name=tool_name,
+            reason="permit_required",
+        )
+    finally:
+        registry.unregister_local(tool_name)
+
+
+@pytest.mark.anyio
+async def test_strict_mode_denies_missing_idempotency_and_audits(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "strict-missing-idempotency-tool"
+    registry = get_service_registry()
+    _register_echo_tool(tool_name)
+    try:
+        permit = await create_tool_permit(
+            client,
+            wallet_id=provisioned["agent_wallet_id"],
+            key_id=provisioned["key_id"],
+            tool_name=tool_name,
+        )
+        resp = await client.post(
+            "/mcp/messages",
+            json=_jsonrpc_body(
+                tool_name=tool_name,
+                wallet_id=provisioned["agent_wallet_id"],
+                request_id="strict-missing-idempotency-call",
+                permit_id=permit["permit_id"],
+            ),
+            headers=provisioned["agent_headers"],
+        )
+        payload = resp.json()
+        assert resp.status_code == 200
+        assert payload["error"]["message"] == "idempotency_key_required"
+        await _assert_denial_audited(
+            wallet_id=provisioned["agent_wallet_id"],
+            tool_name=tool_name,
+            reason="idempotency_key_required",
+        )
+    finally:
+        registry.unregister_local(tool_name)
+
+
+@pytest.mark.anyio
+async def test_strict_mode_denies_wrong_permit_key_wallet_and_tool_with_audit(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    registry = get_service_registry()
+    allowed_tool = "strict-permit-allowed-tool"
+    wrong_tool = "strict-permit-wrong-tool"
+    _register_echo_tool(allowed_tool)
+    _register_echo_tool(wrong_tool)
+    try:
+        permit = await create_tool_permit(
+            client,
+            wallet_id=provisioned["agent_wallet_id"],
+            key_id=provisioned["key_id"],
+            tool_name=allowed_tool,
+        )
+
+        second_key_resp = await client.post(
+            "/v1/api-keys",
+            json={
+                "wallet_id": provisioned["agent_wallet_id"],
+                "key_name": "trust-runtime-wrong-key",
+                "expires_in_days": 30,
+            },
+            headers=BOOTSTRAP_HEADERS,
+        )
+        assert second_key_resp.status_code == 201
+        second_key = second_key_resp.json()["api_key"]
+
+        wrong_key_resp = await client.post(
+            "/mcp/messages",
+            json=_jsonrpc_body(
+                tool_name=allowed_tool,
+                wallet_id=provisioned["agent_wallet_id"],
+                request_id="strict-wrong-key-call",
+                permit_id=permit["permit_id"],
+                idempotency_key="strict-wrong-key-idem",
+            ),
+            headers={"X-API-Key": second_key},
+        )
+        assert wrong_key_resp.json()["error"]["message"] == "permit_key_mismatch"
+        await _assert_denial_audited(
+            wallet_id=provisioned["agent_wallet_id"],
+            tool_name=allowed_tool,
+            reason="permit_key_mismatch",
+        )
+
+        wrong_wallet_resp = await client.post(
+            "/mcp/messages",
+            json=_jsonrpc_body(
+                tool_name=allowed_tool,
+                wallet_id=provisioned["sponsor_wallet_id"],
+                request_id="strict-wrong-wallet-call",
+                permit_id=permit["permit_id"],
+                idempotency_key="strict-wrong-wallet-idem",
+            ),
+            headers=BOOTSTRAP_HEADERS,
+        )
+        assert wrong_wallet_resp.json()["error"]["message"] == "permit_wallet_mismatch"
+        await _assert_denial_audited(
+            wallet_id=provisioned["sponsor_wallet_id"],
+            tool_name=allowed_tool,
+            reason="permit_wallet_mismatch",
+        )
+
+        wrong_tool_resp = await client.post(
+            "/mcp/messages",
+            json=_jsonrpc_body(
+                tool_name=wrong_tool,
+                wallet_id=provisioned["agent_wallet_id"],
+                request_id="strict-wrong-tool-call",
+                permit_id=permit["permit_id"],
+                idempotency_key="strict-wrong-tool-idem",
+            ),
+            headers=provisioned["agent_headers"],
+        )
+        assert wrong_tool_resp.json()["error"]["message"] == "permit_tool_not_allowed"
+        await _assert_denial_audited(
+            wallet_id=provisioned["agent_wallet_id"],
+            tool_name=wrong_tool,
+            reason="permit_tool_not_allowed",
+        )
+    finally:
+        registry.unregister_local(allowed_tool)
+        registry.unregister_local(wrong_tool)
+
+
+@pytest.mark.anyio
+async def test_legacy_mode_still_allows_wallet_only_mcp_invoke(
+    client,
+    clean_database,
+    legacy_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "legacy-wallet-only-tool"
+    registry = get_service_registry()
+    _register_echo_tool(tool_name)
+    try:
+        resp = await client.post(
+            "/mcp/messages",
+            json=_jsonrpc_body(
+                tool_name=tool_name,
+                wallet_id=provisioned["agent_wallet_id"],
+                request_id="legacy-wallet-only-call",
+            ),
+            headers=provisioned["agent_headers"],
+        )
+        payload = resp.json()
+        assert resp.status_code == 200
+        assert payload["result"]["isError"] is False
+        assert "receipt" not in payload["result"]
+    finally:
+        registry.unregister_local(tool_name)

--- a/tests/test_permits.py
+++ b/tests/test_permits.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
+from app.schemas.trust import PermitCreateRequest
+from app.services.idempotency import get_idempotency_service
 from tests.test_trust_helpers import create_tool_permit, provision_agent_wallet
 
 
@@ -64,3 +68,37 @@ async def test_permit_rejects_out_of_scope_tool(client, clean_database):
     assert verify_resp.status_code == 200
     assert verify_resp.json()["valid"] is False
     assert verify_resp.json()["reason"] == "permit_tool_not_allowed"
+
+
+@pytest.mark.anyio
+async def test_permit_create_rejects_in_progress_idempotency_key(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    request_payload = {
+        "issuer_wallet_id": provisioned["agent_wallet_id"],
+        "subject_wallet_id": provisioned["agent_wallet_id"],
+        "subject_key_id": provisioned["key_id"],
+        "allowed_tools": ["in-progress-permit-tool"],
+        "scopes": ["tool:in-progress-permit-tool:invoke", "billing:charge"],
+        "max_credits": 50,
+        "expires_at": (
+            datetime.now(timezone.utc) + timedelta(minutes=30)
+        ).isoformat(),
+    }
+    await get_idempotency_service().begin(
+        wallet_id=provisioned["agent_wallet_id"],
+        endpoint="/v1/permits",
+        idempotency_key="permit-in-progress-key",
+        request_payload=PermitCreateRequest(**request_payload).model_dump(mode="json"),
+    )
+
+    resp = await client.post(
+        "/v1/permits",
+        json=request_payload,
+        headers={"X-API-Key": "test-key", "Idempotency-Key": "permit-in-progress-key"},
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "idempotency_in_progress"

--- a/tests/test_signing_key_lifecycle.py
+++ b/tests/test_signing_key_lifecycle.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.db.database import get_session_factory
+from app.db.models import SigningKeyModel
+from app.main import app
+from app.services.audit_log import record_audit_event
+from app.services.receipts import get_receipt_service
+from app.services.signing_keys import get_signing_key_service
+from tests.test_trust_helpers import (
+    BOOTSTRAP_HEADERS,
+    create_tool_permit,
+    provision_agent_wallet,
+)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.anyio
+async def test_active_signing_key_metadata_endpoint_excludes_private_key(
+    client,
+    clean_database,
+):
+    resp = await client.get("/v1/signing-keys/active", headers=BOOTSTRAP_HEADERS)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["key_id"]
+    assert body["alg"] == "Ed25519"
+    assert body["public_key_b64"]
+    assert body["status"] == "active"
+    assert "private_key" not in body
+    assert "private_key_b64" not in body
+
+
+@pytest.mark.anyio
+async def test_retired_signing_key_metadata_still_verifies_payload(clean_database):
+    service = get_signing_key_service()
+    signature, key_id, payload_hash = await service.sign_payload(
+        {"purpose": "retire-test"}
+    )
+    await service.retire_key_metadata(key_id)
+
+    payload = {
+        "purpose": "retire-test",
+        "alg": "Ed25519",
+        "kid": key_id,
+        "payload_hash": payload_hash,
+    }
+
+    assert await service.verify_payload(payload, signature=signature, key_id=key_id)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        key = await session.get(SigningKeyModel, key_id)
+        assert key is not None
+        assert key.status == "retired"
+        assert key.retired_at is not None
+
+
+@pytest.mark.anyio
+async def test_rotated_metadata_preserves_historical_trust_artifact_verification(
+    client,
+    clean_database,
+):
+    service = get_signing_key_service()
+    original_key_id = service._settings.TRUST_SIGNING_KEY_ID
+    await service.rotate_active_key_metadata(original_key_id)
+
+    provisioned = await provision_agent_wallet(client)
+    old_permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name="historical-tool",
+        idem_key="permit-before-signing-key-rotation",
+    )
+    old_receipt = await get_receipt_service().create_receipt(
+        permit_id=old_permit["permit_id"],
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool="historical-tool",
+        request_payload={"message": "before"},
+        response_payload={"message": "after"},
+        ledger_entry_id=None,
+        credits_authorized=Decimal("2"),
+        credits_charged=Decimal("0"),
+        outcome="success",
+        audit_event_id=None,
+    )
+    audit_event = await record_audit_event(
+        event="trust.rotation.before",
+        wallet_id=provisioned["agent_wallet_id"],
+        tool="historical-tool",
+        key_id=provisioned["key_id"],
+        metadata={"phase": "before"},
+    )
+
+    rotated_key_id = "test-rotated-ed25519"
+    try:
+        rotated_key = await service.rotate_active_key_metadata(rotated_key_id)
+        assert rotated_key.key_id == rotated_key_id
+
+        active_resp = await client.get(
+            "/v1/signing-keys/active",
+            headers=BOOTSTRAP_HEADERS,
+        )
+        assert active_resp.status_code == 200
+        assert active_resp.json()["key_id"] == rotated_key_id
+
+        new_permit = await create_tool_permit(
+            client,
+            wallet_id=provisioned["agent_wallet_id"],
+            key_id=provisioned["key_id"],
+            tool_name="current-tool",
+            idem_key="permit-after-signing-key-rotation",
+        )
+        assert new_permit["key_id"] == rotated_key_id
+
+        permit_verify = await client.post(
+            "/v1/permits/verify",
+            json={
+                "permit_id": old_permit["permit_id"],
+                "wallet_id": provisioned["agent_wallet_id"],
+                "tool": "historical-tool",
+                "estimated_credits": 1,
+            },
+            headers=provisioned["agent_headers"],
+        )
+        assert permit_verify.status_code == 200
+        assert permit_verify.json()["valid"] is True
+
+        receipt_verify = await client.post(
+            "/v1/receipts/verify",
+            json={"receipt_id": old_receipt.receipt_id},
+            headers=provisioned["agent_headers"],
+        )
+        assert receipt_verify.status_code == 200
+        assert receipt_verify.json()["valid"] is True
+
+        audit_verify = await client.post(
+            "/v1/audit/verify-chain",
+            json={"wallet_id": provisioned["agent_wallet_id"]},
+            headers=provisioned["agent_headers"],
+        )
+        assert audit_verify.status_code == 200
+        assert audit_verify.json()["valid"] is True
+
+        old_key_resp = await client.get(
+            f"/v1/signing-keys/{old_permit['key_id']}",
+            headers=BOOTSTRAP_HEADERS,
+        )
+        assert old_key_resp.status_code == 200
+        assert old_key_resp.json()["status"] == "retired"
+        assert old_key_resp.json()["retired_at"] is not None
+        assert audit_event.signature_key_id == old_permit["key_id"]
+
+        factory = get_session_factory()
+        async with factory() as session:
+            result = await session.execute(
+                select(SigningKeyModel).where(
+                    SigningKeyModel.key_id.in_(
+                        [old_permit["key_id"], rotated_key_id]
+                    )
+                )
+            )
+            statuses = {key.key_id: key.status for key in result.scalars().all()}
+        assert statuses[old_permit["key_id"]] == "retired"
+        assert statuses[rotated_key_id] == "active"
+    finally:
+        await service.rotate_active_key_metadata(original_key_id)

--- a/tests/test_trust_mode_guardrails.py
+++ b/tests/test_trust_mode_guardrails.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from app.core.config import Settings
+from app.core.trust_mode import (
+    TrustModeGuardrailError,
+    is_production_like_environment,
+    validate_trust_mode_config,
+    validate_trust_mode_guardrails,
+)
+
+
+@pytest.mark.parametrize(
+    "environment",
+    [
+        "production",
+        "prod",
+        "staging",
+        "stage",
+        "preprod",
+        "preview",
+        "prod-us",
+        "qa",
+    ],
+)
+def test_classifier_marks_production_like_environments(environment: str):
+    assert is_production_like_environment(environment)
+
+
+@pytest.mark.parametrize(
+    "environment",
+    ["", "local", "development", "dev", "test", "testing", "ci", "localhost"],
+)
+def test_classifier_keeps_local_dev_test_compatible(environment: str):
+    assert not is_production_like_environment(environment)
+    validate_trust_mode_config(
+        environment=environment,
+        trust_mode_enabled=True,
+        signing_private_key_b64="",
+        allow_legacy_unpermitted_mcp=True,
+    )
+
+
+def test_production_trust_mode_requires_signing_private_key():
+    with pytest.raises(TrustModeGuardrailError) as exc_info:
+        validate_trust_mode_config(
+            environment="production",
+            trust_mode_enabled=True,
+            signing_private_key_b64="",
+            allow_legacy_unpermitted_mcp=False,
+        )
+
+    assert "TRUST_SIGNING_PRIVATE_KEY_B64" in str(exc_info.value)
+
+
+def test_production_trust_mode_rejects_legacy_unpermitted_mcp():
+    with pytest.raises(TrustModeGuardrailError) as exc_info:
+        validate_trust_mode_config(
+            environment="production",
+            trust_mode_enabled=True,
+            signing_private_key_b64="private-key-material",
+            allow_legacy_unpermitted_mcp=True,
+        )
+
+    assert "ALLOW_LEGACY_UNPERMITTED_MCP" in str(exc_info.value)
+
+
+def test_production_trust_mode_reports_all_fail_closed_violations():
+    with pytest.raises(TrustModeGuardrailError) as exc_info:
+        validate_trust_mode_config(
+            environment="production",
+            trust_mode_enabled=True,
+            signing_private_key_b64="",
+            allow_legacy_unpermitted_mcp=True,
+        )
+
+    message = str(exc_info.value)
+    assert "TRUST_SIGNING_PRIVATE_KEY_B64" in message
+    assert "ALLOW_LEGACY_UNPERMITTED_MCP" in message
+
+
+def test_production_without_trust_mode_stays_compatible():
+    validate_trust_mode_config(
+        environment="production",
+        trust_mode_enabled=False,
+        signing_private_key_b64="",
+        allow_legacy_unpermitted_mcp=True,
+    )
+
+
+def test_settings_wrapper_uses_environment_field():
+    settings = Settings(
+        ENVIRONMENT="staging",
+        TRUST_MODE_ENABLED=True,
+        TRUST_SIGNING_PRIVATE_KEY_B64="private-key-material",
+        ALLOW_LEGACY_UNPERMITTED_MCP=False,
+    )
+
+    validate_trust_mode_guardrails(settings)

--- a/tests/test_trust_operator_inspection.py
+++ b/tests/test_trust_operator_inspection.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.services.audit_log import record_audit_event
+from app.services.receipts import get_receipt_service
+from tests.test_trust_helpers import (
+    BOOTSTRAP_HEADERS,
+    create_tool_permit,
+    provision_agent_wallet,
+)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.anyio
+async def test_admin_and_wallet_can_inspect_permits_with_filters(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name="inspect-tool",
+    )
+
+    admin_list = await client.get(
+        "/v1/permits",
+        params={
+            "wallet_id": provisioned["agent_wallet_id"],
+            "status": "active",
+            "subject_key_id": provisioned["key_id"],
+        },
+        headers=BOOTSTRAP_HEADERS,
+    )
+    assert admin_list.status_code == 200
+    admin_payload = admin_list.json()
+    assert admin_payload["total"] == 1
+    assert admin_payload["permits"][0]["permit_id"] == permit["permit_id"]
+
+    wallet_list = await client.get(
+        "/v1/permits",
+        params={"wallet_id": provisioned["agent_wallet_id"]},
+        headers=provisioned["agent_headers"],
+    )
+    assert wallet_list.status_code == 200
+    assert wallet_list.json()["permits"][0]["subject_key_id"] == provisioned["key_id"]
+
+    fetched = await client.get(
+        f"/v1/permits/{permit['permit_id']}",
+        headers=provisioned["agent_headers"],
+    )
+    assert fetched.status_code == 200
+    assert fetched.json()["permit_id"] == permit["permit_id"]
+
+
+@pytest.mark.anyio
+async def test_wallet_permit_inspection_rejects_global_and_other_wallet_queries(
+    client,
+    clean_database,
+):
+    wallet_a = await provision_agent_wallet(client)
+    wallet_b = await provision_agent_wallet(client)
+
+    global_resp = await client.get("/v1/permits", headers=wallet_a["agent_headers"])
+    assert global_resp.status_code == 403
+
+    other_wallet_resp = await client.get(
+        "/v1/permits",
+        params={"wallet_id": wallet_b["agent_wallet_id"]},
+        headers=wallet_a["agent_headers"],
+    )
+    assert other_wallet_resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_receipt_inspection_filters_and_permit_route_include_audit_ids(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name="receipt-inspect",
+    )
+    audit_event = await record_audit_event(
+        event="mcp.invoke",
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool="receipt-inspect",
+        endpoint="/mcp/messages",
+        auth_source="db",
+        ok=True,
+    )
+    receipt = await get_receipt_service().create_receipt(
+        permit_id=permit["permit_id"],
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool="receipt-inspect",
+        request_payload={"message": "hello"},
+        response_payload={"message": "world"},
+        ledger_entry_id=None,
+        credits_authorized=Decimal("2"),
+        credits_charged=Decimal("0"),
+        outcome="success",
+        audit_event_id=audit_event.event_id,
+    )
+
+    wallet_list = await client.get(
+        "/v1/receipts",
+        params={
+            "permit_id": permit["permit_id"],
+            "wallet_id": provisioned["agent_wallet_id"],
+            "tool": "receipt-inspect",
+            "outcome": "success",
+        },
+        headers=provisioned["agent_headers"],
+    )
+    assert wallet_list.status_code == 200
+    wallet_payload = wallet_list.json()
+    assert wallet_payload["total"] == 1
+    listed = wallet_payload["receipts"][0]
+    assert listed["receipt_id"] == receipt.receipt_id
+    assert listed["audit_event_id"] == audit_event.event_id
+    assert "ledger_entry_id" in listed
+
+    permit_receipts = await client.get(
+        f"/v1/permits/{permit['permit_id']}/receipts",
+        headers=provisioned["agent_headers"],
+    )
+    assert permit_receipts.status_code == 200
+    assert permit_receipts.json()["receipts"][0]["receipt_id"] == receipt.receipt_id
+
+
+@pytest.mark.anyio
+async def test_wallet_receipt_inspection_rejects_global_queries(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+
+    response = await client.get("/v1/receipts", headers=provisioned["agent_headers"])
+
+    assert response.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_permit_issuer_can_inspect_subject_receipts(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    sponsor_key_resp = await client.post(
+        "/v1/api-keys",
+        json={
+            "wallet_id": provisioned["sponsor_wallet_id"],
+            "key_name": "trust-issuer-inspector",
+            "expires_in_days": 30,
+        },
+        headers=BOOTSTRAP_HEADERS,
+    )
+    assert sponsor_key_resp.status_code == 201
+    sponsor_headers = {"X-API-Key": sponsor_key_resp.json()["api_key"]}
+
+    permit_resp = await client.post(
+        "/v1/permits",
+        json={
+            "issuer_wallet_id": provisioned["sponsor_wallet_id"],
+            "subject_wallet_id": provisioned["agent_wallet_id"],
+            "subject_key_id": provisioned["key_id"],
+            "allowed_tools": ["split-inspect-tool"],
+            "scopes": ["tool:split-inspect-tool:invoke", "billing:charge"],
+            "max_credits": 50,
+            "expires_at": (
+                datetime.now(timezone.utc) + timedelta(minutes=30)
+            ).isoformat(),
+        },
+        headers={**sponsor_headers, "Idempotency-Key": "split-inspect-permit"},
+    )
+    assert permit_resp.status_code == 201
+    permit = permit_resp.json()
+
+    audit_event = await record_audit_event(
+        event="mcp.invoke",
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool="split-inspect-tool",
+        endpoint="/mcp/messages",
+        auth_source="db",
+        ok=True,
+    )
+    receipt = await get_receipt_service().create_receipt(
+        permit_id=permit["permit_id"],
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool="split-inspect-tool",
+        request_payload={"message": "hello"},
+        response_payload={"message": "world"},
+        ledger_entry_id=None,
+        credits_authorized=Decimal("2"),
+        credits_charged=Decimal("0"),
+        outcome="success",
+        audit_event_id=audit_event.event_id,
+    )
+
+    permit_receipts = await client.get(
+        f"/v1/permits/{permit['permit_id']}/receipts",
+        headers=sponsor_headers,
+    )
+    assert permit_receipts.status_code == 200
+    assert permit_receipts.json()["receipts"][0]["receipt_id"] == receipt.receipt_id
+
+    filtered_receipts = await client.get(
+        "/v1/receipts",
+        params={
+            "permit_id": permit["permit_id"],
+            "wallet_id": provisioned["agent_wallet_id"],
+        },
+        headers=sponsor_headers,
+    )
+    assert filtered_receipts.status_code == 200
+    assert filtered_receipts.json()["receipts"][0]["receipt_id"] == receipt.receipt_id
+
+    fetched = await client.get(
+        f"/v1/receipts/{receipt.receipt_id}",
+        headers=sponsor_headers,
+    )
+    assert fetched.status_code == 200
+    assert fetched.json()["receipt_id"] == receipt.receipt_id
+
+    verified = await client.post(
+        "/v1/receipts/verify",
+        json={"receipt_id": receipt.receipt_id},
+        headers=sponsor_headers,
+    )
+    assert verified.status_code == 200
+    assert verified.json()["valid"] is True
+
+    other_wallet = await provision_agent_wallet(client)
+    cross_wallet = await client.get(
+        "/v1/receipts",
+        params={
+            "permit_id": permit["permit_id"],
+            "wallet_id": other_wallet["agent_wallet_id"],
+        },
+        headers=sponsor_headers,
+    )
+    assert cross_wallet.status_code == 403


### PR DESCRIPTION
## Summary
- adds operator inspection APIs for trust permits, receipts, and signing-key metadata
- enforces strict governed MCP trust-mode paths with denial audit/receipt handling and idempotent replay
- ships a one-command trust-plane demo proving permit -> invoke -> ledger -> receipt -> audit -> replay -> denial -> isolation
- updates OpenAPI, docs, CI smoke coverage, and the trust release gate script

## Verification
- `pytest -q` -> 641 passed
- `pytest tests/test_golden_path.py tests/test_mcp_trust.py -q` -> 6 passed
- `pytest tests/test_demo_trust_plane.py tests/test_trust_operator_inspection.py tests/test_mcp_trust_mode.py tests/test_signing_key_lifecycle.py tests/test_trust_mode_guardrails.py -q` -> 33 passed
- `python3.12 scripts/export_openapi.py --check`
- `python3.12 scripts/generate_sim_inventory.py --check`
- `python3.12 scripts/demo_trust_plane.py --assert`

## Note
`scripts/trust_release_gate.sh` is included as the intended aggregate gate. In this local shell, invoking the wrapper exposed inconsistent SQLite state in the first full-suite subprocess, while the exact component commands above pass serially with a clean test DB.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the governed MCP enforcement path (permits, idempotency, billing/receipt emission) and adds new inspection endpoints, so regressions could affect authorization, replay safety, and charging semantics despite added tests and a demo smoke gate.
> 
> **Overview**
> **Expands the trust-plane into an inspectable “trust ledger”.** Adds new read surfaces for operators and wallet keys: list/get permits (plus `revoked_at`), list receipts (global filtered list + per-permit drilldown), and expose public signing-key metadata via `GET /v1/signing-keys/active` and `GET /v1/signing-keys/{key_id}` with key lifecycle support (active/retired).
> 
> **Hardens governed MCP behavior in `mcp/messages`.** Strict trust mode now fails closed in production-like envs via new `app/core/trust_mode.py` guardrails (requires `TRUST_SIGNING_PRIVATE_KEY_B64` and disallows legacy unpermitted MCP). Governed invocations now return structured JSON-RPC/HTTP errors that can include **signed receipts** for denials (e.g., out-of-scope), insufficient funds, and tool failures; idempotency replay re-raises the original error/receipt and avoids double-charging, while audit metadata is enriched with `permit_id`, `idempotency_key`, `request_hash`, and `ledger_entry_id`.
> 
> **Adds an executable demo + gates.** Introduces `scripts/demo_trust_plane.py` (and `make demo-trust-plane*`) to prove permit→invoke→ledger→receipt→audit→replay→denial→isolation, adds a CI smoke step for it, and provides a `scripts/trust_release_gate.sh` wrapper; docs and `docs/openapi.json` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e6c681ed689fa94ecc8af98e4d42cd8d0c3ccca. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->