### PR TITLE
Add scoped AGENTS.md (app/services + tests)

### DIFF
--- a/app/services/AGENTS.md
+++ b/app/services/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md — Services (trust-critical core)
+
+This directory holds the trust-critical service code: billing/metering, permits, receipts, signing keys, idempotency, audit, governance, auth, and KYC. Treat everything here as both integrity-critical and security-critical.
+
+## Billing / Metering Integrity
+
+Never change billing, metering, budget, usage, or charge logic without checking:
+
+- idempotency
+- retry behavior
+- double-charge risk
+- tenant isolation
+- budget limits
+- over-budget behavior
+- audit trail
+- receipt linkage
+
+Required tests for billing changes:
+
+- retry does not double-charge
+- over-budget invocation fails
+- invalid tenant cannot access billing records
+- idempotency key prevents duplicate charge
+- usage event links to correct permit/tool/action
+
+## Security
+
+Check:
+
+- authentication
+- authorization
+- tenant isolation
+- delegation scope
+- permit lifecycle
+- revocation
+- replay prevention
+- key handling
+- secret exposure
+- logging of sensitive data
+
+Required tests for security changes:
+
+- unauthorized request fails
+- expired/revoked credential fails
+- permit cannot exceed delegation scope
+- Tenant A cannot access Tenant B data
+- malicious input is rejected

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md — Tests
+
+Tests should verify business-critical behavior, not just happy paths.
+
+Prefer:
+
+- negative-path tests
+- authorization failure tests
+- tenant isolation tests
+- billing/idempotency tests
+- receipt verification tests
+- replay prevention tests
+- malformed input tests
+
+Do not remove tests unless replacing them with equal or better coverage.


### PR DESCRIPTION
## Summary

Adds folder-scoped AGENTS.md guidance to reinforce the root AGENTS.md where the trust-critical code and tests live:

- app/services/AGENTS.md — billing/metering integrity + security rules (idempotency, double-charge, tenant isolation, permits, replay, key handling) with required negative-path tests.
- tests/AGENTS.md — prefer negative-path, authorization, tenant-isolation, idempotency, receipt, replay, and malformed-input tests; do not remove coverage.

Placed at app/services/ (not app/billing or app/security) because the repo organizes trust-critical code in a single flat services directory.

## Type of Change

- [x] docs

## Validation

- [x] Docs-only change; no code paths affected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change adding folder-scoped engineering/test guidance; no runtime logic or security/billing flows are modified.
> 
> **Overview**
> Adds folder-scoped `AGENTS.md` docs in `app/services/` and `tests/` to reinforce expectations for **trust-critical** changes (billing/metering integrity, idempotency, tenant isolation, permits/replay/key handling) and to require/encourage corresponding *negative-path* and isolation-focused test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35e5c499ff574c9bc6cfcc0f2a2bd9d2c4f1b3f9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->