### PR TITLE
fix: replay governed MCP denials consistently

### DIFF
--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -396,6 +396,14 @@ async def _execute_registered_tool(
                 "request_hash": sha256_hex(request_payload or arguments),
             },
         )
+        await _complete_governed_denial_idempotency(
+            idem=idem,
+            idem_started=idem_started,
+            wallet_id=wallet_id,
+            endpoint=endpoint,
+            idempotency_key=idempotency_key,
+            reason="permit_required",
+        )
         raise PermissionError("permit_required")
     if governed_call and not idempotency_key:
         await _audit_mcp_invocation(
@@ -490,6 +498,15 @@ async def _execute_registered_tool(
                     response_reference=receipt.receipt_id,
                     response_json=_governed_error_payload(reason, receipt_payload),
                     status_code=403,
+                )
+            elif permit_validation.reason:
+                await _complete_governed_denial_idempotency(
+                    idem=idem,
+                    idem_started=idem_started,
+                    wallet_id=wallet_id,
+                    endpoint=endpoint,
+                    idempotency_key=idempotency_key,
+                    reason=permit_validation.reason,
                 )
             raise ToolPermissionDenied(
                 permit_validation.reason or "permit_denied",
@@ -801,6 +818,27 @@ def _governed_error_payload(
         "error": reason,
         "receipt": receipt,
     }
+
+
+async def _complete_governed_denial_idempotency(
+    *,
+    idem: Any,
+    idem_started: bool,
+    wallet_id: str,
+    endpoint: str,
+    idempotency_key: str | None,
+    reason: str,
+) -> None:
+    if not idem_started or not idempotency_key:
+        return
+    await idem.complete(
+        wallet_id=wallet_id,
+        endpoint=endpoint,
+        idempotency_key=idempotency_key,
+        response_reference=None,
+        response_json=_governed_error_payload(reason, None),
+        status_code=403,
+    )
 
 
 def _raise_replayed_error(replay: Any) -> None:

--- a/tests/test_mcp_trust_mode.py
+++ b/tests/test_mcp_trust_mode.py
@@ -117,6 +117,27 @@ async def _assert_denial_audited(
     assert events[0].metadata.get("request_hash")
 
 
+async def _assert_no_tool_debits(
+    *,
+    client: AsyncClient,
+    wallet_id: str,
+    headers: dict[str, str],
+    tool_name: str,
+) -> None:
+    ledger_resp = await client.get(
+        f"/v1/billing/ledger/{wallet_id}",
+        headers=headers,
+    )
+    assert ledger_resp.status_code == 200
+    debits = [
+        entry
+        for entry in ledger_resp.json()["entries"]
+        if entry["service_category"] == "agent_comms"
+        and tool_name in entry["description"]
+    ]
+    assert debits == []
+
+
 @pytest.mark.anyio
 async def test_strict_mode_denies_unpermitted_mcp_invoke_and_audits(
     client,
@@ -147,6 +168,123 @@ async def test_strict_mode_denies_unpermitted_mcp_invoke_and_audits(
         )
     finally:
         registry.unregister_local(tool_name)
+
+
+@pytest.mark.anyio
+async def test_strict_mode_replays_missing_permit_denial_with_idempotency_key(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "strict-replay-missing-permit-tool"
+    calls = {"count": 0}
+    registry = get_service_registry()
+
+    def counted_tool(message: str = "ok") -> dict:
+        calls["count"] += 1
+        return {"message": message}
+
+    registry.register_local(
+        service_id=tool_name,
+        name="Strict Replay Missing Permit Tool",
+        description="Trust mode missing permit replay test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=counted_tool,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    body = _jsonrpc_body(
+        tool_name=tool_name,
+        wallet_id=provisioned["agent_wallet_id"],
+        request_id="strict-missing-permit-replay-call",
+        idempotency_key="strict-missing-permit-replay-idem",
+    )
+    try:
+        first = await client.post(
+            "/mcp/messages",
+            json=body,
+            headers=provisioned["agent_headers"],
+        )
+        replay = await client.post(
+            "/mcp/messages",
+            json=body,
+            headers=provisioned["agent_headers"],
+        )
+    finally:
+        registry.unregister_local(tool_name)
+
+    assert first.status_code == 200
+    assert first.json()["error"]["message"] == "permit_required"
+    assert replay.status_code == 200
+    assert replay.json()["error"]["message"] == "permit_required"
+    assert replay.json()["error"]["message"] != "idempotency_in_progress"
+    assert calls["count"] == 0
+    await _assert_no_tool_debits(
+        client=client,
+        wallet_id=provisioned["agent_wallet_id"],
+        headers=provisioned["agent_headers"],
+        tool_name=tool_name,
+    )
+
+
+@pytest.mark.anyio
+async def test_strict_mode_replays_unknown_permit_denial_with_idempotency_key(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "strict-replay-unknown-permit-tool"
+    calls = {"count": 0}
+    registry = get_service_registry()
+
+    def counted_tool(message: str = "ok") -> dict:
+        calls["count"] += 1
+        return {"message": message}
+
+    registry.register_local(
+        service_id=tool_name,
+        name="Strict Replay Unknown Permit Tool",
+        description="Trust mode unknown permit replay test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=counted_tool,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    body = _jsonrpc_body(
+        tool_name=tool_name,
+        wallet_id=provisioned["agent_wallet_id"],
+        request_id="strict-unknown-permit-replay-call",
+        permit_id="permit-does-not-exist",
+        idempotency_key="strict-unknown-permit-replay-idem",
+    )
+    try:
+        first = await client.post(
+            "/mcp/messages",
+            json=body,
+            headers=provisioned["agent_headers"],
+        )
+        replay = await client.post(
+            "/mcp/messages",
+            json=body,
+            headers=provisioned["agent_headers"],
+        )
+    finally:
+        registry.unregister_local(tool_name)
+
+    assert first.status_code == 200
+    assert first.json()["error"]["message"] == "permit_not_found"
+    assert replay.status_code == 200
+    assert replay.json()["error"]["message"] == "permit_not_found"
+    assert replay.json()["error"]["message"] != "idempotency_in_progress"
+    assert calls["count"] == 0
+    await _assert_no_tool_debits(
+        client=client,
+        wallet_id=provisioned["agent_wallet_id"],
+        headers=provisioned["agent_headers"],
+        tool_name=tool_name,
+    )
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary
- complete idempotency records for strict trust-mode denials without receipts
- replay missing-permit and unknown-permit denials as the original JSON-RPC error instead of idempotency_in_progress
- prove denial replay does not execute tools or create ledger debits

## Verification
- scripts/trust_release_gate.sh
- uv run ruff check app/ tests/ scripts/demo_trust_plane.py
- uv run mypy app/

Follow-up to #100.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts governed-call denial handling around idempotency records; mistakes could cause incorrect replay behavior or mask distinct requests, but changes are localized and covered by new tests.
> 
> **Overview**
> Strict trust-mode governed MCP denials now **complete the idempotency record** even when no signed receipt is produced (e.g., missing permit or unknown permit), so repeat calls with the same `idempotency_key` replay the original JSON-RPC denial.
> 
> Adds regression tests asserting denial replays do **not execute the tool** and do **not create billing ledger debits**, and that the replayed error is the original denial reason rather than `idempotency_in_progress`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08c8eddc303a56a04c975d0e12bf21151022bb3c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->