### PR TITLE
feat: add agent ops war room demo

### DIFF
--- a/DEMO_SCRIPT.md
+++ b/DEMO_SCRIPT.md
@@ -41,6 +41,19 @@ For CI or pre-merge verification:
 make demo-trust-plane-check
 ```
 
+For an operator-facing timeline that is easier to narrate in a live design
+partner walkthrough:
+
+```bash
+make agent-ops-war-room
+```
+
+For machine-readable verification of the same war-room flow:
+
+```bash
+make agent-ops-war-room-check
+```
+
 The proof artifact shape is captured in
 [`docs/demo-trust-plane-output.md`](docs/demo-trust-plane-output.md). Use the
 live demo flow below when walking a partner through the product story.

--- a/DESIGN_PARTNER_GUIDE.md
+++ b/DESIGN_PARTNER_GUIDE.md
@@ -27,6 +27,12 @@ Run the focused one-command proof first:
 make demo-trust-plane
 ```
 
+If the partner wants the operator narrative instead of the compact proof, run:
+
+```bash
+make agent-ops-war-room
+```
+
 Then walk the partner through the live flow:
 
 1. Create a sponsor wallet.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: demo-trust-plane demo-trust-plane-check trust-release-gate
+.PHONY: demo-trust-plane demo-trust-plane-check agent-ops-war-room agent-ops-war-room-check trust-release-gate
 
 demo-trust-plane:
 	uv run python scripts/demo_trust_plane.py
 
 demo-trust-plane-check:
 	uv run python scripts/demo_trust_plane.py --assert
+
+agent-ops-war-room:
+	uv run python scripts/agent_ops_war_room_demo.py
+
+agent-ops-war-room-check:
+	uv run python scripts/agent_ops_war_room_demo.py --assert --json
 
 trust-release-gate:
 	scripts/trust_release_gate.sh

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ idempotent replay, and denies an out-of-scope tool with a denial receipt. The
 sample proof artifact is in
 [`docs/demo-trust-plane-output.md`](docs/demo-trust-plane-output.md).
 
+For an operator-style walkthrough that prints the full control-plane timeline:
+
+```bash
+make agent-ops-war-room
+```
+
+That proof walks discovery, bounded authority, governed MCP invocation, receipt
+verification, ledger inspection, audit-chain verification, replay safety, and
+out-of-scope denial in one run.
+
 **Agent-first:** Autonomous clients are the primary audience. Machine-readable discovery and API contracts matter more than narrative docs. Human hosting concerns are in [Operators (deployment only)](#operators-deployment-only) below.
 
 ### Primary interface (autonomous clients)

--- a/scripts/agent_ops_war_room_demo.py
+++ b/scripts/agent_ops_war_room_demo.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""One-command Agent Ops War Room proof.
+
+Runs the real FastAPI app in-process and prints an operator timeline for a
+wallet-scoped MCP invocation: discovery, authority, receipt, replay safety,
+ledger/audit evidence, audit-chain verification, and out-of-scope denial.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import argparse
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+ALLOWED_TOOL = "war-room-echo"
+DENIED_TOOL = "war-room-denied"
+SIGNING_PRIVATE_KEY_B64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _line(emit: bool, message: str) -> None:
+    if emit:
+        print(f"[war-room] {message}")
+
+
+async def _get_json(
+    client: httpx.AsyncClient,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    response = await client.get(path, headers=headers)
+    _require(
+        response.status_code == 200,
+        f"GET {path} returned {response.status_code}: {response.text}",
+    )
+    return response.json()
+
+
+async def _post_json(
+    client: httpx.AsyncClient,
+    path: str,
+    *,
+    json_body: dict[str, Any],
+    headers: dict[str, str],
+    expected_status: int = 200,
+) -> dict[str, Any]:
+    response = await client.post(path, json=json_body, headers=headers)
+    _require(
+        response.status_code == expected_status,
+        f"POST {path} returned {response.status_code}: {response.text}",
+    )
+    return response.json()
+
+
+def _jsonrpc_result(payload: dict[str, Any]) -> dict[str, Any]:
+    _require("result" in payload, f"expected JSON-RPC result, got: {payload}")
+    return payload["result"]
+
+
+def _jsonrpc_error(payload: dict[str, Any]) -> dict[str, Any]:
+    _require("error" in payload, f"expected JSON-RPC error, got: {payload}")
+    return payload["error"]
+
+
+def _matching_echo_debits(ledger: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        entry
+        for entry in ledger["entries"]
+        if entry["service_category"] == "agent_comms"
+        and ALLOWED_TOOL in entry.get("description", "")
+    ]
+
+
+def _mcp_call(
+    *,
+    request_id: str,
+    tool: str,
+    wallet_id: str,
+    permit_id: str,
+    idempotency_key: str,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": tool,
+            "arguments": arguments or {},
+            "mcpContext": {
+                "wallet_id": wallet_id,
+                "permit_id": permit_id,
+                "idempotency_key": idempotency_key,
+            },
+        },
+    }
+
+
+def _register_war_room_tools() -> None:
+    from app.schemas.billing import ServiceCategory
+    from app.services.service_registry import get_service_registry
+
+    registry = get_service_registry()
+
+    def echo(message: str = "ready") -> dict[str, Any]:
+        return {"message": message, "controlled": True}
+
+    def denied() -> dict[str, Any]:
+        return {"should_not_execute": True}
+
+    registry.register_local(
+        service_id=ALLOWED_TOOL,
+        name="War Room Echo",
+        description="Governed MCP demo tool allowed by the signed permit",
+        category=ServiceCategory.AGENT_COMMS,
+        func=echo,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+    registry.register_local(
+        service_id=DENIED_TOOL,
+        name="War Room Denied",
+        description="Governed MCP demo tool intentionally outside permit scope",
+        category=ServiceCategory.AGENT_COMMS,
+        func=denied,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+
+
+def _unregister_war_room_tools() -> None:
+    from app.services.service_registry import get_service_registry
+
+    registry = get_service_registry()
+    registry.unregister_local(ALLOWED_TOOL)
+    registry.unregister_local(DENIED_TOOL)
+
+
+async def run_war_room(
+    *,
+    client: httpx.AsyncClient,
+    bootstrap_api_key: str,
+    emit: bool = True,
+) -> dict[str, Any]:
+    """Run the Agent Ops proof against an existing in-process client."""
+
+    bootstrap_headers = {"X-API-Key": bootstrap_api_key}
+    result: dict[str, Any] = {"status": "running"}
+
+    _register_war_room_tools()
+    try:
+        _line(emit, "discover platform surfaces")
+        agent_manifest = await _get_json(client, "/.well-known/agent.json")
+        tools_manifest = await _get_json(client, "/mcp/tools.json")
+        openapi = await _get_json(client, "/openapi.json")
+        _require(
+            any(tool["name"] == ALLOWED_TOOL for tool in tools_manifest["tools"]),
+            "war-room-echo missing from MCP tools discovery",
+        )
+
+        _line(emit, "create sponsor wallet")
+        sponsor = await _post_json(
+            client,
+            "/v1/billing/wallets/sponsor",
+            headers=bootstrap_headers,
+            expected_status=201,
+            json_body={
+                "sponsor_name": "War Room Sponsor",
+                "email": "war-room@example.com",
+                "initial_credits": 10000,
+                "require_kyc": False,
+            },
+        )
+
+        _line(emit, "create agent wallet")
+        agent = await _post_json(
+            client,
+            "/v1/billing/wallets/agent",
+            headers=bootstrap_headers,
+            expected_status=201,
+            json_body={
+                "sponsor_wallet_id": sponsor["wallet_id"],
+                "agent_id": "war-room-agent",
+                "budget_credits": 1000,
+                "daily_limit": 500,
+            },
+        )
+        wallet_id = agent["wallet_id"]
+
+        _line(emit, "mint wallet-scoped agent API key")
+        key = await _post_json(
+            client,
+            "/v1/api-keys",
+            headers=bootstrap_headers,
+            expected_status=201,
+            json_body={
+                "wallet_id": wallet_id,
+                "key_name": "war-room-runtime",
+                "expires_in_days": 30,
+            },
+        )
+        agent_headers = {"X-API-Key": key["api_key"]}
+
+        _line(emit, "issue signed permit scoped to war-room-echo")
+        expires_at = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
+        permit = await _post_json(
+            client,
+            "/v1/permits",
+            headers={**bootstrap_headers, "Idempotency-Key": "war-room-permit-1"},
+            expected_status=201,
+            json_body={
+                "issuer_wallet_id": wallet_id,
+                "subject_wallet_id": wallet_id,
+                "subject_key_id": key["key_id"],
+                "allowed_tools": [ALLOWED_TOOL],
+                "scopes": [f"tool:{ALLOWED_TOOL}:invoke", "billing:charge"],
+                "max_credits": 25,
+                "expires_at": expires_at,
+            },
+        )
+
+        _line(emit, "invoke governed MCP tool")
+        invoke_body = _mcp_call(
+            request_id="war-room-call-1",
+            tool=ALLOWED_TOOL,
+            wallet_id=wallet_id,
+            permit_id=permit["permit_id"],
+            idempotency_key="war-room-invoke-1",
+            arguments={"message": "operator timeline"},
+        )
+        invoke_payload = await _post_json(
+            client,
+            "/mcp/messages",
+            headers=agent_headers,
+            json_body=invoke_body,
+        )
+        invoke_result = _jsonrpc_result(invoke_payload)
+        receipt = invoke_result["receipt"]
+        _require(receipt["outcome"] == "success", f"unexpected receipt: {receipt}")
+        _require(receipt["ledger_entry_id"], "success receipt missing ledger entry")
+
+        _line(emit, "replay same request and confirm same receipt")
+        replay_payload = await _post_json(
+            client,
+            "/mcp/messages",
+            headers=agent_headers,
+            json_body=invoke_body,
+        )
+        replay_receipt = _jsonrpc_result(replay_payload)["receipt"]
+        same_receipt = replay_receipt["receipt_id"] == receipt["receipt_id"]
+        _require(same_receipt, "replay did not return original receipt")
+
+        _line(emit, "inspect ledger for exactly one echo debit")
+        ledger_payload = await _get_json(
+            client,
+            f"/v1/billing/ledger/{wallet_id}",
+            headers=agent_headers,
+        )
+        echo_debits = _matching_echo_debits(ledger_payload)
+        _require(len(echo_debits) == 1, f"expected one echo debit, got {echo_debits}")
+
+        _line(emit, "verify signed receipt")
+        receipt_verify = await _post_json(
+            client,
+            "/v1/receipts/verify",
+            headers=agent_headers,
+            json_body={"receipt_id": receipt["receipt_id"]},
+        )
+        _require(receipt_verify["valid"] is True, f"receipt invalid: {receipt_verify}")
+
+        _line(emit, "agent inspects its own trust ledger")
+        self_permits = await _get_json(
+            client,
+            "/v1/me/permits?status=active",
+            headers=agent_headers,
+        )
+        _require(
+            any(row["permit_id"] == permit["permit_id"] for row in self_permits["permits"]),
+            f"self permit inspection missed permit: {self_permits}",
+        )
+        self_receipts = await _get_json(
+            client,
+            f"/v1/me/receipts?permit_id={permit['permit_id']}",
+            headers=agent_headers,
+        )
+        _require(
+            any(row["receipt_id"] == receipt["receipt_id"] for row in self_receipts["receipts"]),
+            f"self receipt inspection missed receipt: {self_receipts}",
+        )
+
+        _line(emit, "fetch audit events for wallet and tool")
+        audit_events = await _get_json(
+            client,
+            f"/v1/audit/events?wallet_id={wallet_id}&tool={ALLOWED_TOOL}",
+            headers=agent_headers,
+        )
+        _require(audit_events["total"] >= 1, f"missing audit events: {audit_events}")
+
+        _line(emit, "verify audit chain")
+        audit_chain = await _post_json(
+            client,
+            "/v1/audit/verify-chain",
+            headers=agent_headers,
+            json_body={"wallet_id": wallet_id},
+        )
+        _require(audit_chain["valid"] is True, f"audit chain invalid: {audit_chain}")
+        self_audit = await _get_json(
+            client,
+            f"/v1/me/audit/events?tool={ALLOWED_TOOL}",
+            headers=agent_headers,
+        )
+        _require(self_audit["total"] >= 1, f"missing self audit events: {self_audit}")
+
+        _line(emit, "attempt out-of-scope tool with same permit")
+        denial_body = _mcp_call(
+            request_id="war-room-denial-1",
+            tool=DENIED_TOOL,
+            wallet_id=wallet_id,
+            permit_id=permit["permit_id"],
+            idempotency_key="war-room-denial-1",
+        )
+        denial_payload = await _post_json(
+            client,
+            "/mcp/messages",
+            headers=agent_headers,
+            json_body=denial_body,
+        )
+        denial_error = _jsonrpc_error(denial_payload)
+        _require(
+            denial_error["message"] == "permit_tool_not_allowed",
+            f"unexpected denial: {denial_error}",
+        )
+
+        ledger_after_denial = await _get_json(
+            client,
+            f"/v1/billing/ledger/{wallet_id}",
+            headers=agent_headers,
+        )
+        debits_after_denial = len(_matching_echo_debits(ledger_after_denial))
+        _require(
+            debits_after_denial == len(echo_debits),
+            "replay or denial created an extra echo debit",
+        )
+
+        result = {
+            "status": "pass",
+            "discovery": {
+                "agent_manifest": agent_manifest.get("name")
+                or agent_manifest.get("service"),
+                "tools_seen": len(tools_manifest["tools"]),
+                "openapi_title": openapi["info"]["title"],
+            },
+            "sponsor": {"wallet_id": sponsor["wallet_id"]},
+            "agent": {
+                "wallet_id": f"wallet-{wallet_id}",
+                "runtime_wallet_id": wallet_id,
+                "key_id": key["key_id"],
+            },
+            "permit": {
+                "permit_id": permit["permit_id"],
+                "allowed_tools": permit["allowed_tools"],
+                "expires_at": permit["expires_at"],
+            },
+            "invoke": {
+                "receipt": receipt,
+                "ledger_entry_id": receipt["ledger_entry_id"],
+            },
+            "replay": {
+                "same_receipt": same_receipt,
+                "receipt_id": replay_receipt["receipt_id"],
+            },
+            "ledger": {
+                "matching_debits": len(echo_debits),
+                "entry_ids": [entry["entry_id"] for entry in echo_debits],
+            },
+            "receipt": {
+                "valid": receipt_verify["valid"],
+                "reason": receipt_verify["reason"],
+            },
+            "self_inspection": {
+                "permits": self_permits["total"],
+                "receipts": self_receipts["total"],
+                "audit_events": self_audit["total"],
+            },
+            "audit": {
+                "events": audit_events["total"],
+                "chain": audit_chain,
+            },
+            "denial": {
+                "reason": denial_error["message"],
+                "receipt": denial_error.get("data", {}).get("receipt"),
+                "ledger_debits_after": debits_after_denial,
+            },
+        }
+        _line(emit, "control-plane loop proved")
+        return result
+    finally:
+        _unregister_war_room_tools()
+
+
+def _configure_local_environment(
+    *,
+    database_url: str,
+    bootstrap_api_key: str,
+) -> None:
+    os.environ["DATABASE_URL"] = database_url
+    os.environ["VALID_API_KEYS"] = bootstrap_api_key
+    os.environ["TRUST_MODE_ENABLED"] = "true"
+    os.environ["ALLOW_LEGACY_UNPERMITTED_MCP"] = "false"
+    os.environ["TRUST_SIGNING_KEY_ID"] = "war-room-ed25519"
+    os.environ["TRUST_SIGNING_PRIVATE_KEY_B64"] = SIGNING_PRIVATE_KEY_B64
+
+    from app.core.config import get_settings
+
+    get_settings.cache_clear()
+
+
+async def run_in_process(
+    *,
+    database_url: str | None = None,
+    bootstrap_api_key: str = "war-room-bootstrap-key",
+    emit: bool = True,
+) -> dict[str, Any]:
+    """Run the demo against the local FastAPI app using ASGITransport."""
+
+    async def run_with_database(db_url: str) -> dict[str, Any]:
+        _configure_local_environment(
+            database_url=db_url,
+            bootstrap_api_key=bootstrap_api_key,
+        )
+
+        from app.db.database import close_db, init_db
+        from app.main import app
+
+        await close_db()
+        await init_db()
+        try:
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(
+                transport=transport,
+                base_url="http://war-room.local",
+            ) as client:
+                result = await run_war_room(
+                    client=client,
+                    bootstrap_api_key=bootstrap_api_key,
+                    emit=emit,
+                )
+            if emit:
+                print("AGENT OPS WAR ROOM: PASS")
+            return result
+        finally:
+            await close_db()
+
+    if database_url:
+        return await run_with_database(database_url)
+
+    with tempfile.TemporaryDirectory(prefix="agent-ops-war-room-") as tmpdir:
+        db_path = Path(tmpdir) / "war-room.db"
+        return await run_with_database(f"sqlite+aiosqlite:///{db_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the Agent Ops War Room trust-plane proof."
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print only the machine-readable proof artifact.",
+    )
+    parser.add_argument(
+        "--assert",
+        dest="assert_mode",
+        action="store_true",
+        help="Compatibility flag for CI; failures already raise AssertionError.",
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="Optional SQLAlchemy async database URL. Defaults to a temp SQLite DB.",
+    )
+    parser.add_argument(
+        "--bootstrap-api-key",
+        default="war-room-bootstrap-key",
+        help="Bootstrap API key used to create the proof wallets and key.",
+    )
+    args = parser.parse_args()
+
+    result = asyncio.run(
+        run_in_process(
+            database_url=args.database_url,
+            bootstrap_api_key=args.bootstrap_api_key,
+            emit=not args.json,
+        )
+    )
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_ops_war_room_demo.py
+++ b/tests/test_agent_ops_war_room_demo.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+)
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+from app.routers import mcp as mcp_router
+from app.services.signing_keys import get_signing_key_service
+from scripts.agent_ops_war_room_demo import run_war_room
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def strict_trust_mode(monkeypatch):
+    raw_private_key = Ed25519PrivateKey.generate().private_bytes(
+        Encoding.Raw,
+        PrivateFormat.Raw,
+        NoEncryption(),
+    )
+    monkeypatch.setattr(mcp_router.settings, "TRUST_MODE_ENABLED", True)
+    monkeypatch.setattr(mcp_router.settings, "ALLOW_LEGACY_UNPERMITTED_MCP", False)
+    monkeypatch.setattr(
+        mcp_router.settings,
+        "TRUST_SIGNING_PRIVATE_KEY_B64",
+        base64.b64encode(raw_private_key).decode(),
+    )
+    signing_keys = get_signing_key_service()
+    signing_keys._private_key = None
+
+
+@pytest.mark.anyio
+async def test_agent_ops_war_room_demo_proves_control_plane_loop(
+    client,
+    clean_database,
+    strict_trust_mode,
+):
+    result = await run_war_room(
+        client=client,
+        bootstrap_api_key="test-key",
+        emit=False,
+    )
+
+    assert result["status"] == "pass"
+    assert result["agent"]["wallet_id"].startswith("wallet-")
+    assert result["permit"]["permit_id"].startswith("permit-")
+    assert result["invoke"]["receipt"]["outcome"] == "success"
+    assert result["replay"]["same_receipt"] is True
+    assert result["ledger"]["matching_debits"] == 1
+    assert result["self_inspection"]["permits"] >= 1
+    assert result["self_inspection"]["receipts"] >= 1
+    assert result["self_inspection"]["audit_events"] >= 1
+    assert result["audit"]["chain"]["valid"] is True
+    assert result["denial"]["reason"] == "permit_tool_not_allowed"
+    assert (
+        result["denial"]["ledger_debits_after"]
+        == result["ledger"]["matching_debits"]
+    )
+
+
+def test_agent_ops_war_room_cli_json_proves_control_plane_loop():
+    result = subprocess.run(
+        [sys.executable, "scripts/agent_ops_war_room_demo.py", "--assert", "--json"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr
+    proof = json.loads(result.stdout)
+    assert proof["status"] == "pass"
+    assert proof["permit"]["permit_id"].startswith("permit-")
+    assert proof["invoke"]["receipt"]["outcome"] == "success"
+    assert proof["replay"]["same_receipt"] is True
+    assert proof["ledger"]["matching_debits"] == 1
+    assert proof["audit"]["chain"]["valid"] is True
+    assert proof["denial"]["reason"] == "permit_tool_not_allowed"


### PR DESCRIPTION
## Summary
- adds `scripts/agent_ops_war_room_demo.py`, an executable operator timeline for the trust plane
- wires Makefile and docs commands for live and machine-readable war-room demos
- proves discovery, permit issuance, governed MCP invoke, replay safety, ledger debit, receipt verification, `/v1/me` self-inspection, audit-chain verification, and out-of-scope denial

## Verification
- `pytest tests/test_agent_ops_war_room_demo.py tests/test_me_trust_ledger.py tests/test_mcp_trust.py -q`
- `python3.12 scripts/agent_ops_war_room_demo.py --json`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new standalone demo script, Makefile targets, and tests/docs updates without changing production request-handling logic.
> 
> **Overview**
> Adds a new one-command **“Agent Ops War Room”** demo (`scripts/agent_ops_war_room_demo.py`) that runs the FastAPI app in-process, registers two local MCP tools, and exercises the trust-plane loop end-to-end (discovery, wallet/key setup, permit issuance, governed MCP call, idempotent replay, ledger/receipt/audit verification, and out-of-scope denial).
> 
> Wires the demo into `Makefile` (`agent-ops-war-room`, plus a JSON/assert check target) and updates `README.md`, `DEMO_SCRIPT.md`, and `DESIGN_PARTNER_GUIDE.md` to document the operator-focused walkthrough. Adds `tests/test_agent_ops_war_room_demo.py` to validate both the in-process runner and CLI JSON artifact output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b3430d863e7d89333a999082e9bd0151b10a72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->