### PR TITLE
fix: replay governed MCP tool lookup errors

### DIFF
--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -354,11 +354,31 @@ async def _execute_registered_tool(
     if not service:
         service = await registry.get_persistent(tool_name)
     if not service:
-        raise ValueError(f"Tool not found: {tool_name}")
+        reason = f"Tool not found: {tool_name}"
+        await _complete_governed_denial_idempotency(
+            idem=idem,
+            idem_started=idem_started,
+            wallet_id=wallet_id,
+            endpoint=endpoint,
+            idempotency_key=idempotency_key,
+            reason=reason,
+            status_code=400,
+        )
+        raise ValueError(reason)
 
     func = registry.get_local_func(tool_name)
     if not func:
-        raise ValueError(f"Tool not executable: {tool_name}")
+        reason = f"Tool not executable: {tool_name}"
+        await _complete_governed_denial_idempotency(
+            idem=idem,
+            idem_started=idem_started,
+            wallet_id=wallet_id,
+            endpoint=endpoint,
+            idempotency_key=idempotency_key,
+            reason=reason,
+            status_code=400,
+        )
+        raise ValueError(reason)
 
     category = ServiceCategory(
         service.get("category", ServiceCategory.PLATFORM_FEE.value)
@@ -828,6 +848,7 @@ async def _complete_governed_denial_idempotency(
     endpoint: str,
     idempotency_key: str | None,
     reason: str,
+    status_code: int = 403,
 ) -> None:
     if not idem_started or not idempotency_key:
         return
@@ -837,7 +858,7 @@ async def _complete_governed_denial_idempotency(
         idempotency_key=idempotency_key,
         response_reference=None,
         response_json=_governed_error_payload(reason, None),
-        status_code=403,
+        status_code=status_code,
     )
 
 
@@ -859,6 +880,10 @@ def _raise_replayed_error(replay: Any) -> None:
 def _status_to_jsonrpc_code(status_code: int, reason: str) -> int:
     if status_code == 402 or reason == "insufficient_funds":
         return -32004
+    if reason.startswith("Tool not found"):
+        return -32001
+    if reason.startswith("Tool not executable"):
+        return -32002
     if status_code == 403:
         return -32003
     return -32603

--- a/tests/test_mcp_trust_mode.py
+++ b/tests/test_mcp_trust_mode.py
@@ -288,6 +288,97 @@ async def test_strict_mode_replays_unknown_permit_denial_with_idempotency_key(
 
 
 @pytest.mark.anyio
+async def test_strict_mode_replays_missing_tool_lookup_error_with_idempotency_key(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "strict-missing-lookup-tool"
+    body = _jsonrpc_body(
+        tool_name=tool_name,
+        wallet_id=provisioned["agent_wallet_id"],
+        request_id="strict-missing-lookup-call",
+        idempotency_key="strict-missing-lookup-idem",
+    )
+
+    first = await client.post(
+        "/mcp/messages",
+        json=body,
+        headers=provisioned["agent_headers"],
+    )
+    replay = await client.post(
+        "/mcp/messages",
+        json=body,
+        headers=provisioned["agent_headers"],
+    )
+
+    assert first.status_code == 200
+    assert first.json()["error"]["code"] == -32001
+    assert first.json()["error"]["message"] == f"Tool not found: {tool_name}"
+    assert replay.status_code == 200
+    assert replay.json()["error"]["code"] == -32001
+    assert replay.json()["error"]["message"] == f"Tool not found: {tool_name}"
+    assert replay.json()["error"]["message"] != "idempotency_in_progress"
+    await _assert_no_tool_debits(
+        client=client,
+        wallet_id=provisioned["agent_wallet_id"],
+        headers=provisioned["agent_headers"],
+        tool_name=tool_name,
+    )
+
+
+@pytest.mark.anyio
+async def test_strict_mode_replays_non_executable_tool_error_with_idempotency_key(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    provisioned = await provision_agent_wallet(client)
+    registry = get_service_registry()
+    service = await registry.register_persistent(
+        owner_key="test-key",
+        name="Strict Non Executable Lookup Tool",
+        description="Persistent service without local executable function",
+        category=ServiceCategory.AGENT_COMMS,
+        credits_per_unit=2.0,
+        owner_wallet_id=provisioned["agent_wallet_id"],
+    )
+    tool_name = service["service_id"]
+    body = _jsonrpc_body(
+        tool_name=tool_name,
+        wallet_id=provisioned["agent_wallet_id"],
+        request_id="strict-non-executable-lookup-call",
+        idempotency_key="strict-non-executable-lookup-idem",
+    )
+
+    first = await client.post(
+        "/mcp/messages",
+        json=body,
+        headers=provisioned["agent_headers"],
+    )
+    replay = await client.post(
+        "/mcp/messages",
+        json=body,
+        headers=provisioned["agent_headers"],
+    )
+
+    assert first.status_code == 200
+    assert first.json()["error"]["code"] == -32002
+    assert first.json()["error"]["message"] == f"Tool not executable: {tool_name}"
+    assert replay.status_code == 200
+    assert replay.json()["error"]["code"] == -32002
+    assert replay.json()["error"]["message"] == f"Tool not executable: {tool_name}"
+    assert replay.json()["error"]["message"] != "idempotency_in_progress"
+    await _assert_no_tool_debits(
+        client=client,
+        wallet_id=provisioned["agent_wallet_id"],
+        headers=provisioned["agent_headers"],
+        tool_name=tool_name,
+    )
+
+
+@pytest.mark.anyio
 async def test_strict_mode_denies_missing_idempotency_and_audits(
     client,
     clean_database,


### PR DESCRIPTION
## Summary
- complete governed idempotency records when a strict-mode MCP tool is missing or not executable
- replay those lookup failures as the original JSON-RPC error instead of idempotency_in_progress
- add tests proving no tool debit is created for replayed lookup failures

## Verification
- uv run pytest tests/test_mcp_trust_mode.py -q --tb=short
- uv run ruff check app/routers/mcp.py tests/test_mcp_trust_mode.py

Follow-up hardening after #102.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches governed MCP idempotency completion and error-code mapping, which can affect strict-mode request replay behavior and client-visible JSON-RPC errors. Scope is small but sits on the invocation/billing path, so regressions could change how failures are cached/replayed.
> 
> **Overview**
> In strict trust mode, tool lookup failures (missing tool or no local executable) now **complete the governed idempotency record** instead of leaving the key in-progress, so retries replay the original failure.
> 
> `_complete_governed_denial_idempotency` now accepts a `status_code` (used as `400` for lookup errors), and replayed governed errors map these lookup reasons to JSON-RPC codes `-32001` (not found) and `-32002` (not executable). New tests assert both first-call and replay responses return the same codes/messages and that no tool debits are created.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea86a8cf52207f220165f7af086c8e09a1186620. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->