### PR TITLE
Align AWI control plane with research draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ crewai_tools = [CrewAIB2ATool(api_key="...", wallet_id="...")]
 
 - [Production beta roadmap](docs/production-beta-roadmap.md)
 - [Threat model](docs/threat-model.md)
+- [Related work and claim evidence](docs/related-work.md)
 - [Golden-path wallet-scoped agent flow](docs/golden-path.md)
 
 ### Operators (deployment only)

--- a/app/routers/awi.py
+++ b/app/routers/awi.py
@@ -216,7 +216,7 @@ async def human_intervention(
     try:
         await _require_session_access(intervention.session_id, auth)
         manager = get_awi_session_manager()
-        return await manager.human_intervention(intervention)
+        return await manager.human_intervention(intervention, auth=auth)
     except HTTPException:
         raise
     except Exception as e:
@@ -238,16 +238,7 @@ async def list_actions():
     actions = vocabulary.list_all_actions()
 
     return {
-        "actions": [
-            {
-                "action": a.action.value,
-                "category": a.category.value,
-                "description": a.description,
-                "parameters": a.parameters,
-                "estimated_cost": a.estimated_cost,
-            }
-            for a in actions
-        ],
+        "actions": [a.to_public_dict() for a in actions],
         "categories": [c.value for c in AWIActionCategory],
     }
 
@@ -264,15 +255,7 @@ async def list_actions_by_category(category: AWIActionCategory):
 
     return {
         "category": category.value,
-        "actions": [
-            {
-                "action": a.action.value,
-                "description": a.description,
-                "parameters": a.parameters,
-                "estimated_cost": a.estimated_cost,
-            }
-            for a in actions
-        ],
+        "actions": [a.to_public_dict() for a in actions],
     }
 
 

--- a/app/routers/receipts.py
+++ b/app/routers/receipts.py
@@ -1,15 +1,34 @@
 from __future__ import annotations
 
+from dataclasses import asdict
+from decimal import Decimal
+import json
+
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 
 from app.core.auth import AuthContext, get_auth_context
+from app.db.converters import ledger_entry_model_to_schema
+from app.db.database import get_session_factory
+from app.db.models import (
+    ControlPlaneAuditEventModel,
+    LedgerEntryModel,
+    PermitModel,
+)
+from app.schemas.audit import AuditEventResponse
+from app.schemas.billing import LedgerAction
 from app.schemas.trust import (
+    AuditChainVerifyResponse,
+    PermitResponse,
+    ReceiptEvidenceCheck,
+    ReceiptEvidenceResponse,
     ReceiptListResponse,
     ReceiptResponse,
     ReceiptVerifyRequest,
     ReceiptVerifyResponse,
 )
-from app.services.permits import get_permit_service
+from app.services.audit_chain import verify_audit_chain
+from app.services.permits import get_permit_service, permit_model_to_response
 from app.services.receipts import get_receipt_service
 
 router = APIRouter(prefix="/v1/receipts", tags=["Trust Receipts"])
@@ -54,6 +73,135 @@ async def _authorize_receipt_access(
     if permit and auth.wallet_id in {permit.issuer_wallet_id, permit.subject_wallet_id}:
         return
     auth.require_wallet_access(receipt.wallet_id)
+
+
+def _check(
+    name: str,
+    passed: bool,
+    *,
+    reason: str | None = None,
+    details: dict | None = None,
+) -> ReceiptEvidenceCheck:
+    return ReceiptEvidenceCheck(
+        name=name,
+        status="passed" if passed else "failed",
+        reason=None if passed else reason,
+        details=details or {},
+    )
+
+
+def _skipped(
+    name: str,
+    reason: str,
+    *,
+    details: dict | None = None,
+) -> ReceiptEvidenceCheck:
+    return ReceiptEvidenceCheck(
+        name=name,
+        status="skipped",
+        reason=reason,
+        details=details or {},
+    )
+
+
+def _metadata_from_json(value: str | None) -> dict:
+    if not value:
+        return {}
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return decoded if isinstance(decoded, dict) else {}
+
+
+def _audit_event_response(
+    event: ControlPlaneAuditEventModel,
+) -> AuditEventResponse:
+    return AuditEventResponse(
+        event_id=event.event_id,
+        created_at=event.created_at,
+        event=event.event,
+        wallet_id=event.wallet_id,
+        tool=event.tool,
+        endpoint=event.endpoint,
+        auth_source=event.auth_source,
+        key_id=event.key_id,
+        policy_decision_id=event.policy_decision_id,
+        request_id=event.request_id,
+        ok=event.ok,
+        error=event.error,
+        metadata=_metadata_from_json(event.metadata_json),
+        payload_hash=event.payload_hash,
+        previous_hash=event.previous_hash,
+        chain_hash=event.chain_hash,
+        signature=event.signature,
+        signature_key_id=event.signature_key_id,
+    )
+
+
+async def _get_permit_model(
+    *,
+    permit_id: str,
+    receipt_wallet_id: str,
+) -> PermitModel | None:
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(PermitModel).where(
+                PermitModel.permit_id == permit_id,
+                PermitModel.subject_wallet_id == receipt_wallet_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+
+async def _get_audit_event_model(
+    *,
+    audit_event_id: str,
+    receipt_wallet_id: str,
+) -> ControlPlaneAuditEventModel | None:
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(ControlPlaneAuditEventModel).where(
+                ControlPlaneAuditEventModel.event_id == audit_event_id,
+                ControlPlaneAuditEventModel.wallet_id == receipt_wallet_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+
+async def _get_ledger_entry_model(
+    *,
+    ledger_entry_id: str,
+    receipt_wallet_id: str,
+) -> LedgerEntryModel | None:
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(LedgerEntryModel).where(
+                LedgerEntryModel.entry_id == ledger_entry_id,
+                LedgerEntryModel.wallet_id == receipt_wallet_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+
+async def _refund_exists(
+    *,
+    wallet_id: str,
+    ledger_entry_id: str,
+) -> bool:
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(LedgerEntryModel).where(
+                LedgerEntryModel.wallet_id == wallet_id,
+                LedgerEntryModel.action == LedgerAction.REFUND.value,
+                LedgerEntryModel.correlation_id == ledger_entry_id,
+            )
+        )
+        return result.scalar_one_or_none() is not None
 
 
 @router.get("", response_model=ReceiptListResponse)
@@ -126,6 +274,198 @@ async def get_receipt(
         raise HTTPException(status_code=404, detail="receipt_not_found")
     await _authorize_receipt_access(auth=auth, receipt=receipt)
     return receipt
+
+
+@router.get("/{receipt_id}/evidence", response_model=ReceiptEvidenceResponse)
+async def get_receipt_evidence(
+    receipt_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> ReceiptEvidenceResponse:
+    receipt = await get_receipt_service().get_receipt(receipt_id)
+    if not receipt:
+        raise HTTPException(status_code=404, detail="receipt_not_found")
+    await _authorize_receipt_access(auth=auth, receipt=receipt)
+
+    checks: list[ReceiptEvidenceCheck] = [
+        _check(
+            "wallet_access",
+            True,
+            details={
+                "auth_source": auth.source,
+                "auth_wallet_id": auth.wallet_id,
+                "bootstrap_admin": auth.is_bootstrap_admin,
+            },
+        )
+    ]
+
+    receipt_valid, receipt_reason, _ = await get_receipt_service().verify_receipt(
+        receipt_id
+    )
+    checks.append(_check("receipt_signature", receipt_valid, reason=receipt_reason))
+
+    permit: PermitResponse | None = None
+    permit_model = await _get_permit_model(
+        permit_id=receipt.permit_id,
+        receipt_wallet_id=receipt.wallet_id,
+    )
+    if not permit_model:
+        checks.append(_check("permit_exists", False, reason="permit_not_found"))
+    else:
+        permit = permit_model_to_response(permit_model)
+        checks.append(_check("permit_exists", True))
+        permit_signature_ok = await get_permit_service().verify_signature(permit_model)
+        checks.append(
+            _check(
+                "permit_signature",
+                permit_signature_ok,
+                reason="permit_signature_invalid",
+            )
+        )
+        checks.append(
+            _check(
+                "permit_wallet_binding",
+                permit.subject_wallet_id == receipt.wallet_id,
+                reason="permit_subject_wallet_mismatch",
+                details={
+                    "receipt_wallet_id": receipt.wallet_id,
+                    "permit_subject_wallet_id": permit.subject_wallet_id,
+                },
+            )
+        )
+        tool_allowed = (
+            not permit.allowed_tools or receipt.tool in permit.allowed_tools
+        )
+        required_scope = f"tool:{receipt.tool}:invoke"
+        scope_allowed = (
+            required_scope in permit.scopes and "billing:charge" in permit.scopes
+        )
+        checks.append(
+            _check(
+                "permit_tool_scope",
+                tool_allowed and scope_allowed,
+                reason="permit_scope_or_tool_mismatch",
+                details={
+                    "tool_allowed": tool_allowed,
+                    "required_scope": required_scope,
+                    "scope_allowed": scope_allowed,
+                },
+            )
+        )
+
+    audit_event_payload = None
+    audit_chain_payload = None
+    if not receipt.audit_event_id:
+        checks.append(
+            _check("audit_event_linkage", False, reason="audit_event_id_missing")
+        )
+    else:
+        audit_event = await _get_audit_event_model(
+            audit_event_id=receipt.audit_event_id,
+            receipt_wallet_id=receipt.wallet_id,
+        )
+        if not audit_event:
+            checks.append(
+                _check("audit_event_linkage", False, reason="audit_event_not_found")
+            )
+        else:
+            audit_event_response = _audit_event_response(audit_event)
+            audit_event_payload = audit_event_response.model_dump(mode="json")
+            metadata = audit_event_response.metadata
+            linkage_failures = []
+            if audit_event.wallet_id != receipt.wallet_id:
+                linkage_failures.append("audit_wallet_mismatch")
+            if audit_event.tool != receipt.tool:
+                linkage_failures.append("audit_tool_mismatch")
+            if metadata.get("permit_id") != receipt.permit_id:
+                linkage_failures.append("audit_permit_mismatch")
+            if metadata.get("request_hash") != receipt.request_hash:
+                linkage_failures.append("audit_request_hash_mismatch")
+            if receipt.ledger_entry_id and (
+                metadata.get("ledger_entry_id") != receipt.ledger_entry_id
+            ):
+                linkage_failures.append("audit_ledger_entry_mismatch")
+            checks.append(
+                _check(
+                    "audit_event_linkage",
+                    not linkage_failures,
+                    reason=";".join(linkage_failures) if linkage_failures else None,
+                    details={"audit_event_id": receipt.audit_event_id},
+                )
+            )
+
+            chain = await verify_audit_chain(wallet_id=receipt.wallet_id)
+            audit_chain_payload = AuditChainVerifyResponse(**asdict(chain))
+            checks.append(
+                _check(
+                    "audit_chain",
+                    chain.valid,
+                    reason=chain.reason,
+                    details={
+                        "checked_events": chain.checked_events,
+                        "broken_event_id": chain.broken_event_id,
+                    },
+                )
+            )
+
+    ledger_entry_payload = None
+    if not receipt.ledger_entry_id:
+        if receipt.credits_charged > Decimal("0"):
+            checks.append(
+                _check("ledger_linkage", False, reason="ledger_entry_id_missing")
+            )
+        else:
+            checks.append(
+                _skipped(
+                    "ledger_linkage",
+                    "receipt_has_no_charged_credits",
+                    details={"credits_charged": str(receipt.credits_charged)},
+                )
+            )
+    else:
+        ledger_entry = await _get_ledger_entry_model(
+            ledger_entry_id=receipt.ledger_entry_id,
+            receipt_wallet_id=receipt.wallet_id,
+        )
+        if not ledger_entry:
+            checks.append(_check("ledger_linkage", False, reason="ledger_not_found"))
+        else:
+            ledger_schema = ledger_entry_model_to_schema(ledger_entry)
+            ledger_entry_payload = ledger_schema.model_dump(mode="json")
+            ledger_failures = []
+            if ledger_entry.wallet_id != receipt.wallet_id:
+                ledger_failures.append("ledger_wallet_mismatch")
+            if ledger_entry.action != LedgerAction.DEBIT.value:
+                ledger_failures.append("ledger_action_not_debit")
+            if receipt.credits_charged > Decimal("0"):
+                expected_amount = -receipt.credits_charged
+                if ledger_entry.amount != expected_amount:
+                    ledger_failures.append("ledger_amount_mismatch")
+            elif receipt.outcome == "failed_refunded":
+                refund_found = await _refund_exists(
+                    wallet_id=receipt.wallet_id,
+                    ledger_entry_id=receipt.ledger_entry_id,
+                )
+                if not refund_found:
+                    ledger_failures.append("refund_entry_not_found")
+            checks.append(
+                _check(
+                    "ledger_linkage",
+                    not ledger_failures,
+                    reason=";".join(ledger_failures) if ledger_failures else None,
+                    details={"ledger_entry_id": receipt.ledger_entry_id},
+                )
+            )
+
+    return ReceiptEvidenceResponse(
+        receipt_id=receipt.receipt_id,
+        valid=all(check.status != "failed" for check in checks),
+        checks=checks,
+        receipt=receipt,
+        permit=permit,
+        audit_event=audit_event_payload,
+        audit_chain=audit_chain_payload,
+        ledger_entry=ledger_entry_payload,
+    )
 
 
 @router.post("/verify", response_model=ReceiptVerifyResponse)

--- a/app/routers/well_known.py
+++ b/app/routers/well_known.py
@@ -6,12 +6,15 @@ Standard agent discovery endpoints following common conventions.
 Implements /.well-known/agent.json for agent directory registration.
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
-from typing import Any
 
 from ..core.config import get_settings
+from ..schemas.awi import AWIRepresentationType
+from ..services.awi_action_vocab import get_awi_vocabulary
 
 router = APIRouter(prefix="", tags=["Agent Discovery"])
 
@@ -28,6 +31,7 @@ def get_agent_first_metadata() -> dict[str, Any]:
         "design_principle": "agent_first",
         "bootstrap_sequence": [
             "/.well-known/agent.json",
+            "/.well-known/awi.json",
             "/llm.txt",
             "/mcp/tools.json",
             "/openapi.json",
@@ -146,6 +150,55 @@ def _build_agent_manifest() -> AgentPluginManifest:
     )
 
 
+def build_awi_manifest() -> dict[str, Any]:
+    """Build the AWI-over-MCP discovery manifest."""
+    vocabulary = get_awi_vocabulary()
+    actions = [action.to_public_dict() for action in vocabulary.list_all_actions()]
+
+    return {
+        "schema_version": "0.1.0",
+        "awi_version": "0.1.0-draft",
+        "status": "draft",
+        "profile": "awi-over-mcp",
+        "transport": {
+            "primary": "http",
+            "mcp_compatible": True,
+            "mcp_manifest": "/.well-known/mcp/tools.json",
+        },
+        "description": (
+            "Agentic Web Interface semantics exposed through the existing "
+            "governed MCP/HTTP control plane."
+        ),
+        "endpoints": {
+            "sessions": "/v1/awi/sessions",
+            "execute": "/v1/awi/execute",
+            "represent": "/v1/awi/represent",
+            "intervene": "/v1/awi/intervene",
+            "vocabulary": "/v1/awi/vocabulary",
+            "queue_status": "/v1/awi/queue/status",
+            "audit_events": "/v1/audit/events",
+            "audit_chain_verification": "/v1/audit/verify-chain",
+            "openapi": "/openapi.json",
+        },
+        "representation_types": [item.value for item in AWIRepresentationType],
+        "actions": actions,
+        "safety_capabilities": {
+            "wallet_scoped_authorization": True,
+            "human_intervention": ["pause", "resume", "steer"],
+            "passkey_high_risk_actions": True,
+            "signed_permits": True,
+            "tamper_evident_audit_chain": True,
+            "sensitive_parameter_redaction": True,
+        },
+        "known_limitations": [
+            "This is an AWI semantics profile over MCP/HTTP, not a standalone AWI wire standard.",
+            "The login action is provisional; credential_handle is preferred over plaintext credentials.",
+            "click_button and scroll are compatibility actions, not pure semantic actions.",
+            "Representation efficiency benchmarks are local and deterministic until external WebArena-style evaluation is added.",
+        ],
+    }
+
+
 @router.get(
     "/.well-known/agent.json",
     summary="Agent Plugin Manifest",
@@ -170,6 +223,19 @@ async def get_agent_json(request: Request):
         content=manifest.model_dump(mode="json"),
         media_type="application/json",
     )
+
+
+@router.get(
+    "/.well-known/awi.json",
+    summary="AWI Discovery Manifest",
+    description=(
+        "Returns the draft AWI-over-MCP manifest with action vocabulary, "
+        "representation types, endpoints, safety capabilities, and known limits."
+    ),
+)
+async def get_awi_json():
+    """Serve the draft AWI-over-MCP manifest."""
+    return JSONResponse(content=build_awi_manifest(), media_type="application/json")
 
 
 @router.get(

--- a/app/routers/well_known.py
+++ b/app/routers/well_known.py
@@ -13,7 +13,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
 from ..core.config import get_settings
-from ..schemas.awi import AWIRepresentationType
+from ..schemas.awi import AWIDiscoveryManifest, AWIRepresentationType
 from ..services.awi_action_vocab import get_awi_vocabulary
 
 router = APIRouter(prefix="", tags=["Agent Discovery"])
@@ -227,6 +227,7 @@ async def get_agent_json(request: Request):
 
 @router.get(
     "/.well-known/awi.json",
+    response_model=AWIDiscoveryManifest,
     summary="AWI Discovery Manifest",
     description=(
         "Returns the draft AWI-over-MCP manifest with action vocabulary, "

--- a/app/schemas/awi.py
+++ b/app/schemas/awi.py
@@ -68,6 +68,29 @@ class AWIStandardAction(str, Enum):
     GET_REPRESENTATION = "get_representation"
 
 
+class AWIActionTier(str, Enum):
+    """How directly an action expresses AWI semantic intent."""
+
+    SEMANTIC = "semantic"
+    COMPATIBILITY = "compatibility"
+
+
+class AWIActionStatus(str, Enum):
+    """Maturity status for AWI action contracts."""
+
+    STABLE = "stable"
+    PROVISIONAL = "provisional"
+    DEPRECATED = "deprecated"
+
+
+class AWIActionRiskLevel(str, Enum):
+    """Risk level for policy and human-approval decisions."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
 class AWISessionCreate(BaseModel):
     """Request to create an AWI session."""
 

--- a/app/schemas/awi.py
+++ b/app/schemas/awi.py
@@ -91,6 +91,57 @@ class AWIActionRiskLevel(str, Enum):
     HIGH = "high"
 
 
+class AWIActionDefinitionResponse(BaseModel):
+    """Public action vocabulary entry exposed by AWI discovery surfaces."""
+
+    action: AWIStandardAction
+    category: AWIActionCategory
+    description: str
+    parameters: dict[str, dict[str, Any]]
+    required_preconditions: list[str]
+    postconditions: list[str]
+    estimated_cost: float
+    tier: AWIActionTier
+    status: AWIActionStatus
+    risk_level: AWIActionRiskLevel
+    sensitive_parameters: list[str] = Field(default_factory=list)
+
+
+class AWIManifestTransport(BaseModel):
+    """Transport metadata for the AWI discovery manifest."""
+
+    primary: str
+    mcp_compatible: bool
+    mcp_manifest: str
+
+
+class AWIManifestSafetyCapabilities(BaseModel):
+    """Safety capabilities advertised by the AWI discovery manifest."""
+
+    wallet_scoped_authorization: bool
+    human_intervention: list[str]
+    passkey_high_risk_actions: bool
+    signed_permits: bool
+    tamper_evident_audit_chain: bool
+    sensitive_parameter_redaction: bool
+
+
+class AWIDiscoveryManifest(BaseModel):
+    """Draft AWI-over-MCP discovery manifest."""
+
+    schema_version: str
+    awi_version: str
+    status: str
+    profile: str
+    transport: AWIManifestTransport
+    description: str
+    endpoints: dict[str, str]
+    representation_types: list[AWIRepresentationType]
+    actions: list[AWIActionDefinitionResponse]
+    safety_capabilities: AWIManifestSafetyCapabilities
+    known_limitations: list[str]
+
+
 class AWISessionCreate(BaseModel):
     """Request to create an AWI session."""
 

--- a/app/schemas/trust.py
+++ b/app/schemas/trust.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -108,6 +108,24 @@ class AuditChainVerifyResponse(BaseModel):
     last_event_id: str | None = None
     reason: str | None = None
     broken_event_id: str | None = None
+
+
+class ReceiptEvidenceCheck(BaseModel):
+    name: str
+    status: Literal["passed", "failed", "skipped"]
+    reason: str | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class ReceiptEvidenceResponse(BaseModel):
+    receipt_id: str
+    valid: bool
+    checks: list[ReceiptEvidenceCheck]
+    receipt: ReceiptResponse
+    permit: PermitResponse | None = None
+    audit_event: dict[str, Any] | None = None
+    audit_chain: AuditChainVerifyResponse | None = None
+    ledger_entry: dict[str, Any] | None = None
 
 
 class TrustMcpMetadata(BaseModel):

--- a/app/services/awi_action_vocab.py
+++ b/app/services/awi_action_vocab.py
@@ -12,7 +12,13 @@ Provides a unified vocabulary of web actions that abstract away DOM manipulation
 import uuid
 from typing import Any
 
-from ..schemas.awi import AWIStandardAction, AWIActionCategory
+from ..schemas.awi import (
+    AWIActionCategory,
+    AWIActionRiskLevel,
+    AWIActionStatus,
+    AWIActionTier,
+    AWIStandardAction,
+)
 
 
 class AWIActionDefinition:
@@ -27,6 +33,10 @@ class AWIActionDefinition:
         required_preconditions: list[str],
         postconditions: list[str],
         estimated_cost: float = 0.001,
+        tier: AWIActionTier = AWIActionTier.SEMANTIC,
+        status: AWIActionStatus = AWIActionStatus.STABLE,
+        risk_level: AWIActionRiskLevel = AWIActionRiskLevel.LOW,
+        sensitive_parameters: list[str] | None = None,
     ):
         self.action = action
         self.category = category
@@ -35,6 +45,26 @@ class AWIActionDefinition:
         self.required_preconditions = required_preconditions
         self.postconditions = postconditions
         self.estimated_cost = estimated_cost
+        self.tier = tier
+        self.status = status
+        self.risk_level = risk_level
+        self.sensitive_parameters = sensitive_parameters or []
+
+    def to_public_dict(self) -> dict[str, Any]:
+        """Return the public, transport-safe action definition."""
+        return {
+            "action": self.action.value,
+            "category": self.category.value,
+            "description": self.description,
+            "parameters": self.parameters,
+            "required_preconditions": self.required_preconditions,
+            "postconditions": self.postconditions,
+            "estimated_cost": self.estimated_cost,
+            "tier": self.tier.value,
+            "status": self.status.value,
+            "risk_level": self.risk_level.value,
+            "sensitive_parameters": self.sensitive_parameters,
+        }
 
 
 class AWIActionVocabulary:
@@ -79,6 +109,7 @@ class AWIActionVocabulary:
                 required_preconditions=["item_visible", "cart_accessible"],
                 postconditions=["item_in_cart"],
                 estimated_cost=0.001,
+                risk_level=AWIActionRiskLevel.MEDIUM,
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.CHECKOUT,
@@ -92,6 +123,8 @@ class AWIActionVocabulary:
                 required_preconditions=["cart_not_empty", "user_authenticated"],
                 postconditions=["order_placed", "payment_processed"],
                 estimated_cost=0.01,
+                risk_level=AWIActionRiskLevel.HIGH,
+                sensitive_parameters=["payment_method"],
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.FILL_FORM,
@@ -105,19 +138,42 @@ class AWIActionVocabulary:
                 required_preconditions=["form_visible"],
                 postconditions=["form_filled", "form_submitted"],
                 estimated_cost=0.001,
+                risk_level=AWIActionRiskLevel.MEDIUM,
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.LOGIN,
                 category=AWIActionCategory.AUTH,
-                description="Authenticate with the target website",
+                description=(
+                    "Authenticate with the target website. Provisional: "
+                    "credential_handle is preferred; username/password remains "
+                    "accepted for v0.1 compatibility and is redacted from durable "
+                    "state."
+                ),
                 parameters={
-                    "username": {"type": "string", "required": True},
-                    "password": {"type": "string", "required": True},
+                    "credential_handle": {
+                        "type": "string",
+                        "required": False,
+                        "preferred": True,
+                    },
+                    "username": {
+                        "type": "string",
+                        "required": False,
+                        "deprecated": True,
+                    },
+                    "password": {
+                        "type": "string",
+                        "required": False,
+                        "deprecated": True,
+                        "sensitive": True,
+                    },
                     "remember_me": {"type": "boolean", "required": False},
                 },
                 required_preconditions=["login_page_visible"],
                 postconditions=["user_authenticated", "session_created"],
                 estimated_cost=0.002,
+                status=AWIActionStatus.PROVISIONAL,
+                risk_level=AWIActionRiskLevel.HIGH,
+                sensitive_parameters=["password"],
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.LOGOUT,
@@ -152,6 +208,7 @@ class AWIActionVocabulary:
                 required_preconditions=["button_visible"],
                 postconditions=["button_clicked"],
                 estimated_cost=0.0005,
+                tier=AWIActionTier.COMPATIBILITY,
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.SCROLL,
@@ -164,6 +221,7 @@ class AWIActionVocabulary:
                 required_preconditions=["page_loaded"],
                 postconditions=["scrolled"],
                 estimated_cost=0.0002,
+                tier=AWIActionTier.COMPATIBILITY,
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.SELECT_OPTION,
@@ -189,6 +247,7 @@ class AWIActionVocabulary:
                 required_preconditions=["upload_input_visible"],
                 postconditions=["file_uploaded"],
                 estimated_cost=0.005,
+                risk_level=AWIActionRiskLevel.MEDIUM,
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.EXTRACT_DATA,
@@ -246,11 +305,55 @@ class AWIActionVocabulary:
         if not action_def:
             return False, f"Unknown action: {action}"
 
+        if action == AWIStandardAction.LOGIN:
+            if params.get("credential_handle"):
+                return True, None
+            missing = [
+                name for name in ("username", "password") if name not in params
+            ]
+            if missing:
+                return (
+                    False,
+                    "Missing required login parameters: credential_handle or "
+                    "username+password",
+                )
+            return True, None
+
         for param_name, param_def in action_def.parameters.items():
             if param_def.get("required", False) and param_name not in params:
                 return False, f"Missing required parameter: {param_name}"
 
         return True, None
+
+    def redact_parameters(
+        self, action: AWIStandardAction, params: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Redact sensitive action parameters before durable storage or response."""
+        action_def = self._actions.get(action)
+        sensitive = {
+            "api_key",
+            "access_token",
+            "credential",
+            "password",
+            "refresh_token",
+            "secret",
+            "token",
+        }
+        if action_def:
+            sensitive.update(name.lower() for name in action_def.sensitive_parameters)
+
+        def redact(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {
+                    key: "[REDACTED]" if key.lower() in sensitive else redact(item)
+                    for key, item in value.items()
+                }
+            if isinstance(value, list):
+                return [redact(item) for item in value]
+            return value
+
+        redacted = redact(params)
+        return redacted if isinstance(redacted, dict) else {}
 
     def check_preconditions(
         self, action: AWIStandardAction, session_state: dict[str, Any]

--- a/app/services/awi_action_vocab.py
+++ b/app/services/awi_action_vocab.py
@@ -9,6 +9,7 @@ Provides a unified vocabulary of web actions that abstract away DOM manipulation
 - Actions can be composed into sequences for complex workflows
 """
 
+import re
 import uuid
 from typing import Any
 
@@ -19,6 +20,12 @@ from ..schemas.awi import (
     AWIActionTier,
     AWIStandardAction,
 )
+
+
+def _normalize_sensitive_key(value: str) -> str:
+    """Normalize parameter keys so redaction catches common casing variants."""
+    snake_case = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", value)
+    return snake_case.replace("-", "_").lower()
 
 
 class AWIActionDefinition:
@@ -159,6 +166,7 @@ class AWIActionVocabulary:
                         "type": "string",
                         "required": False,
                         "deprecated": True,
+                        "sensitive": True,
                     },
                     "password": {
                         "type": "string",
@@ -173,7 +181,7 @@ class AWIActionVocabulary:
                 estimated_cost=0.002,
                 status=AWIActionStatus.PROVISIONAL,
                 risk_level=AWIActionRiskLevel.HIGH,
-                sensitive_parameters=["password"],
+                sensitive_parameters=["username", "password"],
             ),
             AWIActionDefinition(
                 action=AWIStandardAction.LOGOUT,
@@ -340,12 +348,17 @@ class AWIActionVocabulary:
             "token",
         }
         if action_def:
-            sensitive.update(name.lower() for name in action_def.sensitive_parameters)
+            sensitive.update(
+                _normalize_sensitive_key(name)
+                for name in action_def.sensitive_parameters
+            )
 
         def redact(value: Any) -> Any:
             if isinstance(value, dict):
                 return {
-                    key: "[REDACTED]" if key.lower() in sensitive else redact(item)
+                    key: "[REDACTED]"
+                    if _normalize_sensitive_key(key) in sensitive
+                    else redact(item)
                     for key, item in value.items()
                 }
             if isinstance(value, list):

--- a/app/services/awi_session.py
+++ b/app/services/awi_session.py
@@ -493,18 +493,28 @@ class AWISessionManager:
                 intervention.steer_instructions
             )
 
-        await record_audit_event(
-            event="awi.human_intervention",
-            wallet_id=session.wallet_id,
-            tool="awi",
-            endpoint="/v1/awi/intervene",
-            auth_source=getattr(auth, "source", None),
-            key_id=getattr(auth, "key_id", None),
-            request_id=session.session_id,
-            ok=ok,
-            error=error,
-            metadata=metadata,
-        )
+        try:
+            await record_audit_event(
+                event="awi.human_intervention",
+                wallet_id=session.wallet_id,
+                tool="awi",
+                endpoint="/v1/awi/intervene",
+                auth_source=getattr(auth, "source", None),
+                key_id=getattr(auth, "key_id", None),
+                request_id=session.session_id,
+                ok=ok,
+                error=error,
+                metadata=metadata,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to audit AWI human intervention",
+                extra={
+                    "event": "awi.human_intervention",
+                    "session_id": session.session_id,
+                    "wallet_id": session.wallet_id,
+                },
+            )
 
     async def destroy_session(self, session_id: str) -> bool:
         """Destroy an AWI session."""

--- a/app/services/awi_session.py
+++ b/app/services/awi_session.py
@@ -15,6 +15,7 @@ Provides:
 - Phase 9: Playwright DOM bridge routing
 """
 
+import hashlib
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -35,6 +36,7 @@ from ..schemas.awi import (
 from .awi_action_vocab import get_awi_vocabulary
 from .awi_representation import get_awi_representation
 from .awi_playwright_bridge import get_playwright_bridge
+from .audit_log import record_audit_event
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +155,9 @@ class AWISessionManager:
         self, request: AWIExecutionRequest
     ) -> AWIExecutionResponse:
         """Execute an AWI action within a session."""
+        response_parameters = self._vocabulary.redact_parameters(
+            request.action, request.parameters
+        )
         session = await self._load_session(request.session_id)
         if not session:
             return AWIExecutionResponse(
@@ -160,7 +165,7 @@ class AWISessionManager:
                 session_id=request.session_id,
                 action=request.action,
                 status="error",
-                parameters=request.parameters,
+                parameters=response_parameters,
                 error=f"Session not found: {request.session_id}",
             )
 
@@ -170,7 +175,7 @@ class AWISessionManager:
                 session_id=request.session_id,
                 action=request.action,
                 status="paused",
-                parameters=request.parameters,
+                parameters=response_parameters,
                 error="Session is paused by human intervention",
             )
 
@@ -183,7 +188,7 @@ class AWISessionManager:
                 session_id=request.session_id,
                 action=request.action,
                 status="max_steps_reached",
-                parameters=request.parameters,
+                parameters=response_parameters,
                 error="Maximum steps reached",
             )
 
@@ -199,7 +204,7 @@ class AWISessionManager:
                 session_id=request.session_id,
                 action=request.action,
                 status="error",
-                parameters=request.parameters,
+                parameters=response_parameters,
                 error=error,
             )
 
@@ -214,7 +219,7 @@ class AWISessionManager:
                 session_id=request.session_id,
                 action=request.action,
                 status="error",
-                parameters=request.parameters,
+                parameters=response_parameters,
                 error=f"Preconditions not met: {unmet}",
             )
 
@@ -232,7 +237,7 @@ class AWISessionManager:
                     session_id=request.session_id,
                     action=request.action,
                     status="passkey_required",
-                    parameters=request.parameters,
+                    parameters=response_parameters,
                     error="This action requires biometric verification. "
                     "Call POST /v1/awi/passkey/challenge first.",
                 )
@@ -265,7 +270,7 @@ class AWISessionManager:
             {
                 "execution_id": execution_id,
                 "action": request.action.value,
-                "parameters": request.parameters,
+                "parameters": response_parameters,
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "success": result.get("success", True),
             }
@@ -299,7 +304,7 @@ class AWISessionManager:
             session_id=request.session_id,
             action=request.action,
             status="success",
-            parameters=request.parameters,
+            parameters=response_parameters,
             result=result,
             new_state=state,
             representation=representation,
@@ -329,7 +334,10 @@ class AWISessionManager:
 
         elif action == AWIStandardAction.FILL_FORM:
             fields = params.get("fields", {})
-            state["form_data"].update(fields)
+            redacted_fields = self._vocabulary.redact_parameters(
+                AWIStandardAction.FILL_FORM, {"fields": fields}
+            ).get("fields", {})
+            state["form_data"].update(redacted_fields)
             return {"success": True, "fields_filled": len(fields)}
 
         elif action == AWIStandardAction.CLICK_BUTTON:
@@ -377,7 +385,7 @@ class AWISessionManager:
         )
 
     async def human_intervention(
-        self, intervention: AWIHumanIntervention
+        self, intervention: AWIHumanIntervention, auth: Any | None = None
     ) -> dict[str, Any]:
         """Handle human intervention in a session."""
         session = await self._load_session(intervention.session_id)
@@ -390,6 +398,12 @@ class AWISessionManager:
             session.pause_reason = intervention.reason
             session.updated_at = datetime.now(timezone.utc)
             await self._save_session(intervention.session_id)
+            await self._record_human_intervention_audit(
+                session=session,
+                intervention=intervention,
+                status="paused",
+                auth=auth,
+            )
             return {"success": True, "status": "paused"}
 
         elif intervention.action == "resume":
@@ -398,27 +412,99 @@ class AWISessionManager:
             session.pause_reason = None
             session.updated_at = datetime.now(timezone.utc)
             await self._save_session(intervention.session_id)
+            await self._record_human_intervention_audit(
+                session=session,
+                intervention=intervention,
+                status="active",
+                auth=auth,
+            )
             return {"success": True, "status": "active"}
 
         elif intervention.action == "steer":
             if not intervention.steer_instructions:
+                await self._record_human_intervention_audit(
+                    session=session,
+                    intervention=intervention,
+                    status=session.status.value,
+                    auth=auth,
+                    ok=False,
+                    error="missing_steer_instructions",
+                )
                 return {"success": False, "error": "No steering instructions provided"}
+            instructions_hash = self._hash_text(intervention.steer_instructions)
             session.action_history.append(
                 {
                     "type": "human_steer",
-                    "instructions": intervention.steer_instructions,
+                    "instructions_sha256": instructions_hash,
+                    "instructions_length": len(intervention.steer_instructions),
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                 }
             )
             session.updated_at = datetime.now(timezone.utc)
             await self._save_session(intervention.session_id)
+            await self._record_human_intervention_audit(
+                session=session,
+                intervention=intervention,
+                status="steered",
+                auth=auth,
+            )
             return {
                 "success": True,
                 "status": "steered",
-                "instructions_recorded": intervention.steer_instructions,
+                "instructions_recorded": True,
+                "instructions_sha256": instructions_hash,
             }
 
+        await self._record_human_intervention_audit(
+            session=session,
+            intervention=intervention,
+            status=session.status.value,
+            auth=auth,
+            ok=False,
+            error=f"unknown_action:{intervention.action}",
+        )
         return {"success": False, "error": f"Unknown action: {intervention.action}"}
+
+    @staticmethod
+    def _hash_text(value: str) -> str:
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+    async def _record_human_intervention_audit(
+        self,
+        *,
+        session: AWISession,
+        intervention: AWIHumanIntervention,
+        status: str,
+        auth: Any | None,
+        ok: bool = True,
+        error: str | None = None,
+    ) -> None:
+        metadata: dict[str, Any] = {
+            "session_id": session.session_id,
+            "action": intervention.action,
+            "status": status,
+            "reason": intervention.reason,
+        }
+        if intervention.steer_instructions:
+            metadata["steer_instructions_sha256"] = self._hash_text(
+                intervention.steer_instructions
+            )
+            metadata["steer_instructions_length"] = len(
+                intervention.steer_instructions
+            )
+
+        await record_audit_event(
+            event="awi.human_intervention",
+            wallet_id=session.wallet_id,
+            tool="awi",
+            endpoint="/v1/awi/intervene",
+            auth_source=getattr(auth, "source", None),
+            key_id=getattr(auth, "key_id", None),
+            request_id=session.session_id,
+            ok=ok,
+            error=error,
+            metadata=metadata,
+        )
 
     async def destroy_session(self, session_id: str) -> bool:
         """Destroy an AWI session."""

--- a/awi_sdk/python/awi_sdk/__init__.py
+++ b/awi_sdk/python/awi_sdk/__init__.py
@@ -8,15 +8,23 @@ pip install agent-middleware-awi
 
 from .client import AWIClient, AWIClientConfig
 from .models import (
-    AWIStandardAction,
+    AWIActionDefinition,
+    AWIActionRiskLevel,
+    AWIActionStatus,
+    AWIActionTier,
     AWIRepresentationType,
-    AWISession,
+    AWIStandardAction,
     AWIExecutionResponse,
+    AWISession,
 )
 
 __all__ = [
     "AWIClient",
     "AWIClientConfig",
+    "AWIActionDefinition",
+    "AWIActionRiskLevel",
+    "AWIActionStatus",
+    "AWIActionTier",
     "AWIStandardAction",
     "AWIRepresentationType",
     "AWISession",

--- a/awi_sdk/python/awi_sdk/models.py
+++ b/awi_sdk/python/awi_sdk/models.py
@@ -73,10 +73,16 @@ class AWIActionDefinition:
     required_preconditions: list[str]
     postconditions: list[str]
     estimated_cost: float
-    tier: str
-    status: str
-    risk_level: str
+    tier: AWIActionTier | str
+    status: AWIActionStatus | str
+    risk_level: AWIActionRiskLevel | str
     sensitive_parameters: list[str]
+
+    def __post_init__(self) -> None:
+        """Coerce metadata literals into SDK enums for invalid-value detection."""
+        self.tier = AWIActionTier(self.tier)
+        self.status = AWIActionStatus(self.status)
+        self.risk_level = AWIActionRiskLevel(self.risk_level)
 
 
 @dataclass

--- a/awi_sdk/python/awi_sdk/models.py
+++ b/awi_sdk/python/awi_sdk/models.py
@@ -39,6 +39,46 @@ class AWIRepresentationType(str, Enum):
     TEXT_EXTRACTION = "text_extraction"
 
 
+class AWIActionTier(str, Enum):
+    """How directly an action expresses AWI semantic intent."""
+
+    SEMANTIC = "semantic"
+    COMPATIBILITY = "compatibility"
+
+
+class AWIActionStatus(str, Enum):
+    """Maturity status for AWI action contracts."""
+
+    STABLE = "stable"
+    PROVISIONAL = "provisional"
+    DEPRECATED = "deprecated"
+
+
+class AWIActionRiskLevel(str, Enum):
+    """Risk level for policy and human-approval decisions."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+@dataclass
+class AWIActionDefinition:
+    """Public AWI action vocabulary entry."""
+
+    action: str
+    category: str
+    description: str
+    parameters: dict[str, dict[str, Any]]
+    required_preconditions: list[str]
+    postconditions: list[str]
+    estimated_cost: float
+    tier: str
+    status: str
+    risk_level: str
+    sensitive_parameters: list[str]
+
+
 @dataclass
 class AWISession:
     """An AWI session."""

--- a/awi_sdk/typescript/index.ts
+++ b/awi_sdk/typescript/index.ts
@@ -67,6 +67,29 @@ export type AWIRepresentationType =
   | "json_structure"
   | "text_extraction";
 
+export type AWIActionTier = "semantic" | "compatibility";
+export type AWIActionStatus = "stable" | "provisional" | "deprecated";
+export type AWIActionRiskLevel = "low" | "medium" | "high";
+
+export interface AWIActionDefinition {
+  action: AWIAction;
+  category: string;
+  description: string;
+  parameters: Record<string, Record<string, unknown>>;
+  required_preconditions: string[];
+  postconditions: string[];
+  estimated_cost: number;
+  tier: AWIActionTier;
+  status: AWIActionStatus;
+  risk_level: AWIActionRiskLevel;
+  sensitive_parameters: string[];
+}
+
+export interface AWIVocabulary {
+  actions: AWIActionDefinition[];
+  categories: string[];
+}
+
 /**
  * AWI TypeScript Client
  *
@@ -101,7 +124,7 @@ export class AWIClient {
     });
   }
 
-  async discover(): Promise<unknown> {
+  async discover(): Promise<AWIVocabulary> {
     const response: AxiosResponse = await this.client.get("/v1/awi/vocabulary");
     return response.data;
   }

--- a/docs/awi-action-vocabulary-spec.md
+++ b/docs/awi-action-vocabulary-spec.md
@@ -45,8 +45,8 @@ This draft does not define:
 
 ## Implementation Status
 
-The action names, categories, parameters, preconditions, postconditions, and
-estimated costs in this draft mirror the current reference implementation.
+The action names, categories, parameters, preconditions, and postconditions in
+this draft mirror the current reference implementation.
 
 The safety language is a draft requirement for implementations, not a guarantee
 that `app/services/awi_action_vocab.py` enforces the behavior by itself. In this
@@ -92,6 +92,67 @@ Fields:
 | `representation_request` | no | Optional representation to return after execution. |
 | `dry_run` | no | If true, validate and preview without intended side effects. |
 
+## Action Response Shape
+
+The reference implementation returns a structured response from
+`POST /v1/awi/execute`.
+
+Successful execution:
+
+```json
+{
+  "execution_id": "awi-exec-id",
+  "session_id": "awi-session-id",
+  "action": "search_and_sort",
+  "status": "success",
+  "parameters": {
+    "query": "laptops"
+  },
+  "result": {
+    "success": true,
+    "results_count": 12
+  },
+  "representation": null,
+  "duration_ms": 14
+}
+```
+
+Validation or execution failure:
+
+```json
+{
+  "execution_id": "awi-exec-id",
+  "session_id": "awi-session-id",
+  "action": "login",
+  "status": "error",
+  "parameters": {
+    "username": "[REDACTED]",
+    "password": "[REDACTED]"
+  },
+  "error": "Missing required login parameters: credential_handle or username+password"
+}
+```
+
+Response fields:
+
+| Field | Meaning |
+| --- | --- |
+| `execution_id` | Unique execution identifier. |
+| `session_id` | Stateful AWI session identifier. |
+| `action` | Action attempted. |
+| `status` | Execution status such as `success`, `error`, `paused`, `passkey_required`, or `max_steps_reached`. |
+| `parameters` | Request parameters after sensitive-parameter redaction. |
+| `result` | Action-specific result payload when execution runs. |
+| `error` | Clear failure reason when `status` is not successful. |
+| `new_state` | Optional state snapshot after execution. |
+| `representation` | Optional representation generated when `representation_request` is set. |
+| `duration_ms` | Runtime duration in milliseconds when execution runs. |
+| `cost_estimate` | Present for dry-run previews when supported. |
+
+Implementations should return a clear error status when validation fails or a
+precondition is unmet. HTTP status codes may still be `200` when the request was
+syntactically valid and the action-level status carries the execution outcome.
+
 ## Representation Types
 
 The current representation vocabulary is:
@@ -134,6 +195,24 @@ The reference implementation exposes these metadata fields for each action:
 
 Default actions are `semantic`, `stable`, and `low` risk unless stated
 otherwise below.
+
+## Preconditions and Postconditions
+
+Preconditions and postconditions are declarative predicates over session state.
+They may be represented as boolean session flags, computed predicates, or
+site-provided capability metadata, but they are not caller-controlled bypasses.
+
+The executor is responsible for checking preconditions before side effects. If a
+precondition is unmet, the executor should reject the action with a clear
+diagnostic or request a remedy such as navigation, login, or human approval.
+Callers may use preconditions for planning, but caller assertions do not satisfy
+the contract by themselves.
+
+Postconditions describe the expected state after successful execution. If a
+postcondition is not achieved, the executor should return a failure status and
+diagnostic information rather than silently treating the action as successful.
+For high-risk actions such as `checkout`, and runtime-sensitive `fill_form`
+requests, authorization and safety decisions should be surfaced in the response.
 
 ## Action Definitions
 
@@ -250,7 +329,12 @@ Postconditions:
 
 Safety requirement: if fields contain regulated, personal, credential, or
 payment data, implementations should treat the request as high risk even though
-the action name is general.
+the action name is general. `risk_level: medium` is baseline metadata only.
+Executors should inspect `fields`, site/form metadata, and caller-provided field
+sensitivity hints, then elevate runtime risk to `high` for sensitive field names
+or values such as `password`, `pass`, `pwd`, `ssn`, `social_security`,
+`credit_card`, `cc_num`, `card_number`, `cvv`, `cvc`, `routing`, `account`,
+`dob`, `date_of_birth`, or financial-context email fields.
 
 ### `login`
 
@@ -264,6 +348,7 @@ Risk level: `high`
 
 Sensitive parameters:
 
+- `username`: string
 - `password`: string
 
 Accepted credential shapes:
@@ -287,7 +372,8 @@ Postconditions:
 Safety requirement: credentials must not be logged in plaintext, included in
 receipts, or exposed in durable state. `credential_handle` is the preferred
 shape; direct `username` and `password` parameters are retained only for v0.1
-compatibility and must be redacted before storage or response.
+compatibility and must be redacted before storage or response because usernames
+are often email addresses or other personally identifying values.
 
 ### `logout`
 

--- a/docs/awi-action-vocabulary-spec.md
+++ b/docs/awi-action-vocabulary-spec.md
@@ -1,0 +1,553 @@
+# AWI Semantic Action Vocabulary Draft
+
+Status: Draft, not a published standard
+Version: 0.1.0
+Date: 2026-05-20
+Source implementation: `app/schemas/awi.py` and `app/services/awi_action_vocab.py`
+
+This document specifies the current semantic action vocabulary implemented by
+Agent Middleware API for Agentic Web Interface (AWI) sessions. It is intended as
+a discussion draft for implementers and researchers, not as a claim of external
+standardization or endorsement by the authors of the AWI paper.
+
+## Scope
+
+The vocabulary defines higher-level web actions that an agent can request
+without controlling raw browser coordinates or low-level DOM events. A conforming
+implementation may expose these actions over HTTP, MCP, a local SDK, or another
+transport, as long as the action contract and safety semantics are preserved.
+
+This draft covers:
+
+- 13 action names across semantic and compatibility tiers
+- Action categories
+- Action tier, maturity status, risk level, and sensitive parameter metadata
+- Required and optional parameters
+- Preconditions and postconditions
+- Representation requests
+- Safety and versioning requirements
+
+This draft does not define:
+
+- A universal AWI wire protocol
+- Browser automation internals
+- A benchmark methodology for representation quality
+- Website-specific business rules
+
+## Design Goals
+
+1. Prefer semantic actions over DOM mechanics.
+2. Keep action contracts stable enough for cross-site agent code.
+3. Let sites enforce local policy before side effects occur.
+4. Return compact, task-relevant representations when possible.
+5. Make high-risk actions auditable, bounded, and interruptible.
+6. Allow extension without fragmenting the core vocabulary.
+
+## Implementation Status
+
+The action names, categories, parameters, preconditions, postconditions, and
+estimated costs in this draft mirror the current reference implementation.
+
+The safety language is a draft requirement for implementations, not a guarantee
+that `app/services/awi_action_vocab.py` enforces the behavior by itself. In this
+repo, enforcement lives in surrounding services where implemented, including
+wallet-scoped authorization, passkey checks, signed permits, receipts, and audit
+chains.
+
+Important unresolved design questions before externalizing this draft:
+
+- Should `click_button` and `scroll` remain core actions, or should they be
+  compatibility primitives outside the semantic vocabulary?
+- Should `login` require secret handles only, or keep transitional support for
+  direct `username` and `password` parameters?
+- Should `checkout` be split into reversible and irreversible steps?
+- Which benchmark should determine whether progressive representations improve
+  token cost or task completion versus DOM or screenshot baselines?
+
+## Action Request Shape
+
+The reference implementation accepts action requests through
+`POST /v1/awi/execute`.
+
+```json
+{
+  "session_id": "awi-session-id",
+  "action": "search_and_sort",
+  "parameters": {
+    "query": "laptops",
+    "sort_by": "price"
+  },
+  "representation_request": "summary",
+  "dry_run": false
+}
+```
+
+Fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `session_id` | yes | Stateful AWI session identifier. |
+| `action` | yes | One of the defined action names or a supported extension action. |
+| `parameters` | no | Action-specific JSON object. Defaults to `{}`. |
+| `representation_request` | no | Optional representation to return after execution. |
+| `dry_run` | no | If true, validate and preview without intended side effects. |
+
+## Representation Types
+
+The current representation vocabulary is:
+
+| Type | Purpose |
+| --- | --- |
+| `summary` | Concise state summary for low-token planning. |
+| `embedding` | Semantic vector or embedding-like representation. |
+| `low_res_screenshot` | Visual state at reduced resolution. |
+| `accessibility_tree` | Accessibility-first structure. |
+| `json_structure` | Structured state object. |
+| `text_extraction` | Extracted visible or relevant text. |
+| `full_dom` | Complete DOM representation when compact forms are insufficient. |
+
+Implementations should prefer the smallest representation that supports the
+agent's next decision. `full_dom` should be treated as a fallback, not the
+default.
+
+## Categories
+
+| Category | Actions |
+| --- | --- |
+| `navigation` | `navigate_to`, `scroll` |
+| `search` | `search_and_sort` |
+| `interaction` | `fill_form`, `click_button`, `select_option`, `upload_file` |
+| `extraction` | `extract_data`, `get_representation` |
+| `transaction` | `add_to_cart`, `checkout` |
+| `auth` | `login`, `logout` |
+
+## Action Metadata
+
+The reference implementation exposes these metadata fields for each action:
+
+| Field | Values | Meaning |
+| --- | --- | --- |
+| `tier` | `semantic`, `compatibility` | Whether the action expresses intent directly or exists as a practical escape hatch. |
+| `status` | `stable`, `provisional`, `deprecated` | Maturity of the action contract. |
+| `risk_level` | `low`, `medium`, `high` | Minimum policy attention expected before execution. |
+| `sensitive_parameters` | list of parameter names | Parameters that must be redacted before durable storage, logs, receipts, or audit payloads. |
+
+Default actions are `semantic`, `stable`, and `low` risk unless stated
+otherwise below.
+
+## Action Definitions
+
+### `search_and_sort`
+
+Search for items or records and optionally sort or filter the result set.
+
+Category: `search`
+
+Required parameters:
+
+- `query`: string
+
+Optional parameters:
+
+- `sort_by`: string
+- `sort_order`: string
+- `filters`: object
+
+Preconditions:
+
+- `page_loaded`
+
+Postconditions:
+
+- `results_displayed`
+
+### `add_to_cart`
+
+Add an item to a shopping cart or equivalent pending transaction container.
+
+Category: `transaction`
+
+Risk level: `medium`
+
+Required parameters:
+
+- `item_id`: string
+
+Optional parameters:
+
+- `quantity`: integer
+- `variant`: string
+
+Preconditions:
+
+- `item_visible`
+- `cart_accessible`
+
+Postconditions:
+
+- `item_in_cart`
+
+### `checkout`
+
+Complete or advance a checkout flow.
+
+Category: `transaction`
+
+Risk level: `high`
+
+Sensitive parameters:
+
+- `payment_method`
+
+Required parameters:
+
+- `payment_method`: string
+
+Optional parameters:
+
+- `shipping_address`: object
+- `billing_address`: object
+
+Preconditions:
+
+- `cart_not_empty`
+- `user_authenticated`
+
+Postconditions:
+
+- `order_placed`
+- `payment_processed`
+
+Safety requirement: `checkout` is high risk. Implementations should require an
+explicit authorization boundary such as a signed permit, human approval,
+passkey/WebAuthn verification, or equivalent local policy before execution.
+
+### `fill_form`
+
+Fill a form with provided field values, optionally submitting it.
+
+Category: `interaction`
+
+Risk level: `medium`
+
+Required parameters:
+
+- `fields`: object
+
+Optional parameters:
+
+- `form_id`: string
+- `submit`: boolean
+
+Preconditions:
+
+- `form_visible`
+
+Postconditions:
+
+- `form_filled`
+- `form_submitted`
+
+Safety requirement: if fields contain regulated, personal, credential, or
+payment data, implementations should treat the request as high risk even though
+the action name is general.
+
+### `login`
+
+Authenticate with the target website.
+
+Category: `auth`
+
+Status: `provisional`
+
+Risk level: `high`
+
+Sensitive parameters:
+
+- `password`: string
+
+Accepted credential shapes:
+
+- Preferred: `credential_handle`: string
+- Transitional v0.1 compatibility: `username`: string plus `password`: string
+
+Optional parameters:
+
+- `remember_me`: boolean
+
+Preconditions:
+
+- `login_page_visible`
+
+Postconditions:
+
+- `user_authenticated`
+- `session_created`
+
+Safety requirement: credentials must not be logged in plaintext, included in
+receipts, or exposed in durable state. `credential_handle` is the preferred
+shape; direct `username` and `password` parameters are retained only for v0.1
+compatibility and must be redacted before storage or response.
+
+### `logout`
+
+End the current authenticated session.
+
+Category: `auth`
+
+Required parameters: none
+
+Optional parameters: none
+
+Preconditions:
+
+- `user_authenticated`
+
+Postconditions:
+
+- `session_terminated`
+- `logged_out`
+
+### `navigate_to`
+
+Navigate to a URL or named page.
+
+Category: `navigation`
+
+Required parameters:
+
+- `url`: string
+
+Optional parameters:
+
+- `wait_for_load`: boolean
+
+Preconditions: none
+
+Postconditions:
+
+- `page_loaded`
+
+Safety requirement: implementations should enforce URL allowlists, same-origin
+policy, or permit scopes when navigation can cross trust boundaries.
+
+### `click_button`
+
+Click a button or interactive element.
+
+Category: `interaction`
+
+Tier: `compatibility`
+
+Required parameters: none
+
+Optional parameters:
+
+- `button_id`: string
+- `button_text`: string
+- `button_selector`: string
+
+Preconditions:
+
+- `button_visible`
+
+Postconditions:
+
+- `button_clicked`
+
+Safety requirement: `click_button` is a compatibility action. Prefer semantic
+actions such as `checkout`, `add_to_cart`, or `select_option` when available.
+Raw selectors should be constrained and previewable because they can bypass the
+intent expressed by a semantic action.
+
+### `scroll`
+
+Scroll the current page or container.
+
+Category: `navigation`
+
+Tier: `compatibility`
+
+Required parameters:
+
+- `direction`: string
+
+Optional parameters:
+
+- `amount`: integer
+
+Preconditions:
+
+- `page_loaded`
+
+Postconditions:
+
+- `scrolled`
+
+### `select_option`
+
+Select an option from a dropdown, radio group, listbox, or similar control.
+
+Category: `interaction`
+
+Required parameters:
+
+- `option_value`: string
+
+Optional parameters:
+
+- `select_id`: string
+- `option_text`: string
+
+Preconditions:
+
+- `select_visible`
+
+Postconditions:
+
+- `option_selected`
+
+### `upload_file`
+
+Upload a file to the target page.
+
+Category: `interaction`
+
+Risk level: `medium`
+
+Required parameters:
+
+- `file_path`: string
+
+Optional parameters:
+
+- `input_id`: string
+
+Preconditions:
+
+- `upload_input_visible`
+
+Postconditions:
+
+- `file_uploaded`
+
+Safety requirement: implementations should restrict file paths to approved
+workspace or upload directories and should prevent arbitrary host filesystem
+access.
+
+### `extract_data`
+
+Extract structured data from the current page or state.
+
+Category: `extraction`
+
+Required parameters:
+
+- `data_type`: string
+
+Optional parameters:
+
+- `selector`: string
+- `limit`: integer
+
+Preconditions:
+
+- `data_visible`
+
+Postconditions:
+
+- `data_extracted`
+
+Safety requirement: extraction can leak private or tenant-scoped data.
+Implementations should apply the same authorization checks used for viewing the
+underlying page or object.
+
+### `get_representation`
+
+Return a specific representation of current state.
+
+Category: `extraction`
+
+Required parameters:
+
+- `representation_type`: string
+
+Optional parameters:
+
+- `options`: object
+
+Preconditions:
+
+- `page_loaded`
+
+Postconditions:
+
+- `representation_returned`
+
+## Safety Model
+
+The action vocabulary is not sufficient by itself. Implementations should pair
+the vocabulary with a governance layer that can answer:
+
+- Who is requesting the action?
+- Which wallet, tenant, user, or principal owns the session?
+- What authority was delegated?
+- What budget or rate limit applies?
+- Is the action idempotent or replay protected?
+- Which evidence proves the action was allowed, denied, charged, or refunded?
+
+The reference implementation uses wallet-scoped API keys, signed permits,
+idempotency keys, signed receipts, and tamper-evident audit chains. Other
+implementations may use different mechanisms, but high-risk and billable actions
+should produce equivalent reviewable evidence.
+
+## Human Intervention
+
+Implementations should expose a human intervention surface with at least:
+
+- `pause`
+- `resume`
+- `steer`
+
+Human intervention should be available before high-risk side effects and during
+long-running task queues.
+
+## Extension Policy
+
+Implementations may add custom actions when the core vocabulary is insufficient.
+Custom actions should:
+
+- Avoid changing the meaning of core action names.
+- Use a clear namespace such as `x_vendor_action` or `vendor.action`.
+- Declare parameters, preconditions, postconditions, action tier, maturity
+  status, risk level, and sensitive parameters.
+- Provide a fallback or explanation for agents that only understand core
+  actions.
+
+Candidate future core actions should demonstrate repeated use across at least
+two independent domains before being added to this draft.
+
+## Versioning Policy
+
+This draft uses semantic versioning:
+
+- Patch versions clarify wording without changing behavior.
+- Minor versions add optional parameters, new representation types, or new core
+  actions.
+- Major versions rename actions, remove actions, or change required parameters.
+
+Action names and required parameters should not change in a minor version.
+Deprecated actions should remain documented for at least two minor versions.
+
+## Open Questions
+
+1. Should `click_button` and `scroll` remain in the 13-action vocabulary as
+   compatibility actions, or move outside the shared vocabulary?
+2. Should `login` move from transitional credential support to
+   `credential_handle` only in v0.2?
+3. Should risk levels be standardized across implementations or left as local
+   policy metadata?
+4. Should `checkout` be split into `start_checkout`, `review_order`, and
+   `confirm_purchase` to better separate reversible and irreversible steps?
+5. What benchmark should determine whether progressive representations are
+   better than DOM or screenshot baselines?

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10957,7 +10957,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/AWIDiscoveryManifest"
+                }
               }
             }
           }
@@ -11289,6 +11291,180 @@
         "title": "AWIActionCategory",
         "description": "Categories of standardized AWI actions."
       },
+      "AWIActionDefinitionResponse": {
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/AWIStandardAction"
+          },
+          "category": {
+            "$ref": "#/components/schemas/AWIActionCategory"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "parameters": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Parameters"
+          },
+          "required_preconditions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Required Preconditions"
+          },
+          "postconditions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Postconditions"
+          },
+          "estimated_cost": {
+            "type": "number",
+            "title": "Estimated Cost"
+          },
+          "tier": {
+            "$ref": "#/components/schemas/AWIActionTier"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AWIActionStatus"
+          },
+          "risk_level": {
+            "$ref": "#/components/schemas/AWIActionRiskLevel"
+          },
+          "sensitive_parameters": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Sensitive Parameters"
+          }
+        },
+        "type": "object",
+        "required": [
+          "action",
+          "category",
+          "description",
+          "parameters",
+          "required_preconditions",
+          "postconditions",
+          "estimated_cost",
+          "tier",
+          "status",
+          "risk_level"
+        ],
+        "title": "AWIActionDefinitionResponse",
+        "description": "Public action vocabulary entry exposed by AWI discovery surfaces."
+      },
+      "AWIActionRiskLevel": {
+        "type": "string",
+        "enum": [
+          "low",
+          "medium",
+          "high"
+        ],
+        "title": "AWIActionRiskLevel",
+        "description": "Risk level for policy and human-approval decisions."
+      },
+      "AWIActionStatus": {
+        "type": "string",
+        "enum": [
+          "stable",
+          "provisional",
+          "deprecated"
+        ],
+        "title": "AWIActionStatus",
+        "description": "Maturity status for AWI action contracts."
+      },
+      "AWIActionTier": {
+        "type": "string",
+        "enum": [
+          "semantic",
+          "compatibility"
+        ],
+        "title": "AWIActionTier",
+        "description": "How directly an action expresses AWI semantic intent."
+      },
+      "AWIDiscoveryManifest": {
+        "properties": {
+          "schema_version": {
+            "type": "string",
+            "title": "Schema Version"
+          },
+          "awi_version": {
+            "type": "string",
+            "title": "Awi Version"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "profile": {
+            "type": "string",
+            "title": "Profile"
+          },
+          "transport": {
+            "$ref": "#/components/schemas/AWIManifestTransport"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "endpoints": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Endpoints"
+          },
+          "representation_types": {
+            "items": {
+              "$ref": "#/components/schemas/AWIRepresentationType"
+            },
+            "type": "array",
+            "title": "Representation Types"
+          },
+          "actions": {
+            "items": {
+              "$ref": "#/components/schemas/AWIActionDefinitionResponse"
+            },
+            "type": "array",
+            "title": "Actions"
+          },
+          "safety_capabilities": {
+            "$ref": "#/components/schemas/AWIManifestSafetyCapabilities"
+          },
+          "known_limitations": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Known Limitations"
+          }
+        },
+        "type": "object",
+        "required": [
+          "schema_version",
+          "awi_version",
+          "status",
+          "profile",
+          "transport",
+          "description",
+          "endpoints",
+          "representation_types",
+          "actions",
+          "safety_capabilities",
+          "known_limitations"
+        ],
+        "title": "AWIDiscoveryManifest",
+        "description": "Draft AWI-over-MCP discovery manifest."
+      },
       "AWIEndpoint": {
         "properties": {
           "path": {
@@ -11512,6 +11688,72 @@
         ],
         "title": "AWIHumanIntervention",
         "description": "Request human intervention in an AWI session."
+      },
+      "AWIManifestSafetyCapabilities": {
+        "properties": {
+          "wallet_scoped_authorization": {
+            "type": "boolean",
+            "title": "Wallet Scoped Authorization"
+          },
+          "human_intervention": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Human Intervention"
+          },
+          "passkey_high_risk_actions": {
+            "type": "boolean",
+            "title": "Passkey High Risk Actions"
+          },
+          "signed_permits": {
+            "type": "boolean",
+            "title": "Signed Permits"
+          },
+          "tamper_evident_audit_chain": {
+            "type": "boolean",
+            "title": "Tamper Evident Audit Chain"
+          },
+          "sensitive_parameter_redaction": {
+            "type": "boolean",
+            "title": "Sensitive Parameter Redaction"
+          }
+        },
+        "type": "object",
+        "required": [
+          "wallet_scoped_authorization",
+          "human_intervention",
+          "passkey_high_risk_actions",
+          "signed_permits",
+          "tamper_evident_audit_chain",
+          "sensitive_parameter_redaction"
+        ],
+        "title": "AWIManifestSafetyCapabilities",
+        "description": "Safety capabilities advertised by the AWI discovery manifest."
+      },
+      "AWIManifestTransport": {
+        "properties": {
+          "primary": {
+            "type": "string",
+            "title": "Primary"
+          },
+          "mcp_compatible": {
+            "type": "boolean",
+            "title": "Mcp Compatible"
+          },
+          "mcp_manifest": {
+            "type": "string",
+            "title": "Mcp Manifest"
+          }
+        },
+        "type": "object",
+        "required": [
+          "primary",
+          "mcp_compatible",
+          "mcp_manifest"
+        ],
+        "title": "AWIManifestTransport",
+        "description": "Transport metadata for the AWI discovery manifest."
       },
       "AWIRepresentationRequest": {
         "properties": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -10944,6 +10944,26 @@
         }
       }
     },
+    "/.well-known/awi.json": {
+      "get": {
+        "tags": [
+          "Agent Discovery"
+        ],
+        "summary": "AWI Discovery Manifest",
+        "description": "Returns the draft AWI-over-MCP manifest with action vocabulary, representation types, endpoints, safety capabilities, and known limits.",
+        "operationId": "get_awi_json__well_known_awi_json_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
     "/.well-known/mcp/tools.json": {
       "get": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9444,6 +9444,53 @@
         }
       }
     },
+    "/v1/receipts/{receipt_id}/evidence": {
+      "get": {
+        "tags": [
+          "Trust Receipts"
+        ],
+        "summary": "Get Receipt Evidence",
+        "operationId": "get_receipt_evidence_v1_receipts__receipt_id__evidence_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "receipt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Receipt Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReceiptEvidenceResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/receipts/verify": {
       "post": {
         "tags": [
@@ -20466,6 +20513,119 @@
         ],
         "title": "RecallRequest",
         "description": "Recall memories for an agent."
+      },
+      "ReceiptEvidenceCheck": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "passed",
+              "failed",
+              "skipped"
+            ],
+            "title": "Status"
+          },
+          "reason": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reason"
+          },
+          "details": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Details"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "status"
+        ],
+        "title": "ReceiptEvidenceCheck"
+      },
+      "ReceiptEvidenceResponse": {
+        "properties": {
+          "receipt_id": {
+            "type": "string",
+            "title": "Receipt Id"
+          },
+          "valid": {
+            "type": "boolean",
+            "title": "Valid"
+          },
+          "checks": {
+            "items": {
+              "$ref": "#/components/schemas/ReceiptEvidenceCheck"
+            },
+            "type": "array",
+            "title": "Checks"
+          },
+          "receipt": {
+            "$ref": "#/components/schemas/ReceiptResponse"
+          },
+          "permit": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PermitResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "audit_event": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audit Event"
+          },
+          "audit_chain": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AuditChainVerifyResponse"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "ledger_entry": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ledger Entry"
+          }
+        },
+        "type": "object",
+        "required": [
+          "receipt_id",
+          "valid",
+          "checks",
+          "receipt"
+        ],
+        "title": "ReceiptEvidenceResponse"
       },
       "ReceiptListResponse": {
         "properties": {

--- a/docs/related-work.md
+++ b/docs/related-work.md
@@ -1,0 +1,86 @@
+# Related Work And Claim Evidence
+
+This document maps external literature to the repo's narrow product wedge:
+
+```text
+discover -> authenticate -> authorize -> invoke -> meter -> receipt -> audit -> govern
+```
+
+The sources below are context for design and positioning. They do not by
+themselves prove production readiness, compliance, settlement safety, or
+enterprise suitability. Repo claims still need code, tests, docs, or executable
+demo evidence.
+
+## Product Boundary
+
+Verified from repo:
+
+- The current wedge is a governed trust plane for scoped, metered MCP tool calls
+  in `WEDGE.md`.
+- The current proof path is signed permit, governed MCP invoke, wallet charge,
+  signed receipt, ledger entry, audit chain verification, replay safety, and
+  out-of-scope denial in `DEMO_SCRIPT.md`.
+- AWI, browser automation, content generation, oracle crawls, media utilities,
+  IoT bridges, red-team services, RTaaS, telemetry auto-PR, and sandbox demos
+  are proof surfaces, not the initial product boundary, in `WEDGE.md`.
+
+## Source Map
+
+| Pillar | Source | Why it matters here | Verification level |
+| --- | --- | --- | --- |
+| AWI | [Build the web for agents, not agents for the web](https://arxiv.org/abs/2506.10953) | Foundation for the AWI proof surface and the idea that agents need machine-native interfaces. | Verified external source; README claim is repo-verified. |
+| AWI | [WebArena](https://arxiv.org/abs/2307.13854) | Empirical context for web-agent failure on human-oriented sites. | Verified external source; repo benchmark alignment is not verified. |
+| MCP | [Model Context Protocol specification](https://modelcontextprotocol.io/specification/2025-11-25) | Normative substrate for MCP discovery, tools, JSON-RPC, authorization, and trust-and-safety expectations. | Verified external source; implementation conformance is partially verified by tests. |
+| MCP | [Introducing the Model Context Protocol](https://www.anthropic.com/news/model-context-protocol) | Primary-source launch framing for MCP as a standard connector layer. | Verified external source. |
+| MCP | [Code execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) | Useful context for why governance, metering, and tool-result discipline matter as MCP tool counts scale. | Verified external source; no repo performance claim implied. |
+| Payments and wallets | [How Agentic AI Will Reshape Payments](https://www.imf.org/en/publications/imf-notes/issues/2026/04/22/how-agentic-ai-will-reshape-payments-575560) | Institutional framing for authorization, settlement, compliance, and resilience in agent-mediated payments. | Verified external source; repo payment readiness is not verified. |
+| Payments and wallets | [Agent Wallets: How AI Agents Spend Money](https://eco.com/support/en/articles/14839403-agent-wallets-how-ai-agents-spend-money) | Practitioner taxonomy for bounded authority, scoped keys, and policy-constrained spend. | Verified external source; use as market context. |
+| Authorization | [API Tokens: A Tedious Survey](https://fly.io/blog/api-tokens-a-tedious-survey/) | Practitioner comparison of token approaches relevant to scoped signed permits. | Verified external source; repo token design remains custom. |
+| Authorization | [Macaroons](https://research.google/pubs/macaroons-cookies-with-contextual-caveats-for-decentralized-authorization-in-the-cloud/) | Academic lineage for attenuated, caveat-bearing authorization credentials. | Verified external source; permits are inspired-by, not macaroons-compatible. |
+| Audit and evidence | [Constant-Size Cryptographic Evidence Structures for Regulated AI Workflows](https://arxiv.org/abs/2511.17118) | Context for hash-and-sign evidence structures that compose with hash chains. | Verified external source; regulated-workflow claims are not verified. |
+| Audit and evidence | [Creating Characteristically Auditable Agentic AI Systems](https://dl.acm.org/doi/10.1145/3759355.3759356) | Context for agent auditability as a first-class system property. | Partially verified externally; DOI/title found, full ACM page not verified here. |
+| Threat model | [From Prompt Injections to Protocol Exploits](https://arxiv.org/abs/2506.23260) | Threat taxonomy for LLM-agent ecosystems, including protocol-level vulnerabilities. | Verified external source. |
+| Threat model | [Design Patterns for Securing LLM Agents against Prompt Injections](https://arxiv.org/abs/2506.08837) | Design-pattern context for prompt-injection resistance when agents use tools. | Verified external source. |
+| Governance | [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework) | Governance vocabulary for enterprise and public-sector risk conversations. | Verified external source; compliance is not claimed. |
+
+## Claim Evidence Matrix
+
+| Public claim | Repo evidence | Reality level |
+| --- | --- | --- |
+| The product wedge is an MCP trust plane, not a broad agent platform. | `WEDGE.md` defines the wedge and lists non-core proof surfaces. | Verified. |
+| Agents can discover machine-readable interfaces. | `README.md` points agents to `/.well-known/agent.json`, `/llm.txt`, `/mcp/tools.json`, and `/openapi.json`; discovery drift tests exist in `tests/test_discovery_drift.py`. | Verified. |
+| Signed permits bind wallet, key, tool, scope, budget, expiry, and nonce. | `app/services/permits.py` creates signed permits and validates wallet, key, tool, scope, budget, expiry, and signature; `tests/test_permits.py` covers valid and invalid cases. | Verified. |
+| Governed MCP requires permits and idempotency in strict trust mode. | `app/routers/mcp.py` enforces permit and idempotency checks for governed calls; `tests/test_mcp_trust_mode.py` covers missing permit, missing idempotency, wrong key, wrong wallet, and wrong tool. | Verified. |
+| Successful governed invokes charge the wallet and emit signed receipts. | `app/routers/mcp.py` charges through `AgentMoney`, records audit, and creates receipts; `tests/test_demo_trust_plane.py` and `tests/test_agent_ops_war_room_demo.py` assert success receipts and replay behavior. | Verified. |
+| Denied governed attempts are auditable and can produce denial receipts when a permit record exists. | `app/routers/mcp.py` creates denial receipts for invalid scoped attempts with an existing permit; strict-mode tests assert denial audit events. | Verified. |
+| Receipts are signature-verifiable. | `app/services/receipts.py` signs and verifies receipt payloads; `tests/test_receipts.py` detects receipt tampering. | Verified. |
+| Wallet audit events are signed and hash-linked. | `app/services/audit_chain.py` signs audit events and verifies payload hash, previous hash, signature, and chain hash; `tests/test_audit_chain.py` detects tampering. | Verified. |
+| Wallet keys can inspect only their own trust ledger records. | `app/routers/me.py`, `app/routers/receipts.py`, and `app/routers/audit.py` enforce wallet-scoped access; `tests/test_me_trust_ledger.py` covers cross-wallet exclusion. | Verified. |
+| Payment settlement is production-ready. | `WEDGE.md` explicitly says not to claim production-ready payments or settlement. | Contradicted if claimed. |
+| Ledger storage is compliance-grade. | `WEDGE.md` explicitly says not to claim compliance-grade ledger storage. | Contradicted if claimed. |
+| Universal policy enforcement across every agent framework exists. | `WEDGE.md` explicitly says not to claim universal policy enforcement across every agent framework. | Contradicted if claimed. |
+
+## How To Use These Sources
+
+- Use AWI sources to explain proof surfaces, not the core wedge.
+- Use MCP sources to justify why this repo sits at the tool boundary.
+- Use wallet/payment sources to explain bounded authority and spend controls,
+  while avoiding production settlement claims.
+- Use Macaroons and token literature to explain the authorization lineage of
+  scoped permits without claiming compatibility.
+- Use audit/evidence sources to justify signed receipts and hash-linked audit
+  chains, while keeping regulated-compliance claims out of product copy.
+- Use threat-model sources to keep prompt injection, protocol exploit, replay,
+  confused deputy, unsafe tool execution, and cross-tenant leakage in scope.
+- Use NIST as governance vocabulary, not as proof of certification or
+  compliance.
+
+## Current Evidence Slice
+
+`GET /v1/receipts/{receipt_id}/evidence` answers one operator question:
+
+> Given a receipt ID, can I verify the receipt signature, permit signature,
+> audit-chain linkage, ledger linkage, and wallet-scoped access in one call?
+
+This strengthens the signed receipt ledger wedge without expanding the product
+surface.

--- a/scripts/awi_representation_benchmark.py
+++ b/scripts/awi_representation_benchmark.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""
+Deterministic local benchmark for AWI progressive representations.
+
+This is a smoke benchmark, not a WebArena substitute. It gives CI a stable
+artifact for comparing representation payload size, approximate token cost,
+latency, and task-relevant field coverage on a fixed page fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from app.schemas.awi import AWIRepresentationType
+from app.services.awi_representation import ProgressiveRepresentationEngine
+
+
+EXPECTED_TERMS = (
+    "luna trail jacket",
+    "add to cart",
+    "$128",
+    "size",
+    "shipping",
+)
+
+
+def build_fixture_page_state() -> dict[str, Any]:
+    """Return a stable commerce-like page state for representation benchmarks."""
+    return {
+        "html": """
+        <html>
+          <head><title>Luna Trail Jacket</title></head>
+          <body>
+            <main>
+              <h1>Luna Trail Jacket</h1>
+              <p>Water resistant shell with two-way stretch.</p>
+              <span class="price">$128</span>
+              <label>Size</label>
+              <select name="size">
+                <option>XS</option><option>M</option><option>L</option>
+              </select>
+              <button id="add-to-cart">Add to cart</button>
+              <p>Free shipping over $75.</p>
+            </main>
+          </body>
+        </html>
+        """,
+        "title": "Luna Trail Jacket",
+        "url": "https://shop.example.com/products/luna-trail-jacket",
+        "forms_count": 0,
+        "links_count": 4,
+        "elements": [
+            {
+                "role": "heading",
+                "name": "Luna Trail Jacket",
+                "actions": [],
+            },
+            {
+                "role": "button",
+                "name": "Add to cart",
+                "actions": ["click"],
+            },
+            {
+                "role": "combobox",
+                "name": "Size",
+                "state": {"expanded": False},
+                "actions": ["select"],
+            },
+        ],
+    }
+
+
+def _serialize(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def _approx_tokens(serialized: str) -> int:
+    return max(1, (len(serialized) + 3) // 4)
+
+
+def _field_coverage(serialized: str) -> float:
+    normalized = serialized.lower()
+    matches = sum(1 for term in EXPECTED_TERMS if term in normalized)
+    return round(matches / len(EXPECTED_TERMS), 3)
+
+
+async def run_benchmark() -> dict[str, Any]:
+    """Run the deterministic local AWI representation benchmark."""
+    engine = ProgressiveRepresentationEngine()
+    page_state = build_fixture_page_state()
+    results = []
+
+    for representation_type in AWIRepresentationType:
+        representation = await engine.generate_representation(
+            "awi-benchmark-local",
+            representation_type,
+            page_state,
+            {"max_length": 500},
+        )
+        serialized = _serialize(representation["content"])
+        results.append(
+            {
+                "representation_type": representation_type.value,
+                "size_bytes": representation["metadata"]["size_bytes"],
+                "serialized_bytes": len(serialized.encode("utf-8")),
+                "approx_tokens": _approx_tokens(serialized),
+                "latency_ms": representation["metadata"]["generation_time_ms"],
+                "task_field_coverage": _field_coverage(serialized),
+            }
+        )
+
+    return {
+        "benchmark": "awi-local-representation-v0",
+        "fixture": "commerce_product_page",
+        "expected_terms": list(EXPECTED_TERMS),
+        "results": results,
+    }
+
+
+def _validate(report: dict[str, Any]) -> None:
+    results = report["results"]
+    observed = {item["representation_type"] for item in results}
+    expected = {item.value for item in AWIRepresentationType}
+    missing = sorted(expected - observed)
+    if missing:
+        raise SystemExit(f"missing representation benchmark rows: {missing}")
+    for item in results:
+        if item["size_bytes"] <= 0:
+            raise SystemExit(f"non-positive size for {item['representation_type']}")
+        if item["approx_tokens"] <= 0:
+            raise SystemExit(f"non-positive tokens for {item['representation_type']}")
+        coverage = item["task_field_coverage"]
+        if coverage < 0 or coverage > 1:
+            raise SystemExit(f"invalid coverage for {item['representation_type']}")
+
+
+async def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="validate benchmark shape without enforcing performance thresholds",
+    )
+    args = parser.parse_args()
+
+    report = await run_benchmark()
+    if args.check:
+        _validate(report)
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/scripts/awi_representation_benchmark.py
+++ b/scripts/awi_representation_benchmark.py
@@ -13,6 +13,7 @@ import argparse
 import asyncio
 import json
 import sys
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
@@ -128,11 +129,18 @@ async def run_benchmark() -> dict[str, Any]:
 
 def _validate(report: dict[str, Any]) -> None:
     results = report["results"]
-    observed = {item["representation_type"] for item in results}
+    counts = Counter(item["representation_type"] for item in results)
+    observed = set(counts)
     expected = {item.value for item in AWIRepresentationType}
     missing = sorted(expected - observed)
-    if missing:
-        raise SystemExit(f"missing representation benchmark rows: {missing}")
+    unexpected = sorted(observed - expected)
+    duplicates = sorted(name for name, count in counts.items() if count > 1)
+    if len(results) != len(expected) or missing or unexpected or duplicates:
+        raise SystemExit(
+            "invalid representation benchmark rows: "
+            f"expected_count={len(expected)} actual_count={len(results)} "
+            f"missing={missing} unexpected={unexpected} duplicates={duplicates}"
+        )
     for item in results:
         if item["size_bytes"] <= 0:
             raise SystemExit(f"non-positive size for {item['representation_type']}")

--- a/tests/test_awi.py
+++ b/tests/test_awi.py
@@ -4,8 +4,10 @@ Tests for AWI (Agentic Web Interface) — Phase 7
 Based on arXiv:2506.10953v1 - "Build the web for agents, not agents for the web"
 """
 
-import pytest
+import json
+from pathlib import Path
 
+import pytest
 from httpx import ASGITransport, AsyncClient
 
 import app.services.awi_session as awi_session_module
@@ -15,6 +17,9 @@ from app.core.durable_state import DurableStateStore
 from app.main import app
 from app.schemas.awi import (
     AWIActionCategory,
+    AWIActionRiskLevel,
+    AWIActionStatus,
+    AWIActionTier,
     AWIExecutionRequest,
     AWISessionCreate,
     AWISessionStatus,
@@ -24,10 +29,12 @@ from app.schemas.awi import (
     AWIRepresentationType,
     AWIHumanIntervention,
 )
-from app.services.awi_action_vocab import AWIActionVocabulary, get_awi_vocabulary
+from app.services.awi_action_vocab import get_awi_vocabulary
 from app.services.awi_representation import get_awi_representation
-from app.services.awi_task_queue import AWITaskQueue, get_awi_task_queue
-from app.services.awi_session import AWISessionManager, get_awi_session_manager
+from app.services.awi_task_queue import AWITaskQueue
+from app.services.awi_session import AWISessionManager
+from app.services.audit_log import list_audit_events
+from scripts.awi_representation_benchmark import run_benchmark
 
 HEADERS = {"X-API-Key": "test-key"}
 
@@ -55,6 +62,26 @@ class TestAWIActionVocabulary:
         assert action is not None
         assert action.category == AWIActionCategory.SEARCH
 
+    def test_action_metadata_for_awi_alignment(self):
+        """Vocabulary exposes tier, status, risk, and sensitive metadata."""
+        vocab = get_awi_vocabulary()
+
+        login = vocab.get_action(AWIStandardAction.LOGIN)
+        click = vocab.get_action(AWIStandardAction.CLICK_BUTTON)
+        scroll = vocab.get_action(AWIStandardAction.SCROLL)
+        checkout = vocab.get_action(AWIStandardAction.CHECKOUT)
+
+        assert login is not None
+        assert login.status == AWIActionStatus.PROVISIONAL
+        assert login.risk_level == AWIActionRiskLevel.HIGH
+        assert login.sensitive_parameters == ["password"]
+        assert click is not None
+        assert click.tier == AWIActionTier.COMPATIBILITY
+        assert scroll is not None
+        assert scroll.tier == AWIActionTier.COMPATIBILITY
+        assert checkout is not None
+        assert checkout.risk_level == AWIActionRiskLevel.HIGH
+
     def test_list_by_category(self):
         """Test listing actions by category."""
         vocab = get_awi_vocabulary()
@@ -80,11 +107,48 @@ class TestAWIActionVocabulary:
         assert is_valid is False
         assert "query" in error
 
+    def test_login_accepts_credential_handle_or_legacy_credentials(self):
+        """Login validation supports v0.1 transition without requiring secrets."""
+        vocab = get_awi_vocabulary()
+
+        handle_valid, handle_error = vocab.validate_parameters(
+            AWIStandardAction.LOGIN, {"credential_handle": "credh_123"}
+        )
+        legacy_valid, legacy_error = vocab.validate_parameters(
+            AWIStandardAction.LOGIN,
+            {"username": "agent@example.com", "password": "secret"},
+        )
+        invalid, invalid_error = vocab.validate_parameters(
+            AWIStandardAction.LOGIN, {"username": "agent@example.com"}
+        )
+
+        assert handle_valid is True
+        assert handle_error is None
+        assert legacy_valid is True
+        assert legacy_error is None
+        assert invalid is False
+        assert "credential_handle" in invalid_error
+
     def test_get_estimated_cost(self):
         """Test getting estimated cost for action."""
         vocab = get_awi_vocabulary()
         cost = vocab.get_estimated_cost(AWIStandardAction.CHECKOUT)
         assert cost > 0
+
+    def test_draft_spec_lists_all_standard_actions(self):
+        """The draft vocabulary spec should not drift from the enum."""
+        spec_path = (
+            Path(__file__).resolve().parents[1]
+            / "docs"
+            / "awi-action-vocabulary-spec.md"
+        )
+        spec_text = spec_path.read_text()
+        missing = [
+            action.value
+            for action in AWIStandardAction
+            if f"`{action.value}`" not in spec_text
+        ]
+        assert missing == []
 
 
 class TestAWIRepresentation:
@@ -128,6 +192,28 @@ class TestAWIRepresentation:
 
         assert result["representation_type"] == "embedding"
         assert "vector" in result["content"]
+
+    @pytest.mark.anyio
+    async def test_local_representation_benchmark_is_repeatable(self):
+        """CI runs the local benchmark harness without threshold gating."""
+        first = await run_benchmark()
+        second = await run_benchmark()
+
+        def stable(report):
+            return [
+                {
+                    key: value
+                    for key, value in row.items()
+                    if key != "latency_ms"
+                }
+                for row in report["results"]
+            ]
+
+        assert first["benchmark"] == "awi-local-representation-v0"
+        assert stable(first) == stable(second)
+        assert {row["representation_type"] for row in first["results"]} == {
+            item.value for item in AWIRepresentationType
+        }
 
 
 class TestAWITaskQueue:
@@ -280,6 +366,70 @@ class TestAWISessionManager:
         assert result.action == AWIStandardAction.NAVIGATE_TO
 
     @pytest.mark.anyio
+    async def test_login_password_is_redacted_from_response_and_session_history(self):
+        """Legacy login credentials are accepted but never stored in plaintext."""
+        manager = AWISessionManager()
+        session = await manager.create_session(
+            AWISessionCreate(target_url="https://example.com/login")
+        )
+        manager._session_state[session.session_id]["capabilities"].append(
+            "login_page_visible"
+        )
+        secret = "correct-horse-battery-staple"
+
+        result = await manager.execute_action(
+            AWIExecutionRequest(
+                session_id=session.session_id,
+                action=AWIStandardAction.LOGIN,
+                parameters={
+                    "username": "agent@example.com",
+                    "password": secret,
+                    "remember_me": True,
+                },
+            )
+        )
+        stored_session = await manager.get_session(session.session_id)
+
+        assert result.status == "success"
+        assert result.parameters["password"] == "[REDACTED]"
+        assert secret not in json.dumps(result.model_dump(mode="json"))
+        assert stored_session is not None
+        assert secret not in json.dumps(stored_session.model_dump(mode="json"))
+        assert (
+            stored_session.action_history[-1]["parameters"]["password"]
+            == "[REDACTED]"
+        )
+
+    @pytest.mark.anyio
+    async def test_fill_form_redacts_nested_password_from_durable_state(self):
+        """Form state storage redacts common secret field names."""
+        manager = AWISessionManager()
+        session = await manager.create_session(
+            AWISessionCreate(target_url="https://example.com/form")
+        )
+        manager._session_state[session.session_id]["capabilities"].append(
+            "form_visible"
+        )
+        secret = "nested-password-value"
+
+        result = await manager.execute_action(
+            AWIExecutionRequest(
+                session_id=session.session_id,
+                action=AWIStandardAction.FILL_FORM,
+                parameters={
+                    "fields": {
+                        "email": "agent@example.com",
+                        "password": secret,
+                    }
+                },
+            )
+        )
+
+        assert result.status == "success"
+        assert secret not in json.dumps(result.model_dump(mode="json"))
+        assert secret not in json.dumps(manager._session_state[session.session_id])
+
+    @pytest.mark.anyio
     async def test_session_rehydrates_from_durable_state(self, tmp_path, monkeypatch):
         """Another manager process can reload AWI session and state rows."""
         monkeypatch.setenv("STATE_BACKEND", "sqlite")
@@ -363,6 +513,44 @@ class TestAWISessionManager:
 
         assert result["success"] is True
         assert "instructions_recorded" in result
+
+    @pytest.mark.anyio
+    async def test_human_intervention_audit_redacts_steer_instructions(
+        self, clean_database
+    ):
+        """Steering writes audit evidence without storing full instructions."""
+        manager = AWISessionManager()
+        session = await manager.create_session(
+            AWISessionCreate(
+                target_url="https://example.com",
+                wallet_id="wallet-awi-audit",
+            )
+        )
+        secret_instruction = "Use customer password lunar"
+
+        result = await manager.human_intervention(
+            AWIHumanIntervention(
+                session_id=session.session_id,
+                action="steer",
+                reason="operator correction",
+                steer_instructions=secret_instruction,
+            )
+        )
+        events = await list_audit_events(
+            event="awi.human_intervention",
+            wallet_id="wallet-awi-audit",
+        )
+        stored_session = await manager.get_session(session.session_id)
+
+        assert result["success"] is True
+        assert events
+        assert events[0].metadata["action"] == "steer"
+        assert "steer_instructions_sha256" in events[0].metadata
+        assert secret_instruction not in json.dumps(events[0].metadata)
+        assert stored_session is not None
+        assert secret_instruction not in json.dumps(
+            stored_session.model_dump(mode="json")
+        )
 
 
 class TestAWIRouter:
@@ -449,6 +637,40 @@ class TestAWIRouter:
             data = response.json()
             assert "actions" in data
             assert len(data["actions"]) > 0
+            login = next(
+                action for action in data["actions"] if action["action"] == "login"
+            )
+            click = next(
+                action
+                for action in data["actions"]
+                if action["action"] == "click_button"
+            )
+            assert login["status"] == "provisional"
+            assert login["risk_level"] == "high"
+            assert login["sensitive_parameters"] == ["password"]
+            assert click["tier"] == "compatibility"
+
+    @pytest.mark.anyio
+    async def test_awi_manifest_matches_action_and_representation_enums(self):
+        """Test GET /.well-known/awi.json discovery contract."""
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/.well-known/awi.json")
+
+            assert response.status_code == 200
+            data = response.json()
+            actions = {action["action"]: action for action in data["actions"]}
+
+            assert data["profile"] == "awi-over-mcp"
+            assert data["endpoints"]["execute"] == "/v1/awi/execute"
+            assert data["safety_capabilities"]["sensitive_parameter_redaction"] is True
+            assert set(actions) == {action.value for action in AWIStandardAction}
+            assert set(data["representation_types"]) == {
+                item.value for item in AWIRepresentationType
+            }
+            assert actions["login"]["status"] == "provisional"
+            assert actions["click_button"]["tier"] == "compatibility"
 
     @pytest.mark.anyio
     async def test_create_task_endpoint(self):
@@ -556,9 +778,24 @@ class TestAWIRouter:
                 },
                 headers=db_headers,
             )
+            blocked_intervene = await client.post(
+                "/v1/awi/intervene",
+                json={
+                    "session_id": other_session_id,
+                    "action": "pause",
+                    "reason": "cross-wallet attempt",
+                },
+                headers=db_headers,
+            )
+            unchanged_session = await client.get(
+                f"/v1/awi/sessions/{other_session_id}", headers=HEADERS
+            )
 
             assert blocked_get.status_code == 403
             assert blocked_execute.status_code == 403
+            assert blocked_intervene.status_code == 403
+            assert unchanged_session.status_code == 200
+            assert unchanged_session.json()["status"] == "created"
 
     @pytest.mark.anyio
     async def test_passkey_challenge_requires_session_owner(self):

--- a/tests/test_awi.py
+++ b/tests/test_awi.py
@@ -34,7 +34,7 @@ from app.services.awi_representation import get_awi_representation
 from app.services.awi_task_queue import AWITaskQueue
 from app.services.awi_session import AWISessionManager
 from app.services.audit_log import list_audit_events
-from scripts.awi_representation_benchmark import run_benchmark
+from scripts.awi_representation_benchmark import _validate, run_benchmark
 
 HEADERS = {"X-API-Key": "test-key"}
 
@@ -74,13 +74,32 @@ class TestAWIActionVocabulary:
         assert login is not None
         assert login.status == AWIActionStatus.PROVISIONAL
         assert login.risk_level == AWIActionRiskLevel.HIGH
-        assert login.sensitive_parameters == ["password"]
+        assert login.sensitive_parameters == ["username", "password"]
         assert click is not None
         assert click.tier == AWIActionTier.COMPATIBILITY
         assert scroll is not None
         assert scroll.tier == AWIActionTier.COMPATIBILITY
         assert checkout is not None
         assert checkout.risk_level == AWIActionRiskLevel.HIGH
+
+    def test_redaction_normalizes_common_key_variants(self):
+        """Redaction catches snake, camel, and hyphenated sensitive keys."""
+        vocab = get_awi_vocabulary()
+
+        redacted = vocab.redact_parameters(
+            AWIStandardAction.CHECKOUT,
+            {
+                "paymentMethod": "card-token",
+                "nested": {
+                    "access-token": "access-secret",
+                    "safe": "visible",
+                },
+            },
+        )
+
+        assert redacted["paymentMethod"] == "[REDACTED]"
+        assert redacted["nested"]["access-token"] == "[REDACTED]"
+        assert redacted["nested"]["safe"] == "visible"
 
     def test_list_by_category(self):
         """Test listing actions by category."""
@@ -214,6 +233,15 @@ class TestAWIRepresentation:
         assert {row["representation_type"] for row in first["results"]} == {
             item.value for item in AWIRepresentationType
         }
+
+    @pytest.mark.anyio
+    async def test_local_representation_benchmark_rejects_duplicate_rows(self):
+        """Benchmark validation rejects duplicate or missing representation rows."""
+        report = await run_benchmark()
+        report["results"][1] = dict(report["results"][0])
+
+        with pytest.raises(SystemExit, match="duplicates"):
+            _validate(report)
 
 
 class TestAWITaskQueue:
@@ -391,10 +419,19 @@ class TestAWISessionManager:
         stored_session = await manager.get_session(session.session_id)
 
         assert result.status == "success"
+        assert result.parameters["username"] == "[REDACTED]"
         assert result.parameters["password"] == "[REDACTED]"
         assert secret not in json.dumps(result.model_dump(mode="json"))
+        assert "agent@example.com" not in json.dumps(result.model_dump(mode="json"))
         assert stored_session is not None
         assert secret not in json.dumps(stored_session.model_dump(mode="json"))
+        assert "agent@example.com" not in json.dumps(
+            stored_session.model_dump(mode="json")
+        )
+        assert (
+            stored_session.action_history[-1]["parameters"]["username"]
+            == "[REDACTED]"
+        )
         assert (
             stored_session.action_history[-1]["parameters"]["password"]
             == "[REDACTED]"
@@ -552,6 +589,35 @@ class TestAWISessionManager:
             stored_session.model_dump(mode="json")
         )
 
+    @pytest.mark.anyio
+    async def test_human_intervention_succeeds_when_audit_write_fails(
+        self, monkeypatch
+    ):
+        """Audit backend failure does not undo an already-authorized intervention."""
+
+        async def fail_audit(**kwargs):
+            raise RuntimeError("audit unavailable")
+
+        monkeypatch.setattr(awi_session_module, "record_audit_event", fail_audit)
+        manager = AWISessionManager()
+        session = await manager.create_session(
+            AWISessionCreate(target_url="https://example.com")
+        )
+
+        result = await manager.human_intervention(
+            AWIHumanIntervention(
+                session_id=session.session_id,
+                action="pause",
+                reason="operator pause",
+            )
+        )
+        stored_session = await manager.get_session(session.session_id)
+
+        assert result == {"success": True, "status": "paused"}
+        assert stored_session is not None
+        assert stored_session.status == AWISessionStatus.PAUSED
+        assert stored_session.paused_by_human is True
+
 
 class TestAWIRouter:
     """Test AWI router endpoints."""
@@ -647,7 +713,7 @@ class TestAWIRouter:
             )
             assert login["status"] == "provisional"
             assert login["risk_level"] == "high"
-            assert login["sensitive_parameters"] == ["password"]
+            assert login["sensitive_parameters"] == ["username", "password"]
             assert click["tier"] == "compatibility"
 
     @pytest.mark.anyio
@@ -665,10 +731,15 @@ class TestAWIRouter:
             assert data["profile"] == "awi-over-mcp"
             assert data["endpoints"]["execute"] == "/v1/awi/execute"
             assert data["safety_capabilities"]["sensitive_parameter_redaction"] is True
+            openapi = app.openapi()
+            manifest_schema = openapi["paths"]["/.well-known/awi.json"]["get"][
+                "responses"
+            ]["200"]["content"]["application/json"]["schema"]
             assert set(actions) == {action.value for action in AWIStandardAction}
             assert set(data["representation_types"]) == {
                 item.value for item in AWIRepresentationType
             }
+            assert manifest_schema == {"$ref": "#/components/schemas/AWIDiscoveryManifest"}
             assert actions["login"]["status"] == "provisional"
             assert actions["click_button"]["tier"] == "compatibility"
 

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -7,9 +7,11 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 
 from app.db.database import get_session_factory
-from app.db.models import ReceiptModel
+from app.db.models import LedgerEntryModel, ReceiptModel
 from app.main import app
+from app.schemas.billing import ServiceCategory
 from app.services.receipts import get_receipt_service
+from app.services.service_registry import get_service_registry
 from tests.test_trust_helpers import create_tool_permit, provision_agent_wallet
 
 
@@ -72,3 +74,236 @@ async def test_receipt_signature_verifies_and_detects_tampering(
     assert tampered_resp.status_code == 200
     assert tampered_resp.json()["valid"] is False
     assert tampered_resp.json()["reason"] == "receipt_signature_invalid"
+
+
+def _register_echo_tool(tool_name: str) -> None:
+    def echo(message: str = "ok") -> dict:
+        return {"message": message}
+
+    get_service_registry().register_local(
+        service_id=tool_name,
+        name=f"Evidence test {tool_name}",
+        description="Receipt evidence test tool",
+        category=ServiceCategory.AGENT_COMMS,
+        func=echo,
+        credits_per_unit=2.0,
+        unit_name="call",
+    )
+
+
+async def _create_governed_receipt(
+    client: AsyncClient,
+    *,
+    provisioned: dict,
+    tool_name: str,
+    idem_key: str,
+) -> tuple[dict, dict]:
+    permit = await create_tool_permit(
+        client,
+        wallet_id=provisioned["agent_wallet_id"],
+        key_id=provisioned["key_id"],
+        tool_name=tool_name,
+        idem_key=f"{idem_key}-permit",
+    )
+    response = await client.post(
+        "/mcp/messages",
+        json={
+            "jsonrpc": "2.0",
+            "id": f"{idem_key}-call",
+            "method": "tools/call",
+            "params": {
+                "name": tool_name,
+                "arguments": {"message": "hello"},
+                "mcpContext": {
+                    "wallet_id": provisioned["agent_wallet_id"],
+                    "permit_id": permit["permit_id"],
+                    "idempotency_key": idem_key,
+                },
+            },
+        },
+        headers=provisioned["agent_headers"],
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["result"]["isError"] is False
+    return permit, payload["result"]["receipt"]
+
+
+@pytest.mark.anyio
+async def test_receipt_evidence_links_governed_mcp_artifacts(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "receipt-evidence-tool"
+    registry = get_service_registry()
+    _register_echo_tool(tool_name)
+    try:
+        permit, receipt = await _create_governed_receipt(
+            client,
+            provisioned=provisioned,
+            tool_name=tool_name,
+            idem_key="receipt-evidence-success",
+        )
+        evidence_resp = await client.get(
+            f"/v1/receipts/{receipt['receipt_id']}/evidence",
+            headers=provisioned["agent_headers"],
+        )
+    finally:
+        registry.unregister_local(tool_name)
+
+    assert evidence_resp.status_code == 200
+    evidence = evidence_resp.json()
+    assert evidence["valid"] is True
+    assert evidence["permit"]["permit_id"] == permit["permit_id"]
+    assert evidence["receipt"]["receipt_id"] == receipt["receipt_id"]
+    assert evidence["audit_event"]["event"] == "mcp.invoke"
+    assert evidence["ledger_entry"]["entry_id"] == receipt["ledger_entry_id"]
+
+    checks = {check["name"]: check for check in evidence["checks"]}
+    for check_name in (
+        "wallet_access",
+        "receipt_signature",
+        "permit_signature",
+        "permit_wallet_binding",
+        "permit_tool_scope",
+        "audit_event_linkage",
+        "audit_chain",
+        "ledger_linkage",
+    ):
+        assert checks[check_name]["status"] == "passed"
+
+
+@pytest.mark.anyio
+async def test_receipt_evidence_denies_cross_wallet_access(
+    client,
+    clean_database,
+):
+    wallet_a = await provision_agent_wallet(client)
+    wallet_b = await provision_agent_wallet(client)
+    tool_name = "receipt-evidence-cross-wallet"
+    registry = get_service_registry()
+    _register_echo_tool(tool_name)
+    try:
+        _, receipt = await _create_governed_receipt(
+            client,
+            provisioned=wallet_a,
+            tool_name=tool_name,
+            idem_key="receipt-evidence-cross-wallet",
+        )
+        response = await client.get(
+            f"/v1/receipts/{receipt['receipt_id']}/evidence",
+            headers=wallet_b["agent_headers"],
+        )
+    finally:
+        registry.unregister_local(tool_name)
+
+    assert response.status_code == 403
+    assert response.json()["detail"]["error"] == "wallet_access_denied"
+
+
+@pytest.mark.anyio
+async def test_receipt_evidence_detects_ledger_tampering(
+    client,
+    clean_database,
+):
+    provisioned = await provision_agent_wallet(client)
+    tool_name = "receipt-evidence-ledger-tamper"
+    registry = get_service_registry()
+    _register_echo_tool(tool_name)
+    try:
+        _, receipt = await _create_governed_receipt(
+            client,
+            provisioned=provisioned,
+            tool_name=tool_name,
+            idem_key="receipt-evidence-ledger-tamper",
+        )
+    finally:
+        registry.unregister_local(tool_name)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(LedgerEntryModel).where(
+                LedgerEntryModel.entry_id == receipt["ledger_entry_id"]
+            )
+        )
+        entry = result.scalar_one()
+        entry.amount = Decimal("-999")
+        session.add(entry)
+        await session.commit()
+
+    evidence_resp = await client.get(
+        f"/v1/receipts/{receipt['receipt_id']}/evidence",
+        headers=provisioned["agent_headers"],
+    )
+
+    assert evidence_resp.status_code == 200
+    evidence = evidence_resp.json()
+    assert evidence["valid"] is False
+    checks = {check["name"]: check for check in evidence["checks"]}
+    assert checks["ledger_linkage"]["status"] == "failed"
+    assert checks["ledger_linkage"]["reason"] == "ledger_amount_mismatch"
+
+
+@pytest.mark.anyio
+async def test_receipt_evidence_does_not_expose_cross_wallet_artifacts(
+    client,
+    clean_database,
+):
+    wallet_a = await provision_agent_wallet(client)
+    wallet_b = await provision_agent_wallet(client)
+    tool_a = "receipt-evidence-wallet-a"
+    tool_b = "receipt-evidence-wallet-b"
+    registry = get_service_registry()
+    _register_echo_tool(tool_a)
+    _register_echo_tool(tool_b)
+    try:
+        _, receipt_a = await _create_governed_receipt(
+            client,
+            provisioned=wallet_a,
+            tool_name=tool_a,
+            idem_key="receipt-evidence-wallet-a",
+        )
+        _, receipt_b = await _create_governed_receipt(
+            client,
+            provisioned=wallet_b,
+            tool_name=tool_b,
+            idem_key="receipt-evidence-wallet-b",
+        )
+    finally:
+        registry.unregister_local(tool_a)
+        registry.unregister_local(tool_b)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(ReceiptModel).where(
+                ReceiptModel.receipt_id == receipt_a["receipt_id"]
+            )
+        )
+        model = result.scalar_one()
+        model.permit_id = receipt_b["permit_id"]
+        model.audit_event_id = receipt_b["audit_event_id"]
+        model.ledger_entry_id = receipt_b["ledger_entry_id"]
+        session.add(model)
+        await session.commit()
+
+    evidence_resp = await client.get(
+        f"/v1/receipts/{receipt_a['receipt_id']}/evidence",
+        headers=wallet_a["agent_headers"],
+    )
+
+    assert evidence_resp.status_code == 200
+    evidence = evidence_resp.json()
+    assert evidence["valid"] is False
+    assert evidence["permit"] is None
+    assert evidence["audit_event"] is None
+    assert evidence["ledger_entry"] is None
+
+    checks = {check["name"]: check for check in evidence["checks"]}
+    assert checks["permit_exists"]["status"] == "failed"
+    assert checks["audit_event_linkage"]["status"] == "failed"
+    assert checks["audit_event_linkage"]["reason"] == "audit_event_not_found"
+    assert checks["ledger_linkage"]["status"] == "failed"
+    assert checks["ledger_linkage"]["reason"] == "ledger_not_found"


### PR DESCRIPTION
## Summary
- publish a draft `/.well-known/awi.json` manifest for the AWI-over-MCP profile
- add action vocabulary metadata for tier/status/risk/sensitive parameters and update SDK types
- add transitional login validation, sensitive parameter redaction, and human intervention audit evidence
- add the draft action vocabulary spec and deterministic local representation benchmark harness

## Security / Trust Notes
- `login` remains backward compatible with `username` + `password`, but passwords are redacted from responses and durable session history
- `steer` audit evidence stores hashes/lengths, not full instructions
- cross-wallet intervention attempts are covered by negative-path tests

## Tests
- `.venv/bin/python -m pytest tests/ -q` (`663 passed, 1 skipped`)
- `ruff check app/ tests/ awi_sdk/python/ scripts/awi_representation_benchmark.py`
- `mypy app/`
- `.venv/bin/python scripts/export_openapi.py --check`
- `.venv/bin/python scripts/awi_representation_benchmark.py --check`
- `git diff --cached --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes touch AWI execution/intervention flows, adding parameter redaction and new audit logging for human steering, which could affect stored session data and security-sensitive behavior. Also introduces a new public discovery endpoint (`/.well-known/awi.json`) that must stay consistent with the exposed action vocabulary.
> 
> **Overview**
> Publishes a draft AWI-over-MCP discovery surface by adding `/.well-known/awi.json` (and updating agent bootstrap hints) that advertises AWI endpoints, supported `representation_types`, and the full action vocabulary.
> 
> Extends the AWI action vocabulary with **tier/status/risk/sensitive-parameter** metadata and standardizes API output via `AWIActionDefinition.to_public_dict()`, with matching type updates in the Python and TypeScript SDKs.
> 
> Hardens safety/audit behavior: `login` now supports `credential_handle` *or* legacy `username`/`password` validation while redacting sensitive parameters from `AWIExecutionResponse`, session `action_history`, and nested `fill_form` state; human interventions now record audit evidence (and store only hashes/lengths for `steer` instructions) while enforcing wallet-scoped access checks.
> 
> Adds a draft vocabulary spec doc plus a deterministic local representation benchmark script, and expands tests to cover manifest/vocabulary consistency, redaction, audit evidence, benchmark repeatability, and cross-wallet intervention denial.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d238510e26a6ea47dde5440c3b3b57faeb10916. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWI discovery endpoint (/.well-known/awi.json) exposing action vocabularies, risk levels, and security capabilities.
  * Enhanced action metadata with tier, maturity status, and risk classifications.
  * LOGIN action now supports credential handles for improved security.
  * Automatic redaction of sensitive parameters in action responses and session records.

* **Documentation**
  * Published AWI Action Vocabulary Specification describing core actions, metadata, and safety requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PetrefiedThunder/agent-middleware-api/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->