### PR TITLE
ci: add trust core coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
             tests/test_route_auth_inventory.py \
             -v --tb=short
 
+      - name: Run trust-core coverage gate
+        if: matrix.python-version == '3.12'
+        run: scripts/trust_coverage_gate.sh
+
       - name: Run trust-plane demo smoke test
         run: python scripts/demo_trust_plane.py --assert
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: demo-trust-plane demo-trust-plane-check agent-ops-war-room agent-ops-war-room-check trust-release-gate
+.PHONY: demo-trust-plane demo-trust-plane-check agent-ops-war-room agent-ops-war-room-check trust-coverage-gate trust-release-gate
 
 demo-trust-plane:
 	uv run python scripts/demo_trust_plane.py
@@ -11,6 +11,9 @@ agent-ops-war-room:
 
 agent-ops-war-room-check:
 	uv run python scripts/agent_ops_war_room_demo.py --assert --json
+
+trust-coverage-gate:
+	scripts/trust_coverage_gate.sh
 
 trust-release-gate:
 	scripts/trust_release_gate.sh

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ That proof walks discovery, bounded authority, governed MCP invocation, receipt
 verification, ledger inspection, audit-chain verification, replay safety, and
 out-of-scope denial in one run.
 
+To prove the trust core has measurable test coverage before a release:
+
+```bash
+make trust-coverage-gate
+```
+
+The gate enforces at least 80% coverage over the trust-plane control modules:
+governed MCP, permits, receipts, signing-key metadata, idempotency, audit
+verification, trust-mode guardrails, and the wallet self-inspection ledger.
+
 **Agent-first:** Autonomous clients are the primary audience. Machine-readable discovery and API contracts matter more than narrative docs. Human hosting concerns are in [Operators (deployment only)](#operators-deployment-only) below.
 
 ### Primary interface (autonomous clients)

--- a/docs/production-beta-roadmap.md
+++ b/docs/production-beta-roadmap.md
@@ -68,6 +68,8 @@ compete with it in product positioning.
 - `/health`, `/ready`, and preflight checks are documented.
 - Release candidates pass one local release-gate command before tagging:
   `scripts/trust_release_gate.sh`
+- Trust-plane changes pass the focused coverage gate:
+  `scripts/trust_coverage_gate.sh`
 - Production env vars have a complete reference.
 - Migrations upgrade an empty database and the latest known production schema.
 - CI is green on `master`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,6 @@ aiosqlite>=0.22.1      # Async SQLite driver for testing
 # --- Development ---
 pytest>=9.0.3
 pytest-asyncio>=1.3.0
+pytest-cov>=7.1.0
 httpx>=0.28.1           # Also used for test client
 mypy>=2.1.0            # Type checking

--- a/scripts/trust_coverage_gate.sh
+++ b/scripts/trust_coverage_gate.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON:-python3.12}"
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+fi
+
+if [[ -n "${PYTEST:-}" ]]; then
+  PYTEST_CMD=("$PYTEST")
+else
+  PYTEST_CMD=("$PYTHON_BIN" -m pytest)
+fi
+
+TRUST_COVERAGE_TESTS=(
+  tests/test_golden_path.py
+  tests/test_demo_trust_plane.py
+  tests/test_agent_ops_war_room_demo.py
+  tests/test_me_trust_ledger.py
+  tests/test_mcp_trust.py
+  tests/test_mcp_trust_mode.py
+  tests/test_trust_operator_inspection.py
+  tests/test_signing_key_lifecycle.py
+  tests/test_trust_mode_guardrails.py
+  tests/test_permits.py
+  tests/test_receipts.py
+  tests/test_audit_chain.py
+  tests/test_idempotency.py
+)
+
+TRUST_COVERAGE_MODULES=(
+  app.routers.mcp
+  app.routers.permits
+  app.routers.receipts
+  app.routers.keys
+  app.routers.audit
+  app.routers.me
+  app.services.permits
+  app.services.receipts
+  app.services.signing_keys
+  app.services.idempotency
+  app.core.trust_mode
+)
+
+COV_ARGS=()
+for module in "${TRUST_COVERAGE_MODULES[@]}"; do
+  COV_ARGS+=("--cov=$module")
+done
+
+echo "[trust-coverage] enforcing 80% coverage over trust-plane control modules"
+"${PYTEST_CMD[@]}" -q \
+  "${TRUST_COVERAGE_TESTS[@]}" \
+  "${COV_ARGS[@]}" \
+  --cov-report=term-missing \
+  --cov-fail-under=80
+
+echo "[trust-coverage] trust coverage gate passed"

--- a/scripts/trust_release_gate.sh
+++ b/scripts/trust_release_gate.sh
@@ -27,6 +27,9 @@ TRUST_TESTS=(
 echo "[trust-gate] focused trust-plane pytest suite"
 "${PYTEST_CMD[@]}" -q "${TRUST_TESTS[@]}"
 
+echo "[trust-gate] trust-core coverage gate"
+scripts/trust_coverage_gate.sh
+
 echo "[trust-gate] trust-plane demo proof"
 "$PYTHON_BIN" scripts/demo_trust_plane.py --assert
 

--- a/tests/test_permits.py
+++ b/tests/test_permits.py
@@ -1,13 +1,18 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal
 
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from app.db.database import get_session_factory
+from app.db.models import PermitModel
 from app.main import app
 from app.schemas.trust import PermitCreateRequest
 from app.services.idempotency import get_idempotency_service
+from app.services.permits import PermitError, get_permit_service
 from tests.test_trust_helpers import create_tool_permit, provision_agent_wallet
 
 
@@ -102,3 +107,208 @@ async def test_permit_create_rejects_in_progress_idempotency_key(
 
     assert resp.status_code == 409
     assert resp.json()["detail"] == "idempotency_in_progress"
+
+
+@pytest.mark.anyio
+async def test_permit_service_rejects_invalid_issuance_requests(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    service = get_permit_service()
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=30)
+
+    base_request = {
+        "issuer_wallet_id": provisioned["agent_wallet_id"],
+        "subject_wallet_id": provisioned["agent_wallet_id"],
+        "subject_key_id": provisioned["key_id"],
+        "allowed_tools": ["service-issue-tool"],
+        "scopes": ["tool:service-issue-tool:invoke", "billing:charge"],
+        "max_credits": Decimal("10"),
+        "expires_at": expires_at,
+    }
+
+    invalid_cases = [
+        ({**base_request, "max_credits": Decimal("0")}, "max_credits_must_be_positive"),
+        (
+            {**base_request, "expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)},
+            "permit_expired_at_creation",
+        ),
+        ({**base_request, "issuer_wallet_id": "missing-wallet"}, "issuer_wallet_not_found"),
+        ({**base_request, "subject_wallet_id": "missing-wallet"}, "subject_wallet_not_found"),
+        ({**base_request, "max_credits": Decimal("100000")}, "permit_budget_exceeds_wallet_balance"),
+    ]
+
+    for payload, reason in invalid_cases:
+        with pytest.raises(PermitError) as exc_info:
+            await service.create_permit(PermitCreateRequest(**payload))
+        assert exc_info.value.reason == reason
+
+
+@pytest.mark.anyio
+async def test_permit_service_budget_lifecycle_and_filters(client, clean_database):
+    provisioned = await provision_agent_wallet(client)
+    service = get_permit_service()
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=30)
+    permit = await service.create_permit(
+        PermitCreateRequest(
+            issuer_wallet_id=provisioned["agent_wallet_id"],
+            subject_wallet_id=provisioned["agent_wallet_id"],
+            subject_key_id=provisioned["key_id"],
+            allowed_tools=["service-budget-tool"],
+            scopes=["tool:service-budget-tool:invoke"],
+            max_credits=Decimal("10"),
+            expires_at=expires_at.replace(tzinfo=None),
+        )
+    )
+
+    assert "billing:charge" in permit.scopes
+    fetched = await service.get_permit(permit.permit_id)
+    assert fetched and fetched.permit_id == permit.permit_id
+
+    permits, total = await service.list_permits(
+        wallet_id=provisioned["agent_wallet_id"],
+        status="active",
+        subject_key_id=provisioned["key_id"],
+        created_after=datetime.now(timezone.utc) - timedelta(minutes=5),
+        created_before=datetime.now(timezone.utc) + timedelta(minutes=5),
+        expires_after=datetime.now(timezone.utc),
+        expires_before=expires_at + timedelta(minutes=5),
+    )
+    assert total == 1
+    assert permits[0].permit_id == permit.permit_id
+
+    await service.reserve_budget(permit.permit_id, Decimal("4"))
+    validation = await service.validate_for_action(
+        permit_id=permit.permit_id,
+        wallet_id=provisioned["agent_wallet_id"],
+        tool_name="service-budget-tool",
+        estimated_credits=Decimal("7"),
+        key_id=provisioned["key_id"],
+    )
+    assert validation.allowed is False
+    assert validation.reason == "permit_budget_exceeded"
+
+    await service.release_budget(permit.permit_id, Decimal("2"))
+    validation = await service.validate_for_action(
+        permit_id=permit.permit_id,
+        wallet_id=provisioned["agent_wallet_id"],
+        tool_name="service-budget-tool",
+        estimated_credits=Decimal("7"),
+        key_id=provisioned["key_id"],
+    )
+    assert validation.allowed is True
+
+    with pytest.raises(PermitError) as missing_reserve:
+        await service.reserve_budget("permit-missing", Decimal("1"))
+    assert missing_reserve.value.reason == "permit_not_found"
+    await service.release_budget("permit-missing", Decimal("1"))
+
+    revoked = await service.revoke_permit(permit.permit_id)
+    assert revoked.status == "revoked"
+    assert revoked.revoked_at is not None
+    validation = await service.validate_for_action(
+        permit_id=permit.permit_id,
+        wallet_id=provisioned["agent_wallet_id"],
+        tool_name="service-budget-tool",
+        estimated_credits=Decimal("1"),
+        key_id=provisioned["key_id"],
+    )
+    assert validation.allowed is False
+    assert validation.reason == "permit_revoked"
+
+
+@pytest.mark.anyio
+async def test_permit_service_validation_denial_reasons(client, clean_database):
+    provisioned = await provision_agent_wallet(client)
+    other = await provision_agent_wallet(client)
+    service = get_permit_service()
+    permit = await service.create_permit(
+        PermitCreateRequest(
+            issuer_wallet_id=provisioned["agent_wallet_id"],
+            subject_wallet_id=provisioned["agent_wallet_id"],
+            subject_key_id=provisioned["key_id"],
+            allowed_tools=["service-validate-tool"],
+            scopes=["tool:service-validate-tool:invoke", "billing:charge"],
+            max_credits=Decimal("10"),
+            expires_at=datetime.now(timezone.utc) + timedelta(minutes=30),
+        )
+    )
+
+    cases = [
+        {
+            "permit_id": "permit-missing",
+            "wallet_id": provisioned["agent_wallet_id"],
+            "tool_name": "service-validate-tool",
+            "estimated_credits": Decimal("1"),
+            "key_id": provisioned["key_id"],
+            "reason": "permit_not_found",
+        },
+        {
+            "permit_id": permit.permit_id,
+            "wallet_id": other["agent_wallet_id"],
+            "tool_name": "service-validate-tool",
+            "estimated_credits": Decimal("1"),
+            "key_id": provisioned["key_id"],
+            "reason": "permit_wallet_mismatch",
+        },
+        {
+            "permit_id": permit.permit_id,
+            "wallet_id": provisioned["agent_wallet_id"],
+            "tool_name": "service-validate-tool",
+            "estimated_credits": Decimal("1"),
+            "key_id": "wrong-key",
+            "reason": "permit_key_mismatch",
+        },
+        {
+            "permit_id": permit.permit_id,
+            "wallet_id": provisioned["agent_wallet_id"],
+            "tool_name": "other-tool",
+            "estimated_credits": Decimal("1"),
+            "key_id": provisioned["key_id"],
+            "reason": "permit_tool_not_allowed",
+        },
+    ]
+
+    for case in cases:
+        reason = case.pop("reason")
+        validation = await service.validate_for_action(**case)
+        assert validation.allowed is False
+        assert validation.reason == reason
+
+    factory = get_session_factory()
+    async with factory() as session:
+        model = await session.get(PermitModel, permit.permit_id)
+        assert model is not None
+        model.allowed_tools_json = json.dumps([])
+        model.scopes_json = json.dumps(["billing:charge"])
+        session.add(model)
+        await session.commit()
+
+    validation = await service.validate_for_action(
+        permit_id=permit.permit_id,
+        wallet_id=provisioned["agent_wallet_id"],
+        tool_name="service-validate-tool",
+        estimated_credits=Decimal("1"),
+        key_id=provisioned["key_id"],
+    )
+    assert validation.allowed is False
+    assert validation.reason == "permit_scope_missing"
+
+    async with factory() as session:
+        model = await session.get(PermitModel, permit.permit_id)
+        assert model is not None
+        model.scopes_json = json.dumps(["tool:service-validate-tool:invoke", "billing:charge"])
+        model.signature = "tampered"
+        session.add(model)
+        await session.commit()
+
+    validation = await service.validate_for_action(
+        permit_id=permit.permit_id,
+        wallet_id=provisioned["agent_wallet_id"],
+        tool_name="service-validate-tool",
+        estimated_credits=Decimal("1"),
+        key_id=provisioned["key_id"],
+    )
+    assert validation.allowed is False
+    assert validation.reason == "permit_signature_invalid"


### PR DESCRIPTION
## Summary
- add pytest-cov and a focused trust-core coverage gate with an 80% minimum
- wire the gate into Makefile, local trust release gate, and Python 3.12 CI
- add permit-service invariant tests for invalid issuance, budget reserve/release, revocation, denial reasons, scope mismatch, and signature tampering

## Verification
- scripts/trust_coverage_gate.sh -> 85.12% trust-core coverage
- scripts/trust_release_gate.sh
- uv run ruff check app/ tests/ scripts/demo_trust_plane.py scripts/agent_ops_war_room_demo.py
- uv run mypy app/
- uv run pytest -q -> 655 passed, 1 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low runtime risk since changes are CI/scripts/docs/tests only, but it may introduce new CI failures by enforcing an 80% coverage threshold on trust-plane modules.
> 
> **Overview**
> **Adds a trust-core coverage gate** by introducing `scripts/trust_coverage_gate.sh` (runs a focused test subset with `pytest-cov` and fails under 80% coverage) and wiring it into GitHub Actions (Python 3.12 only), the `Makefile` (`make trust-coverage-gate`), and `scripts/trust_release_gate.sh`.
> 
> **Strengthens permit invariants via tests** by expanding `tests/test_permits.py` to exercise `PermitService` validation/issuance failures, budget reserve+release lifecycle, revocation behavior, and denial reasons including scope mismatch and signature tampering.
> 
> Documentation and deps are updated accordingly (`README.md`, `docs/production-beta-roadmap.md`, and `requirements.txt` adds `pytest-cov`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2389171267847e71172e8491f8b3613d9de9fda. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->