### PR TITLE
Safety fixes + freeze note

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,10 +1,16 @@
 name: Autonomous PM — Auto-PR Generator
 
-# Runs every 6 hours to check for anomalies and generate fixes
+# DISABLED 2026-05-19: autonomous PR creation is an untrusted-input
+# -> code injection path. Re-enable only with provenance controls
+# and manual approval gates. See repo freeze note in README.
+#
+# Original triggers (disabled, kept for reversibility):
+# on:
+#   schedule:
+#     - cron: "0 * * * *"
+#   workflow_dispatch:  # Allow manual trigger
 on:
-  schedule:
-    - cron: "0 * * * *"
-  workflow_dispatch:  # Allow manual trigger
+  workflow_dispatch:   # manual-only; no automatic triggers
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ Everything else in this repository exists to strengthen that loop or prove it in
 
 **Agent-first:** Autonomous clients are the primary audience. Machine-readable discovery and API contracts matter more than narrative docs. Human hosting concerns are in [Operators (deployment only)](#operators-deployment-only) below.
 
+> ## ⏸️ Project Status: Paused (2026-05-19)
+>
+> This repository is a paused prototype. The core control-plane loop
+> (wallet-scoped billing, API-key auth, MCP discovery/invocation, audit
+> logging) is real and functional. The trust primitives required to
+> position this as infrastructure for autonomous economic actors —
+> signed permits, verifiable signed receipts, replay protection,
+> hardened sandbox isolation — are NOT yet implemented.
+>
+> Development is paused pending a decision on whether to pursue this as
+> a standalone product. No active maintenance. Do not deploy to
+> production.
+
 ### Primary interface (autonomous clients)
 
 Bootstrap in the order given in `GET /.well-known/agent.json` → field `agent_first.bootstrap_sequence`. Minimally:

--- a/app/services/webauthn_provider.py
+++ b/app/services/webauthn_provider.py
@@ -48,7 +48,24 @@ try:
 
     PY_WEBAUTHN_AVAILABLE = True
 except ImportError:
-    pass  # py_webauthn not installed - will use mock verification
+    pass  # py_webauthn not installed - see fail-closed behavior below
+
+
+def _mock_verification_allowed() -> bool:
+    """
+    Whether mock WebAuthn verification is explicitly permitted.
+
+    Defaults to False. Production MUST fail closed when py_webauthn is
+    absent: a security provider that silently degrades to mock
+    verification emits a false "verified" signal, which is worse than
+    having no provider at all. Test config may opt in by setting
+    WEBAUTHN_ALLOW_MOCK=true.
+    """
+    return os.getenv("WEBAUTHN_ALLOW_MOCK", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
 
 class ChallengeStatus(str, Enum):
@@ -611,8 +628,18 @@ class WebAuthnProvider:
             Tuple of (success: bool, new_sign_count: int).
         """
         if not PY_WEBAUTHN_AVAILABLE:
-            logger.warning("py_webauthn not available, using mock verification")
-            return True, 0
+            if _mock_verification_allowed():
+                logger.warning(
+                    "py_webauthn not available; WEBAUTHN_ALLOW_MOCK is set - "
+                    "using MOCK verification (test-only path)"
+                )
+                return True, 0
+            logger.error(
+                "py_webauthn not available and WEBAUTHN_ALLOW_MOCK is not set - "
+                "failing closed: WebAuthn verification cannot succeed without "
+                "the real cryptographic library"
+            )
+            return False, 0
 
         credential_id = credential.get("id", "")
         stored_credential = self._credentials.get(credential_id)

--- a/tests/test_awi_phase9.py
+++ b/tests/test_awi_phase9.py
@@ -25,6 +25,12 @@ from app.services.awi_rag_engine import AWIRAGEngine, SearchResult
 class TestWebAuthnProvider:
     """Tests for WebAuthn/Passkey provider."""
 
+    @pytest.fixture(autouse=True)
+    def _allow_mock_webauthn(self, monkeypatch):
+        # py_webauthn is not installed in CI; production fails closed
+        # without it. Tests explicitly opt into the mock verification path.
+        monkeypatch.setenv("WEBAUTHN_ALLOW_MOCK", "true")
+
     @pytest.fixture
     def provider(self):
         return WebAuthnProvider(


### PR DESCRIPTION
Fail-close WebAuthn, disable auto-PR triggers, mark repo paused. No refactors, no feature work. Repo is being paused per technical review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive authentication behavior and CI automation: environments missing `py_webauthn` will now reject passkey verification unless explicitly opted into mock mode, and the Auto-PR workflow no longer runs on a schedule.
> 
> **Overview**
> **Security hardening + repo freeze controls.** The Auto-PR GitHub Actions workflow is changed to *manual-only* by removing scheduled triggers and adding a warning about untrusted-input/code-injection risk.
> 
> WebAuthn verification now **fails closed** when `py_webauthn` is unavailable, only allowing the previous mock-verification behavior when `WEBAUTHN_ALLOW_MOCK=true` is set; tests are updated to set this env var explicitly. The README adds a prominent *Project Status: Paused* notice and cautions against production deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1141c5e09c7785d78b7efdc3b65bbe08caee09. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->