### PR TITLE
Add agent trust primitives (signed receipts, scoped permits, replay protection)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,40 @@ CAPTION_LANGUAGE=en
 # --- Rate Limiting ---
 RATE_LIMIT_PER_MINUTE=120
 
+# --- Replay Protection (idempotency / nonce) ---
+# Reject replayed state-changing requests that reuse an Idempotency-Key.
+# Durable across workers only when STATE_BACKEND is postgres/redis/sqlite.
+REPLAY_PROTECTION_ENABLED=true
+# Require an Idempotency-Key header on authenticated mutating requests (else 428).
+REPLAY_PROTECTION_REQUIRE_KEY=false
+REPLAY_PROTECTION_TTL_SECONDS=86400
+IDEMPOTENCY_KEY_HEADER=Idempotency-Key
+
+# --- Signed Receipts ---
+# Base64 Ed25519 private key seed (32 bytes) for signing ledger receipts.
+# Generate: python -c "import base64,os;print(base64.b64encode(os.urandom(32)).decode())"
+# If empty, an ephemeral key is generated per process (receipts won't verify
+# across restarts — set this in production).
+RECEIPT_SIGNING_KEY=
+# Fallback HMAC secret, used only if the cryptography library is unavailable.
+RECEIPT_HMAC_SECRET=
+
+# --- Signed Capability Permits ---
+PERMIT_SIGNING_KEY=
+PERMIT_HMAC_SECRET=
+PERMIT_DEFAULT_TTL_SECONDS=3600
+# Require a valid permit on billable MCP tool calls (X-Agent-Permit header).
+PERMITS_ENFORCED=false
+PERMIT_HEADER=X-Agent-Permit
+
+# --- Behavioral Sandbox ---
+# Python execution backend: disabled (default), docker, or unsafe_host.
+# Only docker provides a real process/network boundary for untrusted code.
+BEHAVIORAL_SANDBOX_PYTHON_BACKEND=disabled
+BEHAVIORAL_SANDBOX_DOCKER_IMAGE=python:3.12-slim
+# Local-dev escape hatch ONLY. Host Python is not a production sandbox.
+ALLOW_UNSAFE_HOST_PYTHON_SANDBOX=false
+
 # --- Billing / AgentMoney ---
 # 1000 credits = $1.00 USD (1 credit = $0.001)
 EXCHANGE_RATE=1000.0

--- a/.env.example
+++ b/.env.example
@@ -76,8 +76,9 @@ PERMITS_ENFORCED=false
 PERMIT_HEADER=X-Agent-Permit
 
 # --- Behavioral Sandbox ---
-# Python execution backend: disabled (default), docker, or unsafe_host.
-# Only docker provides a real process/network boundary for untrusted code.
+# Python execution backend: disabled (default), docker, gvisor, or unsafe_host.
+# docker/gvisor provide a real process/network boundary for untrusted code;
+# gvisor adds a user-space kernel (runsc runtime, must be installed on host).
 BEHAVIORAL_SANDBOX_PYTHON_BACKEND=disabled
 BEHAVIORAL_SANDBOX_DOCKER_IMAGE=python:3.12-slim
 # Local-dev escape hatch ONLY. Host Python is not a production sandbox.

--- a/app/audit/lightweight.py
+++ b/app/audit/lightweight.py
@@ -1,20 +1,51 @@
 """
-Minimal structured audit log (stdout via logging).
+Minimal structured audit log.
 
-Use for MCP invocations and other security-sensitive actions. Downstream can
-ship JSON logs to a collector without a full audit service yet.
+Emits one JSON object per line on the audit logger (for log shipping) and keeps
+a bounded in-memory ring buffer of recent events so an admin can inspect them
+via the audit export endpoint without a full audit service yet.
+
+The ring buffer is process-local and best-effort (recent events only). Durable
+audit history comes from shipping the JSON log lines to a collector.
 """
 
 from __future__ import annotations
 
+import threading
+import time
+from collections import deque
+from typing import Any
 import json
 import logging
-from typing import Any
 
 logger = logging.getLogger("agent_middleware.audit")
 
+_MAX_RECENT = 1000
+_recent: deque[dict[str, Any]] = deque(maxlen=_MAX_RECENT)
+_lock = threading.Lock()
+
 
 def record_audit(event: str, **fields: Any) -> None:
-    """Emit one JSON object per line on the audit logger (level INFO)."""
-    payload: dict[str, Any] = {"event": event, **fields}
+    """Emit one JSON object on the audit logger and retain it in the ring buffer."""
+    payload: dict[str, Any] = {
+        "event": event,
+        "ts": time.time(),
+        **fields,
+    }
+    with _lock:
+        _recent.append(payload)
     logger.info("%s", json.dumps(payload, default=str))
+
+
+def get_recent_audit(
+    limit: int = 100, event_prefix: str | None = None
+) -> list[dict[str, Any]]:
+    """Return the most recent audit events (newest last), optionally filtered by
+    an event-name prefix."""
+    with _lock:
+        events = list(_recent)
+    if event_prefix:
+        events = [e for e in events if str(e.get("event", "")).startswith(event_prefix)]
+    if limit > 0:
+        events = events[-limit:]
+    return events

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -4,13 +4,22 @@ Agents pass their key via the X-API-Key header. No cookies, no sessions,
 no OAuth dance — just a key and a handshake.
 """
 
+import hashlib
 from dataclasses import dataclass
 
 from fastapi import HTTPException, Security, status
 from fastapi.security import APIKeyHeader
+
+from ..audit.lightweight import record_audit
 from .config import get_settings
 
 settings = get_settings()
+
+
+def _key_fingerprint(raw_key: str) -> str:
+    """Short, non-reversible fingerprint of a key for audit logs (never the key)."""
+    return hashlib.sha256(raw_key.encode()).hexdigest()[:12]
+
 
 api_key_header = APIKeyHeader(
     name=settings.API_KEY_HEADER,
@@ -35,6 +44,13 @@ class AuthContext:
             return
         if self.wallet_id == wallet_id:
             return
+        record_audit(
+            "auth.wallet_access_denied",
+            source=self.source,
+            key_id=self.key_id,
+            caller_wallet=self.wallet_id,
+            target_wallet=wallet_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
@@ -48,6 +64,12 @@ class AuthContext:
         """Allow only trusted bootstrap/admin environment keys."""
         if self.is_bootstrap_admin:
             return
+        record_audit(
+            "auth.admin_access_denied",
+            source=self.source,
+            key_id=self.key_id,
+            caller_wallet=self.wallet_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={
@@ -115,6 +137,11 @@ async def get_auth_context(
         )
 
     if valid_keys or not settings.DEBUG:
+        record_audit(
+            "auth.denied",
+            reason="unknown_api_key",
+            key_fp=_key_fingerprint(stripped),
+        )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail={

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -160,8 +160,10 @@ class Settings(BaseSettings):
     PLAYWRIGHT_SESSION_TTL_SECONDS: int = 900
 
     # --- Behavioral Sandbox ---
-    # Python execution backend: disabled, docker, or unsafe_host. Docker is the
-    # only built-in backend intended to provide an actual process boundary.
+    # Python execution backend: disabled, docker, gvisor, or unsafe_host.
+    # docker and gvisor provide an actual process boundary (gvisor adds a
+    # user-space kernel via the runsc runtime — stronger multi-tenant isolation
+    # and requires gVisor installed on the host). unsafe_host is dev-only.
     BEHAVIORAL_SANDBOX_PYTHON_BACKEND: str = "disabled"
     BEHAVIORAL_SANDBOX_DOCKER_IMAGE: str = "python:3.12-slim"
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -47,6 +47,28 @@ class Settings(BaseSettings):
     # Comma-separated list of valid API keys (use a secrets manager in production)
     VALID_API_KEYS: str = ""
 
+    # --- Signed Receipts ---
+    # Base64-encoded Ed25519 private key seed (32 bytes) used to sign ledger
+    # receipts. When set, receipts are independently verifiable with the public
+    # key from GET /v1/billing/receipts/public-key. If empty, an ephemeral key
+    # is generated at startup (dev only — receipts won't verify across restarts).
+    RECEIPT_SIGNING_KEY: str = ""
+    # Fallback HMAC secret used only when the cryptography library (Ed25519) is
+    # unavailable. HMAC receipts are tamper-evident but not independently
+    # verifiable by third parties.
+    RECEIPT_HMAC_SECRET: str = ""
+
+    # --- Signed Capability Permits ---
+    # Base64-encoded Ed25519 private key seed for signing scoped permits.
+    # If empty, an ephemeral key is generated at startup (dev only).
+    PERMIT_SIGNING_KEY: str = ""
+    PERMIT_HMAC_SECRET: str = ""
+    PERMIT_DEFAULT_TTL_SECONDS: int = 3600  # 1h
+    # When true, billable MCP tool calls require a valid permit covering the
+    # tool. Default false so existing API-key-only flows keep working.
+    PERMITS_ENFORCED: bool = False
+    PERMIT_HEADER: str = "X-Agent-Permit"
+
     # --- Stripe Payment Processing ---
     STRIPE_SECRET_KEY: str = ""
     STRIPE_WEBHOOK_SECRET: str = ""
@@ -90,6 +112,19 @@ class Settings(BaseSettings):
 
     # --- Rate Limiting ---
     RATE_LIMIT_PER_MINUTE: int = 120
+
+    # --- Replay Protection (idempotency / nonce) ---
+    # When enabled, a state-changing request that carries an Idempotency-Key
+    # header is claimed exactly once per (api key, method, path, key). A repeat
+    # within the TTL is rejected with 409 so a captured request cannot be
+    # replayed to double-charge or re-execute.
+    REPLAY_PROTECTION_ENABLED: bool = True
+    # When true, mutating requests from an authenticated caller MUST carry an
+    # Idempotency-Key header (otherwise 428). Default false for compatibility.
+    REPLAY_PROTECTION_REQUIRE_KEY: bool = False
+    REPLAY_PROTECTION_TTL_SECONDS: int = 86400  # 24h, matches common practice
+    # Header carrying the idempotency token (Stripe-compatible default).
+    IDEMPOTENCY_KEY_HEADER: str = "Idempotency-Key"
 
     # --- LLM / AI Agent Intelligence ---
     # Provider: openai, azure, anthropic, ollama

--- a/app/core/durable_state.py
+++ b/app/core/durable_state.py
@@ -14,6 +14,7 @@ import aiosqlite
 import asyncio
 import json
 import logging
+import time as _time
 from dataclasses import asdict, is_dataclass
 from datetime import date, datetime, time
 from decimal import Decimal
@@ -62,6 +63,11 @@ class DurableStateStore:
         self._redis: redis.Redis | None = None
         self._pg_pool: asyncpg.Pool | None = None
         self._sqlite_conn: aiosqlite.Connection | None = None
+
+        # In-process nonce map for the memory backend (single-worker / tests).
+        # Maps nonce key -> monotonic expiry timestamp.
+        self._nonce_mem: dict[str, float] = {}
+        self._nonce_lock = asyncio.Lock()
 
     @property
     def backend(self) -> str:
@@ -120,6 +126,16 @@ class DurableStateStore:
                             )
                             """
                         )
+                        await conn.execute(
+                            """
+                            CREATE TABLE IF NOT EXISTS app_idempotency (
+                                namespace TEXT NOT NULL,
+                                nonce_key TEXT NOT NULL,
+                                expires_at TIMESTAMPTZ NOT NULL,
+                                PRIMARY KEY(namespace, nonce_key)
+                            )
+                            """
+                        )
                 elif self._backend == "redis":
                     self._redis = redis.from_url(
                         self._redis_url,
@@ -138,6 +154,16 @@ class DurableStateStore:
                             payload TEXT NOT NULL,
                             updated_at TEXT NOT NULL DEFAULT (datetime('now')),
                             PRIMARY KEY(namespace, state_key)
+                        )
+                        """
+                    )
+                    await self._sqlite_conn.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS app_idempotency (
+                            namespace TEXT NOT NULL,
+                            nonce_key TEXT NOT NULL,
+                            expires_at REAL NOT NULL,
+                            PRIMARY KEY(namespace, nonce_key)
                         )
                         """
                     )
@@ -305,6 +331,77 @@ class DurableStateStore:
             if key.startswith(f"{self.namespace}:"):
                 keys.append(key.split(":", 1)[1])
         return sorted(keys)
+
+    async def claim_once(self, key: str, ttl_seconds: int) -> bool:
+        """
+        Atomically claim a nonce / idempotency key for the first time.
+
+        Returns True if the key was newly claimed (the caller may proceed) or
+        False if it was already claimed within its TTL (a replay).
+
+        The claim is backed by the configured durable backend, so it holds
+        across workers when Postgres/Redis/SQLite is configured. With the
+        in-memory backend the claim is per-process only.
+        """
+        await self._ensure_ready()
+        ttl = max(1, int(ttl_seconds))
+
+        if self._backend == "postgres":
+            assert self._pg_pool is not None
+            async with self._pg_pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    WITH expired AS (
+                        DELETE FROM app_idempotency
+                        WHERE namespace = $1 AND nonce_key = $2
+                          AND expires_at < NOW()
+                    )
+                    INSERT INTO app_idempotency (namespace, nonce_key, expires_at)
+                    VALUES ($1, $2, NOW() + make_interval(secs => $3))
+                    ON CONFLICT (namespace, nonce_key) DO NOTHING
+                    RETURNING nonce_key
+                    """,
+                    self.namespace,
+                    key,
+                    ttl,
+                )
+            return row is not None
+
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            now = _time.time()
+            await self._sqlite_conn.execute(
+                "DELETE FROM app_idempotency WHERE namespace = ? "
+                "AND nonce_key = ? AND expires_at < ?",
+                (self.namespace, key, now),
+            )
+            cursor = await self._sqlite_conn.execute(
+                "INSERT OR IGNORE INTO app_idempotency "
+                "(namespace, nonce_key, expires_at) VALUES (?, ?, ?)",
+                (self.namespace, key, now + ttl),
+            )
+            await self._sqlite_conn.commit()
+            return cursor.rowcount == 1
+
+        if self._backend == "redis":
+            assert self._redis is not None
+            was_set = await self._redis.set(
+                self._redis_key(f"nonce:{key}"), "1", nx=True, ex=ttl
+            )
+            return bool(was_set)
+
+        # memory backend: per-process claim map with lazy expiry purge.
+        now = _time.time()
+        async with self._nonce_lock:
+            if len(self._nonce_mem) > 10_000:
+                self._nonce_mem = {
+                    k: exp for k, exp in self._nonce_mem.items() if exp > now
+                }
+            existing = self._nonce_mem.get(key)
+            if existing is not None and existing > now:
+                return False
+            self._nonce_mem[key] = now + ttl
+            return True
 
     async def health_report(self) -> dict[str, Any]:
         await self._ensure_ready()

--- a/app/core/durable_state.py
+++ b/app/core/durable_state.py
@@ -69,6 +69,10 @@ class DurableStateStore:
         self._nonce_mem: dict[str, float] = {}
         self._nonce_lock = asyncio.Lock()
 
+        # In-process budget map for the memory backend: key -> (spent, expiry).
+        self._budget_mem: dict[str, tuple[float, float]] = {}
+        self._budget_lock = asyncio.Lock()
+
     @property
     def backend(self) -> str:
         return self._backend
@@ -136,6 +140,17 @@ class DurableStateStore:
                             )
                             """
                         )
+                        await conn.execute(
+                            """
+                            CREATE TABLE IF NOT EXISTS app_budget (
+                                namespace TEXT NOT NULL,
+                                budget_key TEXT NOT NULL,
+                                spent DOUBLE PRECISION NOT NULL DEFAULT 0,
+                                expires_at TIMESTAMPTZ NOT NULL,
+                                PRIMARY KEY(namespace, budget_key)
+                            )
+                            """
+                        )
                 elif self._backend == "redis":
                     self._redis = redis.from_url(
                         self._redis_url,
@@ -164,6 +179,17 @@ class DurableStateStore:
                             nonce_key TEXT NOT NULL,
                             expires_at REAL NOT NULL,
                             PRIMARY KEY(namespace, nonce_key)
+                        )
+                        """
+                    )
+                    await self._sqlite_conn.execute(
+                        """
+                        CREATE TABLE IF NOT EXISTS app_budget (
+                            namespace TEXT NOT NULL,
+                            budget_key TEXT NOT NULL,
+                            spent REAL NOT NULL DEFAULT 0,
+                            expires_at REAL NOT NULL,
+                            PRIMARY KEY(namespace, budget_key)
                         )
                         """
                     )
@@ -402,6 +428,110 @@ class DurableStateStore:
                 return False
             self._nonce_mem[key] = now + ttl
             return True
+
+    async def consume_budget(
+        self, key: str, amount: float, cap: float, ttl_seconds: int
+    ) -> tuple[bool, float]:
+        """
+        Atomically add ``amount`` to a running total under ``key`` only if the
+        new total stays within ``cap``. Returns ``(allowed, total_after)``; on
+        rejection the stored total is left unchanged.
+
+        Backed by the durable backend so a spend allowance holds across workers
+        when Postgres/Redis/SQLite is configured.
+        """
+        await self._ensure_ready()
+        amount = float(amount)
+        cap = float(cap)
+        ttl = max(1, int(ttl_seconds))
+
+        if amount <= 0:
+            return True, 0.0
+        if amount > cap:
+            return False, 0.0
+
+        if self._backend == "postgres":
+            assert self._pg_pool is not None
+            async with self._pg_pool.acquire() as conn:
+                async with conn.transaction():
+                    await conn.execute(
+                        "DELETE FROM app_budget WHERE namespace = $1 "
+                        "AND budget_key = $2 AND expires_at < NOW()",
+                        self.namespace,
+                        key,
+                    )
+                    row = await conn.fetchrow(
+                        """
+                        INSERT INTO app_budget
+                            (namespace, budget_key, spent, expires_at)
+                        VALUES ($1, $2, $3, NOW() + make_interval(secs => $4))
+                        ON CONFLICT (namespace, budget_key) DO UPDATE
+                            SET spent = app_budget.spent + $3
+                            WHERE app_budget.spent + $3 <= $5
+                        RETURNING spent
+                        """,
+                        self.namespace,
+                        key,
+                        amount,
+                        ttl,
+                        cap,
+                    )
+            if row is not None:
+                return True, float(row["spent"])
+            return False, cap
+
+        if self._backend == "sqlite":
+            assert self._sqlite_conn is not None
+            now = _time.time()
+            await self._sqlite_conn.execute(
+                "DELETE FROM app_budget WHERE namespace = ? AND budget_key = ? "
+                "AND expires_at < ?",
+                (self.namespace, key, now),
+            )
+            async with self._sqlite_conn.execute(
+                "SELECT spent FROM app_budget WHERE namespace = ? AND budget_key = ?",
+                (self.namespace, key),
+            ) as cursor:
+                existing = await cursor.fetchone()
+            current = float(existing["spent"]) if existing else 0.0
+            if current + amount > cap:
+                await self._sqlite_conn.commit()
+                return False, current
+            new_total = current + amount
+            await self._sqlite_conn.execute(
+                """
+                INSERT INTO app_budget (namespace, budget_key, spent, expires_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(namespace, budget_key)
+                DO UPDATE SET spent = ?
+                """,
+                (self.namespace, key, new_total, now + ttl, new_total),
+            )
+            await self._sqlite_conn.commit()
+            return True, new_total
+
+        if self._backend == "redis":
+            assert self._redis is not None
+            redis_key = self._redis_key(f"budget:{key}")
+            new_total = float(await self._redis.incrbyfloat(redis_key, amount))
+            if new_total == amount:
+                await self._redis.expire(redis_key, ttl)
+            if new_total > cap:
+                await self._redis.incrbyfloat(redis_key, -amount)
+                return False, new_total - amount
+            return True, new_total
+
+        # memory backend
+        now = _time.time()
+        async with self._budget_lock:
+            spent, expiry = self._budget_mem.get(key, (0.0, 0.0))
+            if expiry and expiry <= now:
+                spent = 0.0
+            if spent + amount > cap:
+                return False, spent
+            new_total = spent + amount
+            self._budget_mem[key] = (new_total, now + ttl)
+            return True, new_total
 
     async def health_report(self) -> dict[str, Any]:
         await self._ensure_ready()

--- a/app/core/replay_protection.py
+++ b/app/core/replay_protection.py
@@ -1,0 +1,102 @@
+"""
+Replay Protection Middleware
+============================
+Rejects replayed state-changing requests.
+
+A mutating request (POST/PUT/PATCH/DELETE) that carries an ``Idempotency-Key``
+header is claimed exactly once per ``(api key, method, path, key)`` tuple via the
+durable state backend. A repeat within the retention window is rejected with
+``409`` so a captured request cannot be re-executed to double-charge or repeat a
+side effect.
+
+This is replay *rejection*, not Stripe-style cached-response idempotency: a
+replay returns ``409`` rather than the original response body. That is the right
+semantic for the anti-replay trust primitive; response caching could be layered
+on later for retry-safety.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+from .config import get_settings
+from .durable_state import get_durable_state
+
+logger = logging.getLogger(__name__)
+
+_MUTATING_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+
+class ReplayProtectionMiddleware(BaseHTTPMiddleware):
+    """Claim-once guard for mutating requests carrying an idempotency key."""
+
+    def __init__(self, app):
+        super().__init__(app)
+        settings = get_settings()
+        self._enabled = settings.REPLAY_PROTECTION_ENABLED
+        self._require_key = settings.REPLAY_PROTECTION_REQUIRE_KEY
+        self._ttl = settings.REPLAY_PROTECTION_TTL_SECONDS
+        self._header = settings.IDEMPOTENCY_KEY_HEADER
+        self._api_key_header = settings.API_KEY_HEADER
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not self._enabled or request.method not in _MUTATING_METHODS:
+            return await call_next(request)  # type: ignore[no-any-return]
+
+        idem_key = request.headers.get(self._header, "").strip()
+        api_key = request.headers.get(self._api_key_header, "").strip()
+
+        if not idem_key:
+            if self._require_key and api_key:
+                return JSONResponse(
+                    status_code=428,
+                    content={
+                        "detail": {
+                            "error": "idempotency_key_required",
+                            "message": (
+                                f"{self._header} header is required for "
+                                "state-changing requests."
+                            ),
+                        }
+                    },
+                )
+            return await call_next(request)  # type: ignore[no-any-return]
+
+        # Scope the nonce to the caller so tenants cannot collide on or probe
+        # each other's keyspace. Hash the API key so raw keys never reach storage.
+        caller = (
+            hashlib.sha256(api_key.encode()).hexdigest()[:32] if api_key else "anon"
+        )
+        nonce = f"idem:{caller}:{request.method}:{request.url.path}:{idem_key}"
+
+        try:
+            claimed = await get_durable_state().claim_once(nonce, self._ttl)
+        except Exception:
+            # Fail open on unexpected store errors (availability over strictness),
+            # consistent with the rate limiter. Signed-permit nonces fail closed.
+            logger.exception("replay_protection_store_error; allowing request")
+            return await call_next(request)  # type: ignore[no-any-return]
+
+        if not claimed:
+            return JSONResponse(
+                status_code=409,
+                content={
+                    "detail": {
+                        "error": "request_replayed",
+                        "message": (
+                            "This request was already processed. Reusing an "
+                            f"{self._header} within the retention window is "
+                            "not allowed."
+                        ),
+                        "idempotency_key": idem_key,
+                    }
+                },
+                headers={"Idempotency-Replayed": "true"},
+            )
+
+        return await call_next(request)  # type: ignore[no-any-return]

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -68,6 +68,12 @@ class WalletModel(SQLModel, table=True):
     kyc_verified_at: Optional[datetime] = Field(default=None)
     metadata_json: Optional[str] = Field(default=None)
 
+    # Signed-receipt chain head. Each ledger entry links to the previous via
+    # prev_hash; the wallet tracks the latest hash and sequence so new entries
+    # extend the chain without an extra query (the wallet row is already locked).
+    receipt_seq: int = Field(default=0)
+    last_receipt_hash: Optional[str] = Field(default=None, max_length=64)
+
     # Timestamps
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
@@ -116,6 +122,15 @@ class LedgerEntryModel(SQLModel, table=True):
         unique=True,  # Enforces idempotency at DB level
     )
     stripe_session_id: Optional[str] = Field(default=None, max_length=100, index=True)
+
+    # Signed-receipt fields. chain_seq orders entries within a wallet; prev_hash
+    # links to the prior entry's hash; entry_hash is sha256 over the canonical
+    # payload (which includes prev_hash); signature authenticates that payload.
+    chain_seq: Optional[int] = Field(default=None)
+    prev_hash: Optional[str] = Field(default=None, max_length=64)
+    entry_hash: Optional[str] = Field(default=None, max_length=64, index=True)
+    signature: Optional[str] = Field(default=None)
+    receipt_alg: Optional[str] = Field(default=None, max_length=20)
 
     # Timestamp
     timestamp: datetime = Field(default_factory=datetime.utcnow, index=True)

--- a/app/main.py
+++ b/app/main.py
@@ -25,6 +25,7 @@ from .core.config import get_settings
 from .core.durable_state import close_durable_state, get_durable_state
 from .core.health import gather_dependency_report
 from .core.rate_limiter import RateLimitMiddleware
+from .core.replay_protection import ReplayProtectionMiddleware
 from .db.database import init_db, close_db
 from .services.mcp_phase9_tools import (
     ensure_phase9_registered,
@@ -62,6 +63,8 @@ from .routers import (
     well_known,
     static,
     planner,
+    receipts,
+    permits,
 )
 
 settings = get_settings()
@@ -263,6 +266,13 @@ app = FastAPI(
 )
 
 # --- Middleware Stack ---
+# add_middleware prepends, so the last added runs outermost. Adding replay
+# protection before the rate limiter yields inbound order:
+#   CORS -> RateLimit -> ReplayProtection -> app
+# i.e. abusive replay attempts are throttled before they reach the nonce store.
+
+# Replay protection (claim-once on Idempotency-Key for mutating requests)
+app.add_middleware(ReplayProtectionMiddleware)
 
 # Rate limiting (enforces documented 120 req/min per API key)
 app.add_middleware(RateLimitMiddleware)
@@ -306,6 +316,8 @@ app.include_router(awi.router)
 app.include_router(awi_enhanced.router)
 app.include_router(discover.router)
 app.include_router(planner.router)
+app.include_router(receipts.router)
+app.include_router(permits.router)
 app.include_router(well_known.router)
 app.include_router(static.router)
 
@@ -594,6 +606,7 @@ async def root():
                     "GET /v1/dashboard/economics",
                     "GET /v1/dashboard/security",
                     "GET /v1/dashboard/telemetry",
+                    "GET /v1/dashboard/planner",
                     "GET /v1/dashboard/genesis",
                 ],
             },

--- a/app/main.py
+++ b/app/main.py
@@ -65,6 +65,7 @@ from .routers import (
     planner,
     receipts,
     permits,
+    admin,
 )
 
 settings = get_settings()
@@ -318,6 +319,7 @@ app.include_router(discover.router)
 app.include_router(planner.router)
 app.include_router(receipts.router)
 app.include_router(permits.router)
+app.include_router(admin.router)
 app.include_router(well_known.router)
 app.include_router(static.router)
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,0 +1,37 @@
+"""
+Admin-only operational endpoints. All require a bootstrap/admin API key.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+
+from ..audit.lightweight import get_recent_audit, record_audit
+from ..core.auth import AuthContext, get_auth_context
+
+router = APIRouter(prefix="/v1/admin", tags=["admin"])
+
+
+@router.get("/audit", summary="Export recent audit events (admin only)")
+async def export_audit(
+    auth: AuthContext = Depends(get_auth_context),
+    limit: int = Query(100, ge=1, le=1000, description="Max events to return"),
+    event: str | None = Query(None, description="Filter by event-name prefix"),
+) -> dict[str, Any]:
+    """Return recent structured audit events from the in-memory ring buffer.
+
+    Best-effort recent history; durable audit comes from shipping the audit
+    JSON log lines to a collector.
+    """
+    auth.require_bootstrap_admin()
+    events = get_recent_audit(limit=limit, event_prefix=event)
+    record_audit(
+        "admin.audit_export",
+        source=auth.source,
+        key_id=auth.key_id,
+        returned=len(events),
+        event_filter=event,
+    )
+    return {"count": len(events), "events": events}

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -284,6 +284,7 @@ async def _handle_tools_call(
 async def invoke_tool(
     service_id: str,
     request: ToolCallRequest,
+    raw_request: Request,
     auth: AuthContext = Depends(get_auth_context),
 ) -> ToolCallResponse:
     """
@@ -291,9 +292,10 @@ async def invoke_tool(
 
     This endpoint:
     1. Verifies the API key
-    2. Routes the call through the billing layer
-    3. Executes the service function (local) or forwards to API (persistent)
-    4. Returns the result
+    2. Enforces a capability permit when PERMITS_ENFORCED is set
+    3. Routes the call through the billing layer
+    4. Executes the service function (local) or forwards to API (persistent)
+    5. Returns the result
 
     For persistent services, see POST /v1/billing/services/{id}/invoke
     """
@@ -314,6 +316,26 @@ async def invoke_tool(
     if not mcp_context.wallet_id:
         raise HTTPException(status_code=400, detail="Missing wallet_id")
     auth.require_wallet_access(mcp_context.wallet_id)
+
+    if _permit_enforcement_enabled():
+        tool_cost = (
+            float(service.get("credits_per_unit", 1.0))
+            if isinstance(service, dict)
+            else 1.0
+        )
+        permit_token = raw_request.headers.get(get_settings().PERMIT_HEADER)
+        try:
+            await require_permit_for_tool(
+                permit_token,
+                wallet_id=mcp_context.wallet_id,
+                tool_name=service_id,
+                cost=tool_cost,
+            )
+        except PermitError as exc:
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "permit_denied", "reason": str(exc)},
+            )
 
     func = registry.get_local_func(service_id)
     if func:

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -213,9 +213,16 @@ async def _handle_tools_call(
     auth.require_wallet_access(wallet_id)
 
     if _permit_enforcement_enabled():
+        local_service = get_service_registry().get_local(tool_name)
+        tool_cost = (
+            float(local_service.get("credits_per_unit", 1.0)) if local_service else 0.0
+        )
         try:
             await require_permit_for_tool(
-                permit_token, wallet_id=wallet_id, tool_name=tool_name
+                permit_token,
+                wallet_id=wallet_id,
+                tool_name=tool_name,
+                cost=tool_cost,
             )
         except PermitError as exc:
             raise HTTPException(

--- a/app/routers/mcp.py
+++ b/app/routers/mcp.py
@@ -25,13 +25,19 @@ from pydantic import BaseModel, Field
 
 from ..audit.lightweight import record_audit
 from ..core.auth import AuthContext, get_auth_context
+from ..core.config import get_settings
 from ..services.service_registry import get_service_registry
 from ..services.mcp_generator import get_mcp_generator
+from ..services.permits import PermitError, require_permit_for_tool
 from ..schemas.billing import ServiceCategory
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/mcp", tags=["MCP"])
+
+
+def _permit_enforcement_enabled() -> bool:
+    return get_settings().PERMITS_ENFORCED
 
 
 class McpContext(BaseModel):
@@ -128,7 +134,8 @@ async def handle_messages(
 
     elif method == "tools/call":
         try:
-            result = await _handle_tools_call(params, auth)
+            permit_token = request.headers.get(get_settings().PERMIT_HEADER)
+            result = await _handle_tools_call(params, auth, permit_token)
             return JSONResponse(
                 {
                     "jsonrpc": "2.0",
@@ -178,14 +185,17 @@ async def _handle_tools_list(params: dict) -> dict:
     return {"tools": manifest["tools"]}
 
 
-async def _handle_tools_call(params: dict, auth: AuthContext) -> dict:
+async def _handle_tools_call(
+    params: dict, auth: AuthContext, permit_token: str | None = None
+) -> dict:
     """
     Handle MCP tools/call request.
 
     This routes through the existing billing layer:
     1. Extract wallet_id from mcp_context
-    2. Call the service via service registry
-    3. Return the result
+    2. Enforce a capability permit when PERMITS_ENFORCED is set
+    3. Call the service via service registry
+    4. Return the result
 
     For local services, we execute the function directly.
     For persistent services, we call the API endpoint.
@@ -201,6 +211,17 @@ async def _handle_tools_call(params: dict, auth: AuthContext) -> dict:
     if not wallet_id:
         raise ValueError("Missing wallet_id in mcpContext")
     auth.require_wallet_access(wallet_id)
+
+    if _permit_enforcement_enabled():
+        try:
+            await require_permit_for_tool(
+                permit_token, wallet_id=wallet_id, tool_name=tool_name
+            )
+        except PermitError as exc:
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "permit_denied", "reason": str(exc)},
+            )
 
     ok = False
     err: str | None = None

--- a/app/routers/permits.py
+++ b/app/routers/permits.py
@@ -1,0 +1,82 @@
+"""
+Capability permit endpoints: issue, introspect, and publish the signing key.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from ..core.auth import AuthContext, get_auth_context
+from ..services.permits import PermitError, get_permit_service
+
+router = APIRouter(prefix="/v1/permits", tags=["permits"])
+
+
+class PermitIssueRequest(BaseModel):
+    wallet_id: str = Field(..., description="Wallet the permit acts for")
+    scope: list[str] = Field(
+        ..., description="Allowed tool names / service ids ('*' = any)"
+    )
+    max_spend: float | None = Field(
+        None, description="Optional credit ceiling for the permit"
+    )
+    ttl_seconds: int | None = Field(
+        None, ge=1, description="Lifetime in seconds (defaults to server setting)"
+    )
+    agent_id: str | None = Field(None, description="Agent the permit is issued to")
+    single_use: bool = Field(
+        False, description="If true, the permit can be redeemed only once"
+    )
+
+
+class PermitIntrospectRequest(BaseModel):
+    permit: str = Field(..., description="The permit token to verify")
+
+
+@router.post("/issue", summary="Issue a signed scoped capability permit")
+async def issue_permit(
+    request: PermitIssueRequest,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict[str, Any]:
+    auth.require_wallet_access(request.wallet_id)
+    service = get_permit_service()
+    issued = service.issue(
+        wallet_id=request.wallet_id,
+        scope=request.scope,
+        max_spend=request.max_spend,
+        ttl_seconds=request.ttl_seconds,
+        agent_id=request.agent_id,
+        single_use=request.single_use,
+    )
+    return {
+        "permit": issued["permit"],
+        "claims": issued["claims"],
+        "algorithm": service.algorithm,
+    }
+
+
+@router.get("/public-key", summary="Permit signing public key")
+async def permit_public_key() -> dict[str, Any]:
+    service = get_permit_service()
+    return {
+        "algorithm": service.algorithm,
+        "public_key": service.public_key_b64(),
+        "encoding": "base64",
+        "verifiable_offline": service.algorithm == "ed25519",
+    }
+
+
+@router.post("/introspect", summary="Verify a permit and return its claims")
+async def introspect_permit(
+    request: PermitIntrospectRequest,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict[str, Any]:
+    service = get_permit_service()
+    try:
+        claims = service.decode(request.permit)
+    except PermitError as exc:
+        return {"valid": False, "error": str(exc)}
+    return {"valid": True, "claims": claims}

--- a/app/routers/receipts.py
+++ b/app/routers/receipts.py
@@ -1,0 +1,134 @@
+"""
+Signed receipt verification endpoints.
+
+Lets a wallet owner (or auditor with the public key) confirm that ledger
+entries are authentic and that a wallet's receipt chain is unbroken.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+
+from ..core.auth import AuthContext, get_auth_context
+from ..db.database import get_session_factory
+from ..db.models import LedgerEntryModel
+from ..services.receipts import get_receipt_service
+
+router = APIRouter(prefix="/v1/billing/receipts", tags=["billing"])
+
+
+def _receipt_dict(entry: LedgerEntryModel) -> dict[str, Any]:
+    return {
+        "entry_id": entry.entry_id,
+        "wallet_id": entry.wallet_id,
+        "action": entry.action,
+        "amount": str(entry.amount),
+        "balance_after": str(entry.balance_after),
+        "service_category": entry.service_category,
+        "description": entry.description,
+        "chain_seq": entry.chain_seq,
+        "prev_hash": entry.prev_hash,
+        "entry_hash": entry.entry_hash,
+        "signature": entry.signature,
+        "receipt_alg": entry.receipt_alg,
+        "timestamp": entry.timestamp.isoformat() if entry.timestamp else None,
+    }
+
+
+@router.get("/public-key", summary="Receipt signing public key")
+async def receipt_public_key() -> dict[str, Any]:
+    """Public key (and algorithm) used to sign receipts. Public on purpose so
+    third parties can verify receipts offline."""
+    receipts = get_receipt_service()
+    return {
+        "algorithm": receipts.algorithm,
+        "public_key": receipts.public_key_b64(),
+        "encoding": "base64",
+        "verifiable_offline": receipts.algorithm == "ed25519",
+    }
+
+
+@router.get("/entry/{entry_id}", summary="Get a signed receipt for a ledger entry")
+async def get_receipt(
+    entry_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict[str, Any]:
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(LedgerEntryModel).where(LedgerEntryModel.entry_id == entry_id)
+        )
+        entry = result.scalar_one_or_none()
+
+    if not entry:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error": "not_found", "message": "Ledger entry not found."},
+        )
+    auth.require_wallet_access(entry.wallet_id)
+
+    receipts = get_receipt_service()
+    return {
+        "receipt": _receipt_dict(entry),
+        "verified": receipts.verify_entry(entry),
+        "algorithm": receipts.algorithm,
+    }
+
+
+@router.get("/wallet/{wallet_id}/verify", summary="Verify a wallet's receipt chain")
+async def verify_chain(
+    wallet_id: str,
+    auth: AuthContext = Depends(get_auth_context),
+) -> dict[str, Any]:
+    auth.require_wallet_access(wallet_id)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(LedgerEntryModel)
+            .where(LedgerEntryModel.wallet_id == wallet_id)
+            .order_by(LedgerEntryModel.chain_seq.asc())
+        )
+        entries = list(result.scalars().all())
+    receipts = get_receipt_service()
+
+    checked = 0
+    prev_hash: str | None = None
+    broken: list[dict[str, Any]] = []
+
+    for entry in entries:
+        if entry.chain_seq is None or entry.entry_hash is None or not entry.signature:
+            broken.append(
+                {"entry_id": entry.entry_id, "reason": "unsigned_legacy_entry"}
+            )
+            continue
+        if (entry.prev_hash or None) != (prev_hash or None):
+            broken.append(
+                {
+                    "entry_id": entry.entry_id,
+                    "chain_seq": entry.chain_seq,
+                    "reason": "broken_link",
+                }
+            )
+        if not receipts.verify_entry(entry):
+            broken.append(
+                {
+                    "entry_id": entry.entry_id,
+                    "chain_seq": entry.chain_seq,
+                    "reason": "invalid_signature_or_hash",
+                }
+            )
+        prev_hash = entry.entry_hash
+        checked += 1
+
+    return {
+        "wallet_id": wallet_id,
+        "entries_total": len(entries),
+        "entries_checked": checked,
+        "chain_valid": len(entries) > 0 and len(broken) == 0,
+        "broken": broken,
+        "algorithm": receipts.algorithm,
+    }

--- a/app/services/agent_money.py
+++ b/app/services/agent_money.py
@@ -59,6 +59,7 @@ from ..db.converters import (
 )
 from ..services.velocity_monitor import get_velocity_monitor, WalletFrozenError
 from ..services.shadow_ledger import get_shadow_ledger, SimulatedChargeResult
+from ..services.receipts import build_signed_ledger_entry, get_receipt_service
 from ..schemas.billing import (
     WalletType,
     WalletStatus,
@@ -175,8 +176,10 @@ EXCHANGE_RATE = Decimal("1000.0")  # 1000 credits per $1 USD
 # Exceptions
 # ---------------------------------------------------------------------------
 
+
 class InsufficientFundsError(Exception):
     """Raised when a wallet has insufficient funds for a transaction."""
+
     def __init__(self, wallet_id: str, current: Decimal, required: Decimal):
         self.wallet_id = wallet_id
         self.current_balance = current
@@ -187,6 +190,7 @@ class InsufficientFundsError(Exception):
 
 class WalletNotFoundError(Exception):
     """Raised when a wallet is not found."""
+
     def __init__(self, wallet_id: str):
         self.wallet_id = wallet_id
         super().__init__(f"Wallet not found: {wallet_id}")
@@ -194,6 +198,7 @@ class WalletNotFoundError(Exception):
 
 class KYCVerificationRequiredError(Exception):
     """Raised when KYC verification is required but not completed."""
+
     def __init__(self, wallet_id: str, kyc_status: str):
         self.wallet_id = wallet_id
         self.kyc_status = kyc_status
@@ -206,6 +211,7 @@ class KYCVerificationRequiredError(Exception):
 # ---------------------------------------------------------------------------
 # Agent Money Engine
 # ---------------------------------------------------------------------------
+
 
 class AgentMoney:
     """
@@ -226,6 +232,7 @@ class AgentMoney:
     def __init__(self):
         self._session_factory = get_session_factory
         self._state = get_durable_state()
+        self._receipts = get_receipt_service()
 
     async def _get_session(self) -> AsyncSession:
         """Get a database session."""
@@ -263,7 +270,8 @@ class AgentMoney:
                     owner_key=owner_key,
                     metadata_json=_metadata_to_json(metadata),
                     kyc_status=(
-                        KYCStatus.PENDING.value if kyc_required
+                        KYCStatus.PENDING.value
+                        if kyc_required
                         else KYCStatus.NOT_REQUIRED.value
                     ),
                     status="pending_kyc" if kyc_required else "active",
@@ -271,15 +279,17 @@ class AgentMoney:
                 session.add(wallet)
 
                 if initial_credits > Decimal("0"):
-                    entry = LedgerEntryModel(
-                        entry_id=str(uuid.uuid4()),
-                        wallet_id=wallet_id,
-                        action=LedgerAction.CREDIT.value,
-                        amount=initial_credits,
-                        balance_after=initial_credits,
-                        description="Initial sponsor deposit",
+                    session.add(
+                        build_signed_ledger_entry(
+                            self._receipts,
+                            wallet=wallet,
+                            entry_id=str(uuid.uuid4()),
+                            action=LedgerAction.CREDIT.value,
+                            amount=initial_credits,
+                            balance_after=initial_credits,
+                            description="Initial sponsor deposit",
+                        )
                     )
-                    session.add(entry)
 
             await session.commit()
             logger.info(f"Created sponsor wallet {wallet_id} for {sponsor_name}")
@@ -343,24 +353,30 @@ class AgentMoney:
                 session.add(agent_wallet)
 
                 # Ledger entries
-                session.add(LedgerEntryModel(
-                    entry_id=str(uuid.uuid4()),
-                    wallet_id=sponsor_wallet_id,
-                    action=LedgerAction.TRANSFER.value,
-                    amount=-budget_credits,
-                    balance_after=sponsor.balance,
-                    description=(
-                        f"Provision agent wallet {agent_wallet_id} for {agent_id}"
-                    ),
-                ))
-                session.add(LedgerEntryModel(
-                    entry_id=str(uuid.uuid4()),
-                    wallet_id=agent_wallet_id,
-                    action=LedgerAction.TRANSFER.value,
-                    amount=budget_credits,
-                    balance_after=budget_credits,
-                    description=f"Provisioned from sponsor {sponsor_wallet_id}",
-                ))
+                session.add(
+                    build_signed_ledger_entry(
+                        self._receipts,
+                        wallet=sponsor,
+                        entry_id=str(uuid.uuid4()),
+                        action=LedgerAction.TRANSFER.value,
+                        amount=-budget_credits,
+                        balance_after=sponsor.balance,
+                        description=(
+                            f"Provision agent wallet {agent_wallet_id} for {agent_id}"
+                        ),
+                    )
+                )
+                session.add(
+                    build_signed_ledger_entry(
+                        self._receipts,
+                        wallet=agent_wallet,
+                        entry_id=str(uuid.uuid4()),
+                        action=LedgerAction.TRANSFER.value,
+                        amount=budget_credits,
+                        balance_after=budget_credits,
+                        description=f"Provisioned from sponsor {sponsor_wallet_id}",
+                    )
+                )
 
             await session.commit()
             logger.info(
@@ -395,9 +411,9 @@ class AgentMoney:
                 if not parent:
                     raise WalletNotFoundError(parent_wallet_id)
                 if parent.wallet_type not in (
-                        WalletType.AGENT.value,
-                        WalletType.CHILD.value,
-                    ):
+                    WalletType.AGENT.value,
+                    WalletType.CHILD.value,
+                ):
                     raise ValueError(
                         "Only agent or child wallets can spawn child wallets"
                     )
@@ -430,25 +446,31 @@ class AgentMoney:
                 session.add(child)
 
                 # Ledger entries
-                session.add(LedgerEntryModel(
-                    entry_id=str(uuid.uuid4()),
-                    wallet_id=parent_wallet_id,
-                    action=LedgerAction.TRANSFER.value,
-                    amount=-budget_credits,
-                    balance_after=parent.balance,
-                    description=(
-                        f"Delegate to child wallet {child_wallet_id} "
-                        f"({child_agent_id})"
-                    ),
-                ))
-                session.add(LedgerEntryModel(
-                    entry_id=str(uuid.uuid4()),
-                    wallet_id=child_wallet_id,
-                    action=LedgerAction.TRANSFER.value,
-                    amount=budget_credits,
-                    balance_after=budget_credits,
-                    description=f"Provisioned from parent {parent_wallet_id}",
-                ))
+                session.add(
+                    build_signed_ledger_entry(
+                        self._receipts,
+                        wallet=parent,
+                        entry_id=str(uuid.uuid4()),
+                        action=LedgerAction.TRANSFER.value,
+                        amount=-budget_credits,
+                        balance_after=parent.balance,
+                        description=(
+                            f"Delegate to child wallet {child_wallet_id} "
+                            f"({child_agent_id})"
+                        ),
+                    )
+                )
+                session.add(
+                    build_signed_ledger_entry(
+                        self._receipts,
+                        wallet=child,
+                        entry_id=str(uuid.uuid4()),
+                        action=LedgerAction.TRANSFER.value,
+                        amount=budget_credits,
+                        balance_after=budget_credits,
+                        description=f"Provisioned from parent {parent_wallet_id}",
+                    )
+                )
 
             await session.commit()
             logger.info(f"Spawned child wallet {child_wallet_id} for {child_agent_id}")
@@ -495,22 +517,28 @@ class AgentMoney:
                     parent.lifetime_credits += reclaim_amount
 
                     # Ledger entries
-                    session.add(LedgerEntryModel(
-                        entry_id=str(uuid.uuid4()),
-                        wallet_id=child_wallet_id,
-                        action=LedgerAction.TRANSFER.value,
-                        amount=-reclaim_amount,
-                        balance_after=Decimal("0"),
-                        description=f"Reclaimed to parent {parent.wallet_id}",
-                    ))
-                    session.add(LedgerEntryModel(
-                        entry_id=str(uuid.uuid4()),
-                        wallet_id=parent.wallet_id,
-                        action=LedgerAction.TRANSFER.value,
-                        amount=reclaim_amount,
-                        balance_after=parent.balance,
-                        description=f"Reclaimed from child {child_wallet_id}",
-                    ))
+                    session.add(
+                        build_signed_ledger_entry(
+                            self._receipts,
+                            wallet=child,
+                            entry_id=str(uuid.uuid4()),
+                            action=LedgerAction.TRANSFER.value,
+                            amount=-reclaim_amount,
+                            balance_after=Decimal("0"),
+                            description=f"Reclaimed to parent {parent.wallet_id}",
+                        )
+                    )
+                    session.add(
+                        build_signed_ledger_entry(
+                            self._receipts,
+                            wallet=parent,
+                            entry_id=str(uuid.uuid4()),
+                            action=LedgerAction.TRANSFER.value,
+                            amount=reclaim_amount,
+                            balance_after=parent.balance,
+                            description=f"Reclaimed from child {child_wallet_id}",
+                        )
+                    )
 
                 child.status = WalletStatus.CLOSED.value
 
@@ -591,24 +619,30 @@ class AgentMoney:
                 dest.lifetime_credits += amount
 
                 # Create ledger entries on both sides
-                session.add(LedgerEntryModel(
-                    entry_id=str(uuid.uuid4()),
-                    wallet_id=from_wallet_id,
-                    action=LedgerAction.TRANSFER.value,
-                    amount=-amount,
-                    balance_after=source.balance,
-                    description=description or f"Transfer to {to_wallet_id}",
-                    correlation_id=correlation_id,
-                ))
-                session.add(LedgerEntryModel(
-                    entry_id=str(uuid.uuid4()),
-                    wallet_id=to_wallet_id,
-                    action=LedgerAction.TRANSFER.value,
-                    amount=amount,
-                    balance_after=dest.balance,
-                    description=description or f"Transfer from {from_wallet_id}",
-                    correlation_id=correlation_id,
-                ))
+                session.add(
+                    build_signed_ledger_entry(
+                        self._receipts,
+                        wallet=source,
+                        entry_id=str(uuid.uuid4()),
+                        action=LedgerAction.TRANSFER.value,
+                        amount=-amount,
+                        balance_after=source.balance,
+                        description=description or f"Transfer to {to_wallet_id}",
+                        correlation_id=correlation_id,
+                    )
+                )
+                session.add(
+                    build_signed_ledger_entry(
+                        self._receipts,
+                        wallet=dest,
+                        entry_id=str(uuid.uuid4()),
+                        action=LedgerAction.TRANSFER.value,
+                        amount=amount,
+                        balance_after=dest.balance,
+                        description=description or f"Transfer from {from_wallet_id}",
+                        correlation_id=correlation_id,
+                    )
+                )
 
             await session.commit()
 
@@ -649,7 +683,8 @@ class AgentMoney:
             total_delegated = sum(w.lifetime_credits for w in children)
             total_reclaimed = sum(
                 w.lifetime_credits - w.balance - w.lifetime_debits
-                for w in children if w.status == WalletStatus.CLOSED.value
+                for w in children
+                if w.status == WalletStatus.CLOSED.value
             )
             active = [w for w in children if w.status == WalletStatus.ACTIVE.value]
             completed = [w for w in children if w.status == WalletStatus.CLOSED.value]
@@ -663,10 +698,7 @@ class AgentMoney:
                 "active_children": len(active),
                 "completed_children": len(completed),
                 "frozen_children": len(frozen),
-                "children": [
-                    wallet_model_to_response(w)
-                    for w in children
-                ],
+                "children": [wallet_model_to_response(w) for w in children],
             }
 
     async def _dry_run_charge(
@@ -718,7 +750,8 @@ class AgentMoney:
             simulated_balance_after=float(wallet.balance) - float(charge_amount),
             would_succeed=wallet.balance >= charge_amount,
             reason=(
-                None if wallet.balance >= charge_amount
+                None
+                if wallet.balance >= charge_amount
                 else "insufficient_simulated_funds"
             ),
             dry_run=True,
@@ -766,8 +799,8 @@ class AgentMoney:
         margin = charge_amount - compute_cost
 
         velocity_monitor = get_velocity_monitor()
-        velocity_result = (
-            await velocity_monitor.check_and_record_charge(wallet_id, charge_amount)
+        velocity_result = await velocity_monitor.check_and_record_charge(
+            wallet_id, charge_amount
         )
 
         if velocity_result.should_freeze:
@@ -837,9 +870,10 @@ class AgentMoney:
                 wallet.updated_at = datetime.now(timezone.utc)
 
                 entry_id = str(uuid.uuid4())
-                entry = LedgerEntryModel(
+                entry = build_signed_ledger_entry(
+                    self._receipts,
+                    wallet=wallet,
                     entry_id=entry_id,
-                    wallet_id=wallet_id,
                     action=LedgerAction.DEBIT.value,
                     amount=-charge_amount,
                     balance_after=wallet.balance,
@@ -862,8 +896,7 @@ class AgentMoney:
                         alert_type=AlertType.LOW_BALANCE.value,
                         current_balance=wallet.balance,
                         message=(
-                            f"Wallet balance low: "
-                            f"{wallet.balance} credits remaining."
+                            f"Wallet balance low: {wallet.balance} credits remaining."
                         ),
                         severity=AlertSeverity.WARNING.value,
                     )
@@ -913,9 +946,10 @@ class AgentMoney:
                 wallet.lifetime_credits += credits
                 wallet.updated_at = datetime.now(timezone.utc)
 
-                entry = LedgerEntryModel(
+                entry = build_signed_ledger_entry(
+                    self._receipts,
+                    wallet=wallet,
                     entry_id=str(uuid.uuid4()),
-                    wallet_id=wallet_id,
                     action=LedgerAction.CREDIT.value,
                     amount=credits,
                     balance_after=wallet.balance,
@@ -979,13 +1013,17 @@ class AgentMoney:
             for cat_data in by_service.values():
                 rev = cat_data["revenue"]
                 cat_data["margin_pct"] = (
-                    Decimal("100") * cat_data["margin"] / rev
-                ) if rev > 0 else Decimal("0")
+                    (Decimal("100") * cat_data["margin"] / rev)
+                    if rev > 0
+                    else Decimal("0")
+                )
 
             gross_margin = total_revenue - total_cost
             margin_pct = (
-                Decimal("100") * gross_margin / total_revenue
-            ) if total_revenue > 0 else Decimal("0")
+                (Decimal("100") * gross_margin / total_revenue)
+                if total_revenue > 0
+                else Decimal("0")
+            )
 
             # Top profitable actions
             top_actions = sorted(
@@ -1041,9 +1079,9 @@ class AgentMoney:
         async with self._session_factory()() as session:
             if wallet_id:
                 result = await session.execute(
-                    select(BillingAlertModel).where(
-                        BillingAlertModel.wallet_id == wallet_id
-                    ).order_by(BillingAlertModel.created_at.desc())
+                    select(BillingAlertModel)
+                    .where(BillingAlertModel.wallet_id == wallet_id)
+                    .order_by(BillingAlertModel.created_at.desc())
                 )
             else:
                 result = await session.execute(
@@ -1179,6 +1217,7 @@ class AgentMoney:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _metadata_to_json(metadata: dict | None) -> str | None:
     """Convert metadata dict to JSON string."""

--- a/app/services/behavioral_sandbox.py
+++ b/app/services/behavioral_sandbox.py
@@ -302,13 +302,14 @@ class BehavioralSandboxEngine:
         settings = get_settings()
         backend = settings.BEHAVIORAL_SANDBOX_PYTHON_BACKEND.strip().lower()
 
-        if backend == "docker":
+        if backend in ("docker", "gvisor"):
             return await self._execute_python_docker(
                 sandbox_code=sandbox_code,
                 timeout_seconds=timeout_seconds,
                 memory_limit_mb=memory_limit_mb,
                 env_vars=env_vars,
                 image=settings.BEHAVIORAL_SANDBOX_DOCKER_IMAGE,
+                runtime="runsc" if backend == "gvisor" else None,
             )
 
         if (
@@ -378,12 +379,16 @@ print(json.dumps(result))
         sandbox_code: str,
         memory_limit_mb: int,
         env_vars: dict[str, str],
+        runtime: str | None = None,
     ) -> list[str]:
         """Build the hardened ``docker run`` argv.
 
         Every isolation flag here is load-bearing: dropping any one of them
         weakens the container boundary. The ``test_sandbox_isolation`` suite
         asserts their presence so they cannot be silently removed.
+
+        ``runtime`` selects the OCI runtime (e.g. ``runsc`` for gVisor's
+        user-space kernel), giving a stronger boundary than the default runc.
         """
         command = [
             "docker",
@@ -419,6 +424,9 @@ print(json.dumps(result))
             "--env",
             "PYTHONUNBUFFERED=1",
         ]
+        if runtime:
+            # Insert right after "docker run" so it applies to the container.
+            command[2:2] = ["--runtime", runtime]
         for name, value in env_vars.items():
             if name.isidentifier() and name not in cls._RESERVED_ENV_NAMES:
                 command.extend(["--env", f"{name}={value}"])
@@ -433,6 +441,7 @@ print(json.dumps(result))
         memory_limit_mb: int,
         env_vars: dict[str, str],
         image: str,
+        runtime: str | None = None,
     ) -> dict[str, Any]:
         """Execute Python in an unprivileged, network-isolated Docker container."""
         command = self._build_docker_run_command(
@@ -440,6 +449,7 @@ print(json.dumps(result))
             sandbox_code=sandbox_code,
             memory_limit_mb=memory_limit_mb,
             env_vars=env_vars,
+            runtime=runtime,
         )
 
         try:

--- a/app/services/behavioral_sandbox.py
+++ b/app/services/behavioral_sandbox.py
@@ -311,7 +311,10 @@ class BehavioralSandboxEngine:
                 image=settings.BEHAVIORAL_SANDBOX_DOCKER_IMAGE,
             )
 
-        if backend in ("unsafe_host", "host") or settings.ALLOW_UNSAFE_HOST_PYTHON_SANDBOX:
+        if (
+            backend in ("unsafe_host", "host")
+            or settings.ALLOW_UNSAFE_HOST_PYTHON_SANDBOX
+        ):
             return await self._execute_python_host(
                 sandbox_code=sandbox_code,
                 timeout_seconds=timeout_seconds,
@@ -361,6 +364,68 @@ result = sandboxed_execute(context, dry_run)
 print(json.dumps(result))
 """
 
+    # Reserved environment names that callers may not override; these protect
+    # the container's isolation posture and Python startup behavior.
+    _RESERVED_ENV_NAMES = frozenset(
+        {"SANDBOX", "PYTHONDONTWRITEBYTECODE", "PYTHONUNBUFFERED", "PATH", "HOME"}
+    )
+
+    @classmethod
+    def _build_docker_run_command(
+        cls,
+        *,
+        image: str,
+        sandbox_code: str,
+        memory_limit_mb: int,
+        env_vars: dict[str, str],
+    ) -> list[str]:
+        """Build the hardened ``docker run`` argv.
+
+        Every isolation flag here is load-bearing: dropping any one of them
+        weakens the container boundary. The ``test_sandbox_isolation`` suite
+        asserts their presence so they cannot be silently removed.
+        """
+        command = [
+            "docker",
+            "run",
+            "--rm",
+            "--network",
+            "none",  # no network egress
+            "--memory",
+            f"{memory_limit_mb}m",
+            "--memory-swap",
+            f"{memory_limit_mb}m",  # forbid swap escape from the memory cap
+            "--cpus",
+            "1",
+            "--pids-limit",
+            "64",  # fork-bomb protection
+            "--ulimit",
+            "nofile=64:64",  # cap open file descriptors
+            "--ulimit",
+            "fsize=8388608:8388608",  # cap written file size to 8 MB
+            "--read-only",  # immutable root filesystem
+            "--tmpfs",
+            "/tmp:rw,noexec,nosuid,size=16m",
+            "--security-opt",
+            "no-new-privileges",
+            "--cap-drop",
+            "ALL",  # drop all Linux capabilities
+            "--user",
+            "65534:65534",  # run as nobody, never root
+            "--env",
+            "SANDBOX=true",
+            "--env",
+            "PYTHONDONTWRITEBYTECODE=1",
+            "--env",
+            "PYTHONUNBUFFERED=1",
+        ]
+        for name, value in env_vars.items():
+            if name.isidentifier() and name not in cls._RESERVED_ENV_NAMES:
+                command.extend(["--env", f"{name}={value}"])
+        # -I isolated mode, -S no site: minimal interpreter surface.
+        command.extend([image, "python", "-I", "-S", "-c", sandbox_code])
+        return command
+
     async def _execute_python_docker(
         self,
         sandbox_code: str,
@@ -369,37 +434,13 @@ print(json.dumps(result))
         env_vars: dict[str, str],
         image: str,
     ) -> dict[str, Any]:
-        """Execute Python in an unprivileged Docker container."""
-        command = [
-            "docker",
-            "run",
-            "--rm",
-            "--network",
-            "none",
-            "--memory",
-            f"{memory_limit_mb}m",
-            "--cpus",
-            "1",
-            "--pids-limit",
-            "64",
-            "--read-only",
-            "--tmpfs",
-            "/tmp:rw,noexec,nosuid,size=16m",
-            "--security-opt",
-            "no-new-privileges",
-            "--cap-drop",
-            "ALL",
-            "--user",
-            "65534:65534",
-            "--env",
-            "SANDBOX=true",
-            "--env",
-            "PYTHONDONTWRITEBYTECODE=1",
-        ]
-        for name, value in env_vars.items():
-            if name.isidentifier():
-                command.extend(["--env", f"{name}={value}"])
-        command.extend([image, "python", "-I", "-S", "-c", sandbox_code])
+        """Execute Python in an unprivileged, network-isolated Docker container."""
+        command = self._build_docker_run_command(
+            image=image,
+            sandbox_code=sandbox_code,
+            memory_limit_mb=memory_limit_mb,
+            env_vars=env_vars,
+        )
 
         try:
             proc = await asyncio.create_subprocess_exec(

--- a/app/services/permits.py
+++ b/app/services/permits.py
@@ -159,11 +159,14 @@ async def require_permit_for_tool(
     *,
     wallet_id: str,
     tool_name: str,
+    cost: float = 0.0,
 ) -> dict[str, Any]:
     """Authorize a tool call against a permit. Raises PermitError on failure.
 
-    For single-use permits the jti is claimed once via the durable nonce store,
-    so a captured permit cannot be replayed.
+    Enforces, in order: signature/expiry, wallet match, tool scope, single-use
+    replay (jti claimed once via the durable nonce store), and — when the permit
+    carries ``max_spend`` and a positive ``cost`` is supplied — a cumulative
+    spend allowance tracked per permit across calls (the allowance model).
     """
     if not token:
         raise PermitError("permit_required")
@@ -178,15 +181,26 @@ async def require_permit_for_tool(
     if "*" not in scope and tool_name not in scope:
         raise PermitError("out_of_scope")
 
+    ttl = max(1, int(claims.get("exp", 0)) - int(time.time()))
+
     if claims.get("single_use"):
         from ..core.durable_state import get_durable_state
 
-        ttl = max(1, int(claims.get("exp", 0)) - int(time.time()))
         claimed = await get_durable_state().claim_once(
             f"permit:{claims.get('jti')}", ttl
         )
         if not claimed:
             raise PermitError("permit_replayed")
+
+    max_spend = claims.get("max_spend")
+    if max_spend is not None and cost and float(cost) > 0:
+        from ..core.durable_state import get_durable_state
+
+        allowed, _ = await get_durable_state().consume_budget(
+            f"permit_spend:{claims.get('jti')}", float(cost), float(max_spend), ttl
+        )
+        if not allowed:
+            raise PermitError("spend_cap_exceeded")
 
     return claims
 

--- a/app/services/permits.py
+++ b/app/services/permits.py
@@ -1,0 +1,197 @@
+"""
+Signed Capability Permits
+=========================
+A permit is a compact, signed, expiring token that grants an agent scoped
+authority to invoke specific tools on behalf of a wallet, up to a spend cap.
+
+Format (JWT-like, but with a fixed algorithm — no alg negotiation):
+
+    base64url(payload_json) + "." + base64url(signature)
+
+Claims:
+    jti        unique permit id (also the replay nonce for single-use permits)
+    wallet_id  the wallet the permit acts for
+    scope      allowed tool names / service ids ("*" = any)
+    max_spend  optional credit ceiling (string Decimal), enforced where the
+               per-call cost is known
+    agent_id   optional agent the permit was issued to
+    iat / exp  issued-at / expiry (unix seconds)
+    single_use if true, the jti is claimed once via the durable nonce store so
+               the permit cannot be replayed
+
+The server verifies permits; with the Ed25519 public key an agent can also
+verify a permit it holds before presenting it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from functools import lru_cache
+from typing import Any, Iterable
+
+from ..core.config import get_settings
+
+try:
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    _ED25519_AVAILABLE = True
+except Exception:  # pragma: no cover - only when cryptography is missing
+    _ED25519_AVAILABLE = False
+
+
+class PermitError(Exception):
+    """Raised when a permit is malformed, invalid, expired, or unauthorized."""
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _b64url_decode(value: str) -> bytes:
+    pad = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + pad)
+
+
+class PermitService:
+    """Issues and verifies signed capability permits."""
+
+    def __init__(self, signing_key_b64: str = "", hmac_secret: str = ""):
+        self._ed_private: Any = None
+        self._ed_public: Any = None
+        self._hmac_secret: bytes = b""
+
+        if _ED25519_AVAILABLE:
+            self.algorithm = "ed25519"
+            if signing_key_b64:
+                self._ed_private = Ed25519PrivateKey.from_private_bytes(
+                    base64.b64decode(signing_key_b64)
+                )
+            else:
+                self._ed_private = Ed25519PrivateKey.generate()
+            self._ed_public = self._ed_private.public_key()
+        else:
+            self.algorithm = "hmac-sha256"
+            secret = hmac_secret or base64.b64encode(os.urandom(32)).decode()
+            self._hmac_secret = secret.encode()
+
+    def _sign(self, payload: bytes) -> bytes:
+        if self.algorithm == "ed25519":
+            return self._ed_private.sign(payload)
+        return hmac.new(self._hmac_secret, payload, hashlib.sha256).digest()
+
+    def _verify_sig(self, payload: bytes, sig: bytes) -> bool:
+        if self.algorithm == "ed25519":
+            try:
+                self._ed_public.verify(sig, payload)
+                return True
+            except InvalidSignature:
+                return False
+            except Exception:
+                return False
+        expected = hmac.new(self._hmac_secret, payload, hashlib.sha256).digest()
+        return hmac.compare_digest(sig, expected)
+
+    def public_key_b64(self) -> str | None:
+        if self.algorithm == "ed25519" and self._ed_public is not None:
+            raw = self._ed_public.public_bytes(Encoding.Raw, PublicFormat.Raw)
+            return base64.b64encode(raw).decode()
+        return None
+
+    def issue(
+        self,
+        *,
+        wallet_id: str,
+        scope: Iterable[str],
+        max_spend: Any = None,
+        ttl_seconds: int | None = None,
+        agent_id: str | None = None,
+        single_use: bool = False,
+    ) -> dict[str, Any]:
+        settings = get_settings()
+        now = int(time.time())
+        ttl = int(ttl_seconds or settings.PERMIT_DEFAULT_TTL_SECONDS)
+        claims = {
+            "jti": _b64url_encode(os.urandom(12)),
+            "wallet_id": wallet_id,
+            "scope": list(scope),
+            "max_spend": (str(max_spend) if max_spend is not None else None),
+            "agent_id": agent_id,
+            "iat": now,
+            "exp": now + max(1, ttl),
+            "single_use": bool(single_use),
+            "alg": self.algorithm,
+        }
+        payload = json.dumps(claims, sort_keys=True, separators=(",", ":")).encode()
+        token = f"{_b64url_encode(payload)}.{_b64url_encode(self._sign(payload))}"
+        return {"permit": token, "claims": claims}
+
+    def decode(self, token: str) -> dict[str, Any]:
+        """Verify signature and expiry, returning the claims. Raises PermitError."""
+        try:
+            payload_b64, sig_b64 = token.split(".", 1)
+            payload = _b64url_decode(payload_b64)
+            sig = _b64url_decode(sig_b64)
+        except Exception:
+            raise PermitError("malformed_permit")
+
+        if not self._verify_sig(payload, sig):
+            raise PermitError("invalid_signature")
+
+        try:
+            claims: dict[str, Any] = json.loads(payload)
+        except Exception:
+            raise PermitError("malformed_permit")
+
+        if int(claims.get("exp", 0)) < int(time.time()):
+            raise PermitError("expired")
+        return claims
+
+
+async def require_permit_for_tool(
+    token: str | None,
+    *,
+    wallet_id: str,
+    tool_name: str,
+) -> dict[str, Any]:
+    """Authorize a tool call against a permit. Raises PermitError on failure.
+
+    For single-use permits the jti is claimed once via the durable nonce store,
+    so a captured permit cannot be replayed.
+    """
+    if not token:
+        raise PermitError("permit_required")
+
+    service = get_permit_service()
+    claims = service.decode(token)
+
+    if claims.get("wallet_id") != wallet_id:
+        raise PermitError("wallet_mismatch")
+
+    scope = claims.get("scope") or []
+    if "*" not in scope and tool_name not in scope:
+        raise PermitError("out_of_scope")
+
+    if claims.get("single_use"):
+        from ..core.durable_state import get_durable_state
+
+        ttl = max(1, int(claims.get("exp", 0)) - int(time.time()))
+        claimed = await get_durable_state().claim_once(
+            f"permit:{claims.get('jti')}", ttl
+        )
+        if not claimed:
+            raise PermitError("permit_replayed")
+
+    return claims
+
+
+@lru_cache()
+def get_permit_service() -> PermitService:
+    settings = get_settings()
+    return PermitService(settings.PERMIT_SIGNING_KEY, settings.PERMIT_HMAC_SECRET)

--- a/app/services/receipts.py
+++ b/app/services/receipts.py
@@ -1,0 +1,192 @@
+"""
+Signed Receipts
+===============
+Makes ledger entries tamper-evident and independently verifiable.
+
+Each entry is hash-chained per wallet (``prev_hash`` links to the previous
+entry's ``entry_hash``) and signed over a canonical payload. With an Ed25519
+key, any third party can verify a receipt using the public key from
+``GET /v1/billing/receipts/public-key`` — without trusting the database.
+
+Tampering with any historical entry changes its ``entry_hash``, which breaks the
+``prev_hash`` linkage of every later entry and invalidates the signature.
+
+Signing backend:
+- Ed25519 (via ``cryptography``) when available — asymmetric, independently
+  verifiable. This is the default.
+- HMAC-SHA256 fallback when ``cryptography`` is absent — tamper-evident but only
+  verifiable by a holder of the server secret.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+from decimal import Decimal
+from functools import lru_cache
+from typing import Any
+
+from ..core.config import get_settings
+from ..db.models import LedgerEntryModel
+
+logger = logging.getLogger(__name__)
+
+try:
+    from cryptography.exceptions import InvalidSignature
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    _ED25519_AVAILABLE = True
+except Exception:  # pragma: no cover - only when cryptography is missing
+    _ED25519_AVAILABLE = False
+
+
+def _fmt_amount(value: Decimal | None) -> str:
+    """Canonical fixed-precision string so signing and verification agree
+    regardless of how the database round-trips the Decimal's exponent."""
+    if value is None:
+        return ""
+    return f"{Decimal(value):.8f}"
+
+
+class ReceiptService:
+    """Signs and verifies ledger receipts."""
+
+    def __init__(self, signing_key_b64: str = "", hmac_secret: str = ""):
+        self._ed_private: Any = None
+        self._ed_public: Any = None
+        self._hmac_secret: bytes = b""
+
+        if _ED25519_AVAILABLE:
+            self.algorithm = "ed25519"
+            if signing_key_b64:
+                seed = base64.b64decode(signing_key_b64)
+                self._ed_private = Ed25519PrivateKey.from_private_bytes(seed)
+            else:
+                self._ed_private = Ed25519PrivateKey.generate()
+                logger.warning(
+                    "RECEIPT_SIGNING_KEY not set; using an ephemeral Ed25519 key. "
+                    "Receipts will not verify across restarts — set "
+                    "RECEIPT_SIGNING_KEY in production."
+                )
+            self._ed_public = self._ed_private.public_key()
+        else:
+            self.algorithm = "hmac-sha256"
+            if hmac_secret:
+                self._hmac_secret = hmac_secret.encode()
+            else:
+                self._hmac_secret = base64.b64encode(os.urandom(32))
+                logger.warning(
+                    "cryptography unavailable and RECEIPT_HMAC_SECRET not set; "
+                    "using an ephemeral HMAC secret (dev only)."
+                )
+
+    def canonical_payload(
+        self, entry: LedgerEntryModel, prev_hash: str | None
+    ) -> bytes:
+        """Deterministic byte payload bound by the hash and signature."""
+        payload = {
+            "entry_id": entry.entry_id,
+            "wallet_id": entry.wallet_id,
+            "action": entry.action,
+            "amount": _fmt_amount(entry.amount),
+            "balance_after": _fmt_amount(entry.balance_after),
+            "service_category": entry.service_category or "",
+            "request_path": entry.request_path or "",
+            "description": entry.description or "",
+            "chain_seq": entry.chain_seq,
+            "prev_hash": prev_hash or "",
+            "timestamp": entry.timestamp.isoformat() if entry.timestamp else "",
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+    def hash_payload(self, payload: bytes) -> str:
+        return hashlib.sha256(payload).hexdigest()
+
+    def sign(self, payload: bytes) -> str:
+        if self.algorithm == "ed25519":
+            sig = self._ed_private.sign(payload)
+        else:
+            sig = hmac.new(self._hmac_secret, payload, hashlib.sha256).digest()
+        return base64.b64encode(sig).decode()
+
+    def verify(self, payload: bytes, signature_b64: str) -> bool:
+        try:
+            sig = base64.b64decode(signature_b64)
+        except Exception:
+            return False
+
+        if self.algorithm == "ed25519":
+            try:
+                self._ed_public.verify(sig, payload)
+                return True
+            except InvalidSignature:
+                return False
+            except Exception:
+                return False
+
+        expected = hmac.new(self._hmac_secret, payload, hashlib.sha256).digest()
+        return hmac.compare_digest(sig, expected)
+
+    def public_key_b64(self) -> str | None:
+        """Base64 raw Ed25519 public key, or None for the HMAC backend."""
+        if self.algorithm == "ed25519" and self._ed_public is not None:
+            raw = self._ed_public.public_bytes(Encoding.Raw, PublicFormat.Raw)
+            return base64.b64encode(raw).decode()
+        return None
+
+    def verify_entry(self, entry: LedgerEntryModel) -> bool:
+        """Verify a stored entry's hash and signature against its content."""
+        if not entry.signature or entry.entry_hash is None:
+            return False
+        payload = self.canonical_payload(entry, entry.prev_hash)
+        if self.hash_payload(payload) != entry.entry_hash:
+            return False
+        return self.verify(payload, entry.signature)
+
+
+def build_signed_ledger_entry(
+    receipts: ReceiptService,
+    *,
+    wallet: Any,
+    entry_id: str,
+    action: str,
+    amount: Decimal,
+    balance_after: Decimal,
+    **fields: Any,
+) -> LedgerEntryModel:
+    """Construct a ledger entry that extends the wallet's signed receipt chain.
+
+    The wallet row is expected to be locked by the caller's transaction, so
+    reading/advancing ``receipt_seq`` and ``last_receipt_hash`` is race-free.
+    """
+    seq = (wallet.receipt_seq or 0) + 1
+    prev_hash = wallet.last_receipt_hash
+    entry = LedgerEntryModel(
+        entry_id=entry_id,
+        wallet_id=wallet.wallet_id,
+        action=action,
+        amount=amount,
+        balance_after=balance_after,
+        chain_seq=seq,
+        prev_hash=prev_hash,
+        **fields,
+    )
+    payload = receipts.canonical_payload(entry, prev_hash)
+    entry.entry_hash = receipts.hash_payload(payload)
+    entry.signature = receipts.sign(payload)
+    entry.receipt_alg = receipts.algorithm
+
+    wallet.receipt_seq = seq
+    wallet.last_receipt_hash = entry.entry_hash
+    return entry
+
+
+@lru_cache()
+def get_receipt_service() -> ReceiptService:
+    settings = get_settings()
+    return ReceiptService(settings.RECEIPT_SIGNING_KEY, settings.RECEIPT_HMAC_SECRET)

--- a/app/services/stripe_integration.py
+++ b/app/services/stripe_integration.py
@@ -20,9 +20,10 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy import select
 
 from ..db.database import get_session_factory
-from ..db.models import WalletModel, LedgerEntryModel
+from ..db.models import WalletModel, LedgerEntryModel  # noqa: F401
 from ..core.config import get_settings
 from .agent_money import WalletNotFoundError
+from .receipts import build_signed_ledger_entry, get_receipt_service
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -40,14 +41,14 @@ class StripeIntegration:
 
     def __init__(self):
         self._session_factory = get_session_factory
+        self._receipts = get_receipt_service()
 
     @staticmethod
     def _is_duplicate_payment_intent_error(exc: IntegrityError) -> bool:
         """Return true only for the idempotency unique constraint."""
         message = str(getattr(exc, "orig", exc)).lower()
-        return (
-            "payment_intent_id" in message
-            and ("unique" in message or "duplicate" in message)
+        return "payment_intent_id" in message and (
+            "unique" in message or "duplicate" in message
         )
 
     async def create_top_up_intent(
@@ -173,8 +174,8 @@ class StripeIntegration:
         from ..services.notifications import get_notification_service
 
         wallet_id = payment_intent["metadata"].get("wallet_id")
-        error_msg = (
-            payment_intent.get("last_payment_error", {}).get("message", "Unknown error")
+        error_msg = payment_intent.get("last_payment_error", {}).get(
+            "message", "Unknown error"
         )
 
         logger.warning(f"Payment failed for wallet {wallet_id}: {error_msg}")
@@ -246,9 +247,10 @@ class StripeIntegration:
                     wallet.balance += amount
                     wallet.lifetime_credits += amount
 
-                    entry = LedgerEntryModel(
+                    entry = build_signed_ledger_entry(
+                        self._receipts,
+                        wallet=wallet,
                         entry_id=str(uuid4()),
-                        wallet_id=wallet_id,
                         action="credit",
                         amount=amount,
                         balance_after=wallet.balance,
@@ -297,9 +299,10 @@ class StripeIntegration:
                 wallet.balance -= amount
                 wallet.lifetime_debits += amount
 
-                entry = LedgerEntryModel(
+                entry = build_signed_ledger_entry(
+                    self._receipts,
+                    wallet=wallet,
                     entry_id=str(uuid4()),
-                    wallet_id=wallet_id,
                     action="refund",
                     amount=-amount,
                     balance_after=wallet.balance,

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6758,7 +6758,12 @@
               }
             }
           }
-        }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ]
       }
     },
     "/mcp/tools/{service_id}/invoke": {
@@ -9096,6 +9101,247 @@
             }
           }
         }
+      }
+    },
+    "/v1/billing/receipts/public-key": {
+      "get": {
+        "tags": [
+          "billing"
+        ],
+        "summary": "Receipt signing public key",
+        "description": "Public key (and algorithm) used to sign receipts. Public on purpose so\nthird parties can verify receipts offline.",
+        "operationId": "receipt_public_key_v1_billing_receipts_public_key_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Receipt Public Key V1 Billing Receipts Public Key Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/billing/receipts/entry/{entry_id}": {
+      "get": {
+        "tags": [
+          "billing"
+        ],
+        "summary": "Get a signed receipt for a ledger entry",
+        "operationId": "get_receipt_v1_billing_receipts_entry__entry_id__get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "entry_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entry Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Receipt V1 Billing Receipts Entry  Entry Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/billing/receipts/wallet/{wallet_id}/verify": {
+      "get": {
+        "tags": [
+          "billing"
+        ],
+        "summary": "Verify a wallet's receipt chain",
+        "operationId": "verify_chain_v1_billing_receipts_wallet__wallet_id__verify_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "wallet_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Wallet Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Verify Chain V1 Billing Receipts Wallet  Wallet Id  Verify Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/permits/issue": {
+      "post": {
+        "tags": [
+          "permits"
+        ],
+        "summary": "Issue a signed scoped capability permit",
+        "operationId": "issue_permit_v1_permits_issue_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermitIssueRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Issue Permit V1 Permits Issue Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ]
+      }
+    },
+    "/v1/permits/public-key": {
+      "get": {
+        "tags": [
+          "permits"
+        ],
+        "summary": "Permit signing public key",
+        "operationId": "permit_public_key_v1_permits_public_key_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Permit Public Key V1 Permits Public Key Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/permits/introspect": {
+      "post": {
+        "tags": [
+          "permits"
+        ],
+        "summary": "Verify a permit and return its claims",
+        "operationId": "introspect_permit_v1_permits_introspect_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PermitIntrospectRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Introspect Permit V1 Permits Introspect Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ]
       }
     },
     "/.well-known/mcp/tools.json": {
@@ -16681,6 +16927,86 @@
         ],
         "title": "PasskeyVerifyResponse",
         "description": "Response after successful passkey verification."
+      },
+      "PermitIntrospectRequest": {
+        "properties": {
+          "permit": {
+            "type": "string",
+            "title": "Permit",
+            "description": "The permit token to verify"
+          }
+        },
+        "type": "object",
+        "required": [
+          "permit"
+        ],
+        "title": "PermitIntrospectRequest"
+      },
+      "PermitIssueRequest": {
+        "properties": {
+          "wallet_id": {
+            "type": "string",
+            "title": "Wallet Id",
+            "description": "Wallet the permit acts for"
+          },
+          "scope": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scope",
+            "description": "Allowed tool names / service ids ('*' = any)"
+          },
+          "max_spend": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max Spend",
+            "description": "Optional credit ceiling for the permit"
+          },
+          "ttl_seconds": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 1.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl Seconds",
+            "description": "Lifetime in seconds (defaults to server setting)"
+          },
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id",
+            "description": "Agent the permit is issued to"
+          },
+          "single_use": {
+            "type": "boolean",
+            "title": "Single Use",
+            "description": "If true, the permit can be redeemed only once",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": [
+          "wallet_id",
+          "scope"
+        ],
+        "title": "PermitIssueRequest"
       },
       "PipelineListResponse": {
         "properties": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -9344,6 +9344,79 @@
         ]
       }
     },
+    "/v1/admin/audit": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Export recent audit events (admin only)",
+        "description": "Return recent structured audit events from the in-memory ring buffer.\n\nBest-effort recent history; durable audit comes from shipping the audit\nJSON log lines to a collector.",
+        "operationId": "export_audit_v1_admin_audit_get",
+        "security": [
+          {
+            "APIKeyHeader": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 1000,
+              "minimum": 1,
+              "description": "Max events to return",
+              "default": 100,
+              "title": "Limit"
+            },
+            "description": "Max events to return"
+          },
+          {
+            "name": "event",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by event-name prefix",
+              "title": "Event"
+            },
+            "description": "Filter by event-name prefix"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Export Audit V1 Admin Audit Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/.well-known/mcp/tools.json": {
       "get": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -6772,7 +6772,7 @@
           "MCP"
         ],
         "summary": "Invoke a registered MCP tool",
-        "description": "Invoke an MCP-enabled service.\n\nThis endpoint:\n1. Verifies the API key\n2. Routes the call through the billing layer\n3. Executes the service function (local) or forwards to API (persistent)\n4. Returns the result\n\nFor persistent services, see POST /v1/billing/services/{id}/invoke",
+        "description": "Invoke an MCP-enabled service.\n\nThis endpoint:\n1. Verifies the API key\n2. Enforces a capability permit when PERMITS_ENFORCED is set\n3. Routes the call through the billing layer\n4. Executes the service function (local) or forwards to API (persistent)\n5. Returns the result\n\nFor persistent services, see POST /v1/billing/services/{id}/invoke",
         "operationId": "Invoke_MCP_Tool_mcp_tools__service_id__invoke_post",
         "security": [
           {

--- a/docs/sim-inventory.json
+++ b/docs/sim-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-22T10:25:57.576717+00:00",
+  "generated_at": "2026-05-22T10:35:23.706362+00:00",
   "mcp_tool_count": 9,
   "mcp_tools_local": [
     {

--- a/docs/sim-inventory.json
+++ b/docs/sim-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-22T10:35:23.706362+00:00",
+  "generated_at": "2026-05-22T20:47:09.399665+00:00",
   "mcp_tool_count": 9,
   "mcp_tools_local": [
     {

--- a/docs/sim-inventory.json
+++ b/docs/sim-inventory.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-17T07:11:20.287900+00:00",
+  "generated_at": "2026-05-22T10:25:57.576717+00:00",
   "mcp_tool_count": 9,
   "mcp_tools_local": [
     {

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -47,6 +47,18 @@ and sandboxed execution.
 - Alembic migrations cover wallet/API-key/KYC/service registry schema drift.
 - Tests cover revoked/expired DB keys, cross-wallet denial, sandbox auth, MCP
   header auth, and migration creation.
+- A route-auth inventory test fails CI if any state-changing route lacks an
+  auth dependency (allowlisted exceptions require a documented reason).
+- Replay protection: mutating requests carrying an Idempotency-Key are claimed
+  once via the durable backend; replays return 409.
+- Signed receipts: every ledger entry is hash-chained per wallet and signed
+  (Ed25519 when available), so tampering is detectable and receipts are
+  independently verifiable via the published public key.
+- Signed capability permits: scoped, expiring, optionally single-use tokens can
+  gate billable MCP tool calls (enforced when PERMITS_ENFORCED is set).
+- Docker sandbox backend runs untrusted Python with no network, dropped
+  capabilities, a read-only root, non-root user, and memory/CPU/PID/file limits;
+  host execution stays disabled by default. Isolation flags are pinned by test.
 
 ## Primary Threats And Required Mitigations
 
@@ -139,6 +151,16 @@ Required controls:
 
 - Add structured audit events for every auth decision on sensitive routes.
 - Add admin-only audit export endpoints.
-- Replace subprocess sandbox execution with a hardened isolation provider.
-- Add a route inventory test that fails if a state-changing route lacks auth.
+- Enforce permit `max_spend` against per-call cost and track cumulative spend
+  (the allowance model); today permits enforce scope, expiry, and single-use.
+- Offer a stronger isolation provider (gVisor/Firecracker/managed) as an option
+  beyond the hardened Docker backend for multi-tenant untrusted execution.
 - Add ownership tests whenever new wallet-bound resources are introduced.
+
+### Recently closed
+
+- Route-auth inventory test guarding every state-changing route.
+- Replay protection (idempotency/nonce) on mutating requests.
+- Signed, hash-chained, independently verifiable ledger receipts.
+- Signed scoped capability permits with single-use replay protection.
+- Hardened, network-isolated Docker sandbox backend (host exec off by default).

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -149,18 +149,22 @@ Required controls:
 
 ## Open Security Work
 
-- Add structured audit events for every auth decision on sensitive routes.
-- Add admin-only audit export endpoints.
-- Enforce permit `max_spend` against per-call cost and track cumulative spend
-  (the allowance model); today permits enforce scope, expiry, and single-use.
-- Offer a stronger isolation provider (gVisor/Firecracker/managed) as an option
-  beyond the hardened Docker backend for multi-tenant untrusted execution.
-- Add ownership tests whenever new wallet-bound resources are introduced.
+- Persist audit events durably (a table or shipped log store); the in-memory
+  ring buffer behind the export endpoint only retains recent events per process.
+- Make `AgentMoney.charge` permit-aware so the spend allowance is enforced on
+  every billable path, not only MCP tool calls.
+- Offer Firecracker/microVM or a managed sandbox beyond the gVisor option for
+  the strictest multi-tenant untrusted execution.
+- Continue adding ownership tests whenever new wallet-bound resources appear.
 
 ### Recently closed
 
 - Route-auth inventory test guarding every state-changing route.
 - Replay protection (idempotency/nonce) on mutating requests.
 - Signed, hash-chained, independently verifiable ledger receipts.
-- Signed scoped capability permits with single-use replay protection.
-- Hardened, network-isolated Docker sandbox backend (host exec off by default).
+- Signed scoped capability permits with single-use replay protection and a
+  cumulative `max_spend` allowance enforced on MCP tool calls.
+- Structured audit events for auth denials + an admin-only audit export endpoint.
+- Hardened, network-isolated Docker sandbox backend plus an optional gVisor
+  (runsc) runtime; host exec off by default, isolation flags pinned by test.
+- Cross-wallet ownership tests for the receipts and permits endpoints.

--- a/migrations/versions/014_signed_receipts.py
+++ b/migrations/versions/014_signed_receipts.py
@@ -1,0 +1,49 @@
+"""Signed receipt chain columns on wallets and ledger_entries.
+
+Revision ID: 014_signed_receipts
+Revises: 013_optimizer_telemetry
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "014_signed_receipts"
+down_revision: Union[str, None] = "013_optimizer_telemetry"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Receipt chain head on the wallet.
+    op.add_column(
+        "wallets",
+        sa.Column("receipt_seq", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "wallets",
+        sa.Column("last_receipt_hash", sa.String(length=64), nullable=True),
+    )
+
+    # Per-entry receipt fields. Nullable so pre-existing rows remain valid.
+    op.add_column("ledger_entries", sa.Column("chain_seq", sa.Integer(), nullable=True))
+    op.add_column(
+        "ledger_entries", sa.Column("prev_hash", sa.String(length=64), nullable=True)
+    )
+    op.add_column(
+        "ledger_entries", sa.Column("entry_hash", sa.String(length=64), nullable=True)
+    )
+    op.add_column("ledger_entries", sa.Column("signature", sa.Text(), nullable=True))
+    op.add_column(
+        "ledger_entries", sa.Column("receipt_alg", sa.String(length=20), nullable=True)
+    )
+    op.create_index("ix_ledger_entries_entry_hash", "ledger_entries", ["entry_hash"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ledger_entries_entry_hash", table_name="ledger_entries")
+    for col in ("receipt_alg", "signature", "entry_hash", "prev_hash", "chain_seq"):
+        op.drop_column("ledger_entries", col)
+    op.drop_column("wallets", "last_receipt_hash")
+    op.drop_column("wallets", "receipt_seq")

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ aiocoap>=0.4.17          # CoAP protocol support
 # --- Telemetry / Autonomous PM ---
 httpx>=0.28.1           # Async HTTP client for git API calls
 
+# --- Planner Optimizer ---
+pulp>=2.8.0             # MILP solver for constrained action selection
+
 # --- Media Engine ---
 python-multipart>=0.0.27 # File upload support
 
@@ -24,6 +27,9 @@ redis>=7.4.0            # Redis-backed rate limiting and runtime persistence
 asyncpg>=0.30.0         # PostgreSQL-backed runtime persistence
 stripe>=15.1.0           # Stripe payment processing
 mcp>=1.0.0             # MCP (Model Context Protocol) SDK for tool servers
+
+# --- Signed Receipts ---
+cryptography>=44.0.0    # Ed25519 signing for independently verifiable receipts
 
 # --- Database ---
 sqlmodel>=0.0.38        # SQLAlchemy + Pydantic hybrid ORM

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,85 @@
+"""
+Tests for structured audit events and the admin-only audit export endpoint.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from app.audit.lightweight import get_recent_audit, record_audit
+from app.main import app
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def test_recent_audit_buffer_records_and_filters():
+    marker = f"test.audit.{uuid.uuid4().hex[:8]}"
+    record_audit(marker, detail="hello")
+    events = get_recent_audit(limit=1000, event_prefix=marker)
+    assert len(events) == 1
+    assert events[0]["event"] == marker
+    assert events[0]["detail"] == "hello"
+    assert "ts" in events[0]
+
+
+@pytest.mark.anyio
+async def test_audit_export_requires_admin(client):
+    # A wallet-scoped DB key is not a bootstrap admin.
+    headers = {"X-API-Key": "test-key"}
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={"sponsor_name": f"a-{uuid.uuid4().hex[:6]}", "email": "a@test.example"},
+        headers=headers,
+    )
+    wallet_id = sponsor.json()["wallet_id"]
+    key_resp = await client.post(
+        "/v1/api-keys",
+        json={"wallet_id": wallet_id, "key_name": "scoped"},
+        headers=headers,
+    )
+    scoped = {"X-API-Key": key_resp.json()["api_key"]}
+
+    denied = await client.get("/v1/admin/audit", headers=scoped)
+    assert denied.status_code == 403
+
+    allowed = await client.get("/v1/admin/audit", headers=headers)
+    assert allowed.status_code == 200
+    assert "events" in allowed.json()
+
+
+@pytest.mark.anyio
+async def test_wallet_access_denial_is_audited(client):
+    headers = {"X-API-Key": "test-key"}
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={"sponsor_name": f"b-{uuid.uuid4().hex[:6]}", "email": "b@test.example"},
+        headers=headers,
+    )
+    wallet_id = sponsor.json()["wallet_id"]
+    key_resp = await client.post(
+        "/v1/api-keys",
+        json={"wallet_id": wallet_id, "key_name": "scoped"},
+        headers=headers,
+    )
+    scoped = {"X-API-Key": key_resp.json()["api_key"]}
+
+    # Scoped key tries to act for a different wallet -> denied + audited.
+    denied = await client.post(
+        "/v1/permits/issue",
+        json={"wallet_id": "someone-elses-wallet", "scope": ["*"]},
+        headers=scoped,
+    )
+    assert denied.status_code == 403
+
+    export = await client.get(
+        "/v1/admin/audit?event=auth.wallet_access_denied", headers=headers
+    )
+    assert export.status_code == 200
+    events = export.json()["events"]
+    assert any(e.get("target_wallet") == "someone-elses-wallet" for e in events)

--- a/tests/test_permits.py
+++ b/tests/test_permits.py
@@ -1,0 +1,209 @@
+"""
+Tests for signed capability permits: the PermitService, the tool-call
+authorization helper, the HTTP endpoints, and MCP enforcement.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+import app.services.permits as permits_mod
+from app.main import app
+from app.routers import mcp as mcp_module
+from app.services.permits import (
+    PermitError,
+    PermitService,
+    get_permit_service,
+    require_permit_for_tool,
+)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+# --- PermitService ---
+
+
+def test_issue_and_decode_round_trip():
+    svc = PermitService()
+    issued = svc.issue(wallet_id="w1", scope=["tool-a"], max_spend=10)
+    claims = svc.decode(issued["permit"])
+    assert claims["wallet_id"] == "w1"
+    assert claims["scope"] == ["tool-a"]
+    assert claims["max_spend"] == "10"
+
+
+def test_decode_rejects_tampered_token():
+    svc = PermitService()
+    token = svc.issue(wallet_id="w1", scope=["*"])["permit"]
+    payload_b64, sig_b64 = token.split(".", 1)
+    # Swap the signature for another permit's signature.
+    other_sig = svc.issue(wallet_id="w2", scope=["*"])["permit"].split(".", 1)[1]
+    with pytest.raises(PermitError):
+        svc.decode(f"{payload_b64}.{other_sig}")
+
+
+def test_decode_rejects_expired(monkeypatch):
+    svc = PermitService()
+    token = svc.issue(wallet_id="w1", scope=["*"], ttl_seconds=10)["permit"]
+
+    class _FarFuture:
+        @staticmethod
+        def time():
+            return 9_999_999_999
+
+    monkeypatch.setattr(permits_mod, "time", _FarFuture)
+    with pytest.raises(PermitError) as exc:
+        svc.decode(token)
+    assert "expired" in str(exc.value)
+
+
+# --- require_permit_for_tool ---
+
+
+@pytest.mark.anyio
+async def test_permit_authorizes_in_scope_tool():
+    svc = get_permit_service()
+    token = svc.issue(wallet_id="w1", scope=["tool-a"])["permit"]
+    claims = await require_permit_for_tool(token, wallet_id="w1", tool_name="tool-a")
+    assert claims["wallet_id"] == "w1"
+
+
+@pytest.mark.anyio
+async def test_permit_rejects_out_of_scope_tool():
+    svc = get_permit_service()
+    token = svc.issue(wallet_id="w1", scope=["tool-a"])["permit"]
+    with pytest.raises(PermitError) as exc:
+        await require_permit_for_tool(token, wallet_id="w1", tool_name="tool-b")
+    assert "out_of_scope" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_permit_rejects_wallet_mismatch():
+    svc = get_permit_service()
+    token = svc.issue(wallet_id="w1", scope=["*"])["permit"]
+    with pytest.raises(PermitError) as exc:
+        await require_permit_for_tool(token, wallet_id="other", tool_name="x")
+    assert "wallet_mismatch" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_missing_permit_raises():
+    with pytest.raises(PermitError) as exc:
+        await require_permit_for_tool(None, wallet_id="w1", tool_name="x")
+    assert "permit_required" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_single_use_permit_cannot_be_replayed():
+    svc = get_permit_service()
+    token = svc.issue(wallet_id="w1", scope=["*"], single_use=True)["permit"]
+    await require_permit_for_tool(token, wallet_id="w1", tool_name="x")
+    with pytest.raises(PermitError) as exc:
+        await require_permit_for_tool(token, wallet_id="w1", tool_name="x")
+    assert "permit_replayed" in str(exc.value)
+
+
+# --- HTTP endpoints ---
+
+
+@pytest.mark.anyio
+async def test_issue_and_introspect_endpoints(client):
+    headers = {"X-API-Key": "test-key"}
+    issued = await client.post(
+        "/v1/permits/issue",
+        json={"wallet_id": "w-http", "scope": ["tool-a"], "ttl_seconds": 600},
+        headers=headers,
+    )
+    assert issued.status_code == 200
+    token = issued.json()["permit"]
+
+    introspect = await client.post(
+        "/v1/permits/introspect", json={"permit": token}, headers=headers
+    )
+    assert introspect.status_code == 200
+    body = introspect.json()
+    assert body["valid"] is True
+    assert body["claims"]["wallet_id"] == "w-http"
+
+
+@pytest.mark.anyio
+async def test_introspect_rejects_garbage(client):
+    headers = {"X-API-Key": "test-key"}
+    resp = await client.post(
+        "/v1/permits/introspect", json={"permit": "not-a-real-token"}, headers=headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["valid"] is False
+
+
+@pytest.mark.anyio
+async def test_cross_wallet_permit_issue_denied(client):
+    """A DB key scoped to wallet A cannot mint a permit for wallet B."""
+    headers = {"X-API-Key": "test-key"}
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={"sponsor_name": f"p-{uuid.uuid4().hex[:6]}", "email": "p@test.example"},
+        headers=headers,
+    )
+    wallet_id = sponsor.json()["wallet_id"]
+    key_resp = await client.post(
+        "/v1/api-keys",
+        json={"wallet_id": wallet_id, "key_name": "scoped"},
+        headers=headers,
+    )
+    scoped = {"X-API-Key": key_resp.json()["api_key"]}
+
+    denied = await client.post(
+        "/v1/permits/issue",
+        json={"wallet_id": "some-other-wallet", "scope": ["*"]},
+        headers=scoped,
+    )
+    assert denied.status_code == 403
+
+
+# --- MCP enforcement ---
+
+
+@pytest.mark.anyio
+async def test_mcp_tool_call_denied_without_permit_when_enforced(client, monkeypatch):
+    monkeypatch.setattr(mcp_module, "_permit_enforcement_enabled", lambda: True)
+    resp = await client.post(
+        "/mcp/messages",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "any-tool", "mcpContext": {"wallet_id": "w1"}},
+        },
+        headers={"X-API-Key": "test-key"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["error"] == "permit_denied"
+
+
+@pytest.mark.anyio
+async def test_mcp_tool_call_allowed_with_valid_permit(client, monkeypatch):
+    monkeypatch.setattr(mcp_module, "_permit_enforcement_enabled", lambda: True)
+    token = get_permit_service().issue(wallet_id="w1", scope=["any-tool"])["permit"]
+    resp = await client.post(
+        "/mcp/messages",
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "any-tool", "mcpContext": {"wallet_id": "w1"}},
+        },
+        headers={"X-API-Key": "test-key", "X-Agent-Permit": token},
+    )
+    # Permit passed the gate; the tool itself doesn't exist, so we get a
+    # JSON-RPC error rather than a 403 permit denial.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "error" in body
+    assert "not found" in body["error"]["message"].lower()

--- a/tests/test_permits.py
+++ b/tests/test_permits.py
@@ -249,3 +249,37 @@ async def test_mcp_tool_call_allowed_with_valid_permit(client, monkeypatch):
     body = resp.json()
     assert "error" in body
     assert "not found" in body["error"]["message"].lower()
+
+
+@pytest.mark.anyio
+async def test_http_invoke_path_also_enforces_permit(client, monkeypatch):
+    """The HTTP invoke endpoint must enforce permits too — not just JSON-RPC —
+    so PERMITS_ENFORCED cannot be bypassed by choosing the other path."""
+    from app.schemas.billing import ServiceCategory
+    from app.services.service_registry import get_service_registry
+
+    monkeypatch.setattr(mcp_module, "_permit_enforcement_enabled", lambda: True)
+    get_service_registry().register_local(
+        service_id="echo-tool",
+        name="Echo",
+        description="echo",
+        category=ServiceCategory.PLATFORM_FEE,
+        func=lambda **kw: {"ok": True},
+        credits_per_unit=1.0,
+    )
+    body = {"name": "echo-tool", "arguments": {}, "mcp_context": {"wallet_id": "w1"}}
+
+    denied = await client.post(
+        "/mcp/tools/echo-tool/invoke", json=body, headers={"X-API-Key": "test-key"}
+    )
+    assert denied.status_code == 403
+    assert denied.json()["detail"]["error"] == "permit_denied"
+
+    token = get_permit_service().issue(wallet_id="w1", scope=["echo-tool"])["permit"]
+    allowed = await client.post(
+        "/mcp/tools/echo-tool/invoke",
+        json=body,
+        headers={"X-API-Key": "test-key", "X-Agent-Permit": token},
+    )
+    assert allowed.status_code == 200
+    assert allowed.json()["isError"] is False

--- a/tests/test_permits.py
+++ b/tests/test_permits.py
@@ -109,6 +109,48 @@ async def test_single_use_permit_cannot_be_replayed():
     assert "permit_replayed" in str(exc.value)
 
 
+# --- spend allowance (max_spend) ---
+
+
+@pytest.mark.anyio
+async def test_consume_budget_accumulates_and_caps():
+    from app.core.durable_state import get_durable_state
+
+    store = get_durable_state()
+    key = f"budget-{uuid.uuid4()}"
+
+    ok, total = await store.consume_budget(key, 4.0, 10.0, 60)
+    assert ok is True and total == 4.0
+    ok, total = await store.consume_budget(key, 4.0, 10.0, 60)
+    assert ok is True and total == 8.0
+    # 8 + 4 = 12 > 10 -> rejected, total unchanged
+    ok, total = await store.consume_budget(key, 4.0, 10.0, 60)
+    assert ok is False and total == 8.0
+
+
+@pytest.mark.anyio
+async def test_permit_enforces_cumulative_spend_cap():
+    svc = get_permit_service()
+    token = svc.issue(wallet_id="w1", scope=["t"], max_spend=10)["permit"]
+
+    await require_permit_for_tool(token, wallet_id="w1", tool_name="t", cost=4)
+    await require_permit_for_tool(token, wallet_id="w1", tool_name="t", cost=4)
+    with pytest.raises(PermitError) as exc:
+        await require_permit_for_tool(token, wallet_id="w1", tool_name="t", cost=4)
+    assert "spend_cap_exceeded" in str(exc.value)
+
+
+@pytest.mark.anyio
+async def test_permit_without_max_spend_ignores_cost():
+    svc = get_permit_service()
+    token = svc.issue(wallet_id="w1", scope=["t"])["permit"]  # no max_spend
+    # Large cost is fine when no cap is set.
+    claims = await require_permit_for_tool(
+        token, wallet_id="w1", tool_name="t", cost=1000
+    )
+    assert claims["max_spend"] is None
+
+
 # --- HTTP endpoints ---
 
 

--- a/tests/test_replay_protection.py
+++ b/tests/test_replay_protection.py
@@ -1,0 +1,123 @@
+"""
+Tests for replay protection: the durable claim-once primitive and the
+ReplayProtectionMiddleware that rejects replayed mutating requests.
+"""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+from app.core.durable_state import get_durable_state
+from app.main import app
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _planner_body():
+    return {
+        "state": {
+            "wallet_id": "w1",
+            "agent_id": "a1",
+            "task_id": "t1",
+            "request_id": "r1",
+            "wallet_balance": 100,
+            "daily_spend_used": 0,
+            "daily_limit": 100,
+            "rate_limit_headroom": 1,
+            "service_health": {},
+            "simulation_flags": {},
+            "auth_scope": ["invoke"],
+            "task_context": {"candidate_actions": []},
+            "remaining_budget": 10,
+            "slo_window_seconds": 2,
+        }
+    }
+
+
+# --- claim_once primitive ---
+
+
+@pytest.mark.anyio
+async def test_claim_once_first_claim_succeeds_then_replays_fail():
+    store = get_durable_state()
+    key = f"test-nonce-{uuid.uuid4()}"
+
+    assert await store.claim_once(key, 60) is True
+    assert await store.claim_once(key, 60) is False
+    assert await store.claim_once(key, 60) is False
+
+
+@pytest.mark.anyio
+async def test_claim_once_distinct_keys_are_independent():
+    store = get_durable_state()
+    a = f"test-nonce-{uuid.uuid4()}"
+    b = f"test-nonce-{uuid.uuid4()}"
+
+    assert await store.claim_once(a, 60) is True
+    assert await store.claim_once(b, 60) is True
+
+
+@pytest.mark.anyio
+async def test_claim_once_reclaimable_after_expiry():
+    store = get_durable_state()
+    key = f"test-nonce-{uuid.uuid4()}"
+
+    assert await store.claim_once(key, 60) is True
+    # Force the in-memory claim to look expired, then it must be reclaimable.
+    if key in store._nonce_mem:
+        store._nonce_mem[key] = 0.0
+    assert await store.claim_once(key, 60) is True
+
+
+# --- middleware behavior ---
+
+
+@pytest.mark.anyio
+async def test_replayed_request_is_rejected(client):
+    idem = str(uuid.uuid4())
+    headers = {"Idempotency-Key": idem}
+
+    first = await client.post(
+        "/v1/planner/optimize", json=_planner_body(), headers=headers
+    )
+    assert first.status_code != 409
+
+    second = await client.post(
+        "/v1/planner/optimize", json=_planner_body(), headers=headers
+    )
+    assert second.status_code == 409
+    assert second.json()["detail"]["error"] == "request_replayed"
+    assert second.headers.get("Idempotency-Replayed") == "true"
+
+
+@pytest.mark.anyio
+async def test_distinct_idempotency_keys_both_pass(client):
+    body = _planner_body()
+    r1 = await client.post(
+        "/v1/planner/optimize",
+        json=body,
+        headers={"Idempotency-Key": str(uuid.uuid4())},
+    )
+    r2 = await client.post(
+        "/v1/planner/optimize",
+        json=body,
+        headers={"Idempotency-Key": str(uuid.uuid4())},
+    )
+    assert r1.status_code != 409
+    assert r2.status_code != 409
+
+
+@pytest.mark.anyio
+async def test_no_idempotency_key_is_not_enforced(client):
+    """Backwards compatible: absent the header, repeats are allowed."""
+    body = _planner_body()
+    r1 = await client.post("/v1/planner/optimize", json=body)
+    r2 = await client.post("/v1/planner/optimize", json=body)
+    assert r1.status_code != 409
+    assert r2.status_code != 409

--- a/tests/test_route_auth_inventory.py
+++ b/tests/test_route_auth_inventory.py
@@ -1,0 +1,92 @@
+"""
+Route auth inventory guard.
+
+Fails if any state-changing route (POST/PUT/PATCH/DELETE) is reachable without
+an authentication dependency. This is a structural regression test: it does not
+exercise the routes, it inspects the resolved FastAPI dependency graph.
+
+When you add a new state-changing route, it must either depend on
+``get_auth_context`` / ``verify_api_key`` (directly or transitively) or be
+added to ``PUBLIC_STATE_CHANGING_ROUTES`` below with a documented reason.
+"""
+
+from __future__ import annotations
+
+from fastapi.routing import APIRoute
+
+from app.core.auth import get_auth_context, verify_api_key
+from app.main import app
+
+# Routes intentionally reachable without an API key. Each entry needs a reason
+# because every addition widens the unauthenticated attack surface.
+PUBLIC_STATE_CHANGING_ROUTES: dict[tuple[str, str], str] = {
+    ("POST", "/v1/planner/optimize"): (
+        "Stateless advisory action-selection. No side effects, no wallet "
+        "mutation; safe to expose unauthenticated by design."
+    ),
+    ("POST", "/v1/webhooks/stripe"): (
+        "Authenticated by Stripe webhook signature (STRIPE_WEBHOOK_SECRET), "
+        "not by the X-API-Key scheme. Rejects missing/invalid signatures."
+    ),
+    ("POST", "/v1/webhooks/stripe/identity"): (
+        "Authenticated by Stripe webhook signature (STRIPE_WEBHOOK_SECRET), "
+        "not by the X-API-Key scheme. Rejects missing/invalid signatures."
+    ),
+}
+
+_AUTH_CALLS = {get_auth_context, verify_api_key}
+
+
+def _route_has_auth(route: APIRoute) -> bool:
+    """True if an auth dependency appears anywhere in the route's dependant tree."""
+    dependant = getattr(route, "dependant", None)
+    if dependant is None:
+        return False
+
+    seen: set[int] = set()
+    stack = [dependant]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen:
+            continue
+        seen.add(id(node))
+        if getattr(node, "call", None) in _AUTH_CALLS:
+            return True
+        stack.extend(node.dependencies)
+    return False
+
+
+def _state_changing_routes() -> list[tuple[str, str, APIRoute]]:
+    rows: list[tuple[str, str, APIRoute]] = []
+    for route in app.routes:
+        if not isinstance(route, APIRoute):
+            continue
+        methods = (route.methods or set()) & {"POST", "PUT", "PATCH", "DELETE"}
+        for method in sorted(methods):
+            rows.append((method, route.path, route))
+    return rows
+
+
+def test_all_state_changing_routes_require_auth():
+    unauthenticated: list[str] = []
+    for method, path, route in _state_changing_routes():
+        if (method, path) in PUBLIC_STATE_CHANGING_ROUTES:
+            continue
+        if not _route_has_auth(route):
+            unauthenticated.append(f"{method} {path}")
+
+    assert not unauthenticated, (
+        "State-changing routes missing an auth dependency:\n  "
+        + "\n  ".join(sorted(unauthenticated))
+        + "\n\nEither add get_auth_context/verify_api_key as a dependency, or "
+        "register the route in PUBLIC_STATE_CHANGING_ROUTES with a reason."
+    )
+
+
+def test_public_allowlist_has_no_stale_entries():
+    """Every allowlisted route must still exist, so the list can't rot."""
+    live = {(m, p) for m, p, _ in _state_changing_routes()}
+    stale = [
+        f"{m} {p}" for (m, p) in PUBLIC_STATE_CHANGING_ROUTES if (m, p) not in live
+    ]
+    assert not stale, f"Stale PUBLIC_STATE_CHANGING_ROUTES entries: {stale}"

--- a/tests/test_sandbox_isolation.py
+++ b/tests/test_sandbox_isolation.py
@@ -1,0 +1,82 @@
+"""
+Regression guard for behavioral sandbox isolation.
+
+The Docker backend is the only built-in execution boundary intended for
+untrusted code. These tests assert that its hardening flags stay in place so a
+future change cannot silently weaken the sandbox. They build the command only —
+no Docker daemon is required.
+"""
+
+from app.services.behavioral_sandbox import BehavioralSandboxEngine
+
+
+def _has_flag(cmd: list[str], flag: str) -> bool:
+    return flag in cmd
+
+
+def _has_pair(cmd: list[str], flag: str, value: str) -> bool:
+    return any(cmd[i] == flag and cmd[i + 1] == value for i in range(len(cmd) - 1))
+
+
+def _build(**overrides):
+    return BehavioralSandboxEngine._build_docker_run_command(
+        image=overrides.get("image", "python:3.12-slim"),
+        sandbox_code=overrides.get("sandbox_code", "print('x')"),
+        memory_limit_mb=overrides.get("memory_limit_mb", 128),
+        env_vars=overrides.get("env_vars", {}),
+    )
+
+
+def test_docker_command_enforces_network_isolation():
+    assert _has_pair(_build(), "--network", "none")
+
+
+def test_docker_command_drops_all_capabilities_and_privileges():
+    cmd = _build()
+    assert _has_pair(cmd, "--cap-drop", "ALL")
+    assert _has_pair(cmd, "--security-opt", "no-new-privileges")
+
+
+def test_docker_command_runs_as_non_root():
+    assert _has_pair(_build(), "--user", "65534:65534")
+
+
+def test_docker_command_caps_memory_and_forbids_swap_escape():
+    cmd = _build(memory_limit_mb=256)
+    assert _has_pair(cmd, "--memory", "256m")
+    assert _has_pair(cmd, "--memory-swap", "256m")
+
+
+def test_docker_command_limits_processes_and_files():
+    cmd = _build()
+    assert _has_pair(cmd, "--pids-limit", "64")
+    assert _has_pair(cmd, "--ulimit", "nofile=64:64")
+    assert _has_pair(cmd, "--ulimit", "fsize=8388608:8388608")
+
+
+def test_docker_command_uses_readonly_root_and_noexec_tmp():
+    cmd = _build()
+    assert _has_flag(cmd, "--read-only")
+    assert _has_pair(cmd, "--tmpfs", "/tmp:rw,noexec,nosuid,size=16m")
+
+
+def test_docker_command_runs_isolated_python_last():
+    cmd = _build(image="custom:img", sandbox_code="print(1)")
+    assert cmd[-6:] == ["custom:img", "python", "-I", "-S", "-c", "print(1)"]
+
+
+def test_caller_env_vars_forwarded_but_reserved_and_invalid_blocked():
+    cmd = _build(
+        env_vars={
+            "MY_VAR": "hello",
+            "SANDBOX": "false",  # reserved -> must not override
+            "PATH": "/evil",  # reserved -> blocked
+            "bad-name": "x",  # not an identifier -> blocked
+        }
+    )
+    assert _has_pair(cmd, "--env", "MY_VAR=hello")
+    assert not _has_pair(cmd, "--env", "SANDBOX=false")
+    assert not _has_pair(cmd, "--env", "PATH=/evil")
+    assert not any(c == "bad-name=x" for c in cmd)
+    # The hardened SANDBOX=true is still set.
+    assert _has_pair(cmd, "--env", "SANDBOX=true")

--- a/tests/test_sandbox_isolation.py
+++ b/tests/test_sandbox_isolation.py
@@ -65,6 +65,28 @@ def test_docker_command_runs_isolated_python_last():
     assert cmd[-6:] == ["custom:img", "python", "-I", "-S", "-c", "print(1)"]
 
 
+def test_default_docker_command_has_no_runtime_override():
+    cmd = _build()
+    assert "--runtime" not in cmd
+
+
+def test_gvisor_backend_selects_runsc_runtime_and_keeps_hardening():
+    cmd = BehavioralSandboxEngine._build_docker_run_command(
+        image="python:3.12-slim",
+        sandbox_code="print('x')",
+        memory_limit_mb=128,
+        env_vars={},
+        runtime="runsc",
+    )
+    assert _has_pair(cmd, "--runtime", "runsc")
+    # gVisor must not replace the existing isolation flags.
+    assert _has_pair(cmd, "--network", "none")
+    assert _has_pair(cmd, "--cap-drop", "ALL")
+    assert _has_pair(cmd, "--user", "65534:65534")
+    # Runtime flag precedes the image.
+    assert cmd.index("--runtime") < cmd.index("python:3.12-slim")
+
+
 def test_caller_env_vars_forwarded_but_reserved_and_invalid_blocked():
     cmd = _build(
         env_vars={

--- a/tests/test_signed_receipts.py
+++ b/tests/test_signed_receipts.py
@@ -1,0 +1,219 @@
+"""
+Tests for signed verifiable receipts: the ReceiptService crypto, the
+per-wallet hash chain, and the HTTP verification endpoints.
+"""
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient, ASGITransport
+from sqlalchemy import text
+
+from app.main import app
+from app.services.receipts import (
+    ReceiptService,
+    build_signed_ledger_entry,
+    get_receipt_service,
+)
+
+
+@pytest.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+def _fake_wallet():
+    return SimpleNamespace(wallet_id="w-test", receipt_seq=0, last_receipt_hash=None)
+
+
+# --- ReceiptService crypto ---
+
+
+def test_sign_and_verify_round_trip():
+    svc = ReceiptService()
+    payload = b'{"x":1}'
+    sig = svc.sign(payload)
+    assert svc.verify(payload, sig) is True
+
+
+def test_verify_fails_on_tampered_payload():
+    svc = ReceiptService()
+    sig = svc.sign(b'{"amount":"1.00000000"}')
+    assert svc.verify(b'{"amount":"9999.00000000"}', sig) is False
+
+
+def test_ed25519_exposes_public_key_when_available():
+    svc = ReceiptService()
+    if svc.algorithm == "ed25519":
+        assert svc.public_key_b64() is not None
+    else:  # HMAC fallback environment
+        assert svc.public_key_b64() is None
+
+
+# --- hash chain ---
+
+
+def test_build_signed_entry_chains_and_verifies():
+    svc = ReceiptService()
+    wallet = _fake_wallet()
+
+    e1 = build_signed_ledger_entry(
+        svc,
+        wallet=wallet,
+        entry_id="e1",
+        action="credit",
+        amount=Decimal("100"),
+        balance_after=Decimal("100"),
+        description="first",
+    )
+    e2 = build_signed_ledger_entry(
+        svc,
+        wallet=wallet,
+        entry_id="e2",
+        action="debit",
+        amount=Decimal("-10"),
+        balance_after=Decimal("90"),
+        description="second",
+    )
+
+    assert e1.chain_seq == 1 and e2.chain_seq == 2
+    assert e1.prev_hash is None
+    assert e2.prev_hash == e1.entry_hash  # linked
+    assert e1.entry_hash != e2.entry_hash
+    assert wallet.last_receipt_hash == e2.entry_hash
+    assert svc.verify_entry(e1) is True
+    assert svc.verify_entry(e2) is True
+
+
+def test_verify_entry_detects_mutation():
+    svc = ReceiptService()
+    wallet = _fake_wallet()
+    entry = build_signed_ledger_entry(
+        svc,
+        wallet=wallet,
+        entry_id="e1",
+        action="debit",
+        amount=Decimal("-10"),
+        balance_after=Decimal("90"),
+    )
+    assert svc.verify_entry(entry) is True
+    # Mutate the amount after signing -> verification must fail.
+    entry.amount = Decimal("-9999")
+    assert svc.verify_entry(entry) is False
+
+
+# --- HTTP endpoints ---
+
+
+@pytest.mark.anyio
+async def test_public_key_endpoint(client):
+    resp = await client.get("/v1/billing/receipts/public-key")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["algorithm"] in ("ed25519", "hmac-sha256")
+    if body["algorithm"] == "ed25519":
+        assert body["public_key"]
+        assert body["verifiable_offline"] is True
+
+
+@pytest.mark.anyio
+async def test_wallet_chain_verifies_end_to_end(client):
+    headers = {"X-API-Key": "test-key"}
+
+    # Sponsor with an initial deposit -> one signed CREDIT entry.
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": f"recv-{uuid.uuid4().hex[:6]}",
+            "email": "r@test.example",
+            "initial_credits": 1000,
+        },
+        headers=headers,
+    )
+    assert sponsor.status_code == 201
+    sponsor_id = sponsor.json()["wallet_id"]
+
+    # Provision an agent wallet -> TRANSFER entries on both chains.
+    agent = await client.post(
+        "/v1/billing/wallets/agent",
+        json={
+            "sponsor_wallet_id": sponsor_id,
+            "agent_id": f"agt-{uuid.uuid4().hex[:6]}",
+            "budget_credits": 200,
+        },
+        headers=headers,
+    )
+    assert agent.status_code == 201
+
+    verify = await client.get(
+        f"/v1/billing/receipts/wallet/{sponsor_id}/verify", headers=headers
+    )
+    assert verify.status_code == 200
+    body = verify.json()
+    assert body["entries_total"] == 2  # initial deposit + provisioning transfer
+    assert body["chain_valid"] is True
+    assert body["broken"] == []
+
+
+@pytest.mark.anyio
+async def test_single_receipt_is_verified(client):
+    headers = {"X-API-Key": "test-key"}
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": f"recv-{uuid.uuid4().hex[:6]}",
+            "email": "r@test.example",
+            "initial_credits": 500,
+        },
+        headers=headers,
+    )
+    sponsor_id = sponsor.json()["wallet_id"]
+
+    ledger = await client.get(f"/v1/billing/ledger/{sponsor_id}", headers=headers)
+    assert ledger.status_code == 200
+    entries = ledger.json()["entries"]
+    assert entries
+    entry_id = entries[0]["entry_id"]
+
+    receipt = await client.get(
+        f"/v1/billing/receipts/entry/{entry_id}", headers=headers
+    )
+    assert receipt.status_code == 200
+    assert receipt.json()["verified"] is True
+
+
+@pytest.mark.anyio
+async def test_db_tamper_breaks_chain(client):
+    headers = {"X-API-Key": "test-key"}
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": f"recv-{uuid.uuid4().hex[:6]}",
+            "email": "r@test.example",
+            "initial_credits": 750,
+        },
+        headers=headers,
+    )
+    sponsor_id = sponsor.json()["wallet_id"]
+
+    # Tamper with the stored amount directly in the database.
+    from app.db.database import get_session_factory
+
+    factory = get_session_factory()
+    async with factory() as session:
+        await session.execute(
+            text("UPDATE ledger_entries SET amount = :a WHERE wallet_id = :w"),
+            {"a": "999999.00000000", "w": sponsor_id},
+        )
+        await session.commit()
+
+    verify = await client.get(
+        f"/v1/billing/receipts/wallet/{sponsor_id}/verify", headers=headers
+    )
+    body = verify.json()
+    assert body["chain_valid"] is False
+    assert any(b["reason"] == "invalid_signature_or_hash" for b in body["broken"])

--- a/tests/test_signed_receipts.py
+++ b/tests/test_signed_receipts.py
@@ -186,6 +186,56 @@ async def test_single_receipt_is_verified(client):
     assert receipt.json()["verified"] is True
 
 
+async def _sponsor_with_scoped_key(client, headers, credits=0):
+    sponsor = await client.post(
+        "/v1/billing/wallets/sponsor",
+        json={
+            "sponsor_name": f"own-{uuid.uuid4().hex[:6]}",
+            "email": "o@test.example",
+            "initial_credits": credits,
+        },
+        headers=headers,
+    )
+    wallet_id = sponsor.json()["wallet_id"]
+    key_resp = await client.post(
+        "/v1/api-keys",
+        json={"wallet_id": wallet_id, "key_name": "scoped"},
+        headers=headers,
+    )
+    return wallet_id, {"X-API-Key": key_resp.json()["api_key"]}
+
+
+@pytest.mark.anyio
+async def test_cross_wallet_chain_verify_denied(client):
+    headers = {"X-API-Key": "test-key"}
+    wallet_a, key_a = await _sponsor_with_scoped_key(client, headers)
+    wallet_b, _ = await _sponsor_with_scoped_key(client, headers, credits=100)
+
+    # Wallet A's key may verify its own chain...
+    own = await client.get(
+        f"/v1/billing/receipts/wallet/{wallet_a}/verify", headers=key_a
+    )
+    assert own.status_code == 200
+    # ...but not wallet B's.
+    denied = await client.get(
+        f"/v1/billing/receipts/wallet/{wallet_b}/verify", headers=key_a
+    )
+    assert denied.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_cross_wallet_receipt_entry_denied(client):
+    headers = {"X-API-Key": "test-key"}
+    wallet_a, key_a = await _sponsor_with_scoped_key(client, headers)
+    wallet_b, _ = await _sponsor_with_scoped_key(client, headers, credits=100)
+
+    ledger = await client.get(f"/v1/billing/ledger/{wallet_b}", headers=headers)
+    entry_id = ledger.json()["entries"][0]["entry_id"]
+
+    denied = await client.get(f"/v1/billing/receipts/entry/{entry_id}", headers=key_a)
+    assert denied.status_code == 403
+
+
 @pytest.mark.anyio
 async def test_db_tamper_breaks_chain(client):
     headers = {"X-API-Key": "test-key"}


### PR DESCRIPTION
## Summary
Adds the trust layer the README flagged as missing for positioning this as
infrastructure for autonomous economic actors:
- **Replay protection** — claim-once on `Idempotency-Key` (atomic across postgres/redis/sqlite/memory backends).
- **Signed receipts** — per-wallet hash-chained, Ed25519-signed ledger entries (HMAC fallback), independently verifiable via the published public key. All ledger writes routed through one signing helper. Migration `014`.
- **Signed scoped permits** — expiring capability tokens with scope, single-use replay protection, and a cumulative `max_spend` allowance; enforced on **both** MCP tool-call paths (JSON-RPC + HTTP) behind `PERMITS_ENFORCED`.
- **Auth-decision audit + admin export** — `record_audit` ring buffer + denial events; `GET /v1/admin/audit` (bootstrap admin).
- **Sandbox** — route-auth inventory test; hardened Docker command with pinned isolation flags + optional gVisor (runsc) backend; host exec off by default.

## Operational notes (before deploy)
- Set `RECEIPT_SIGNING_KEY` and `PERMIT_SIGNING_KEY` — otherwise ephemeral per-process keys break cross-worker verification. Use `STATE_BACKEND=postgres`/`redis`, not memory, in multi-worker deploys.
- Run Alembic migration `014`.
- `PERMITS_ENFORCED` and `REPLAY_PROTECTION_REQUIRE_KEY` default off — ramp deliberately.

## Test plan
- [x] `pytest -p no:randomly` green (602 passed); ruff + mypy clean
- [x] OpenAPI + sim-inventory regenerated (`export_openapi.py --check` passes)
- [ ] Independent review via /ultrareview
- [ ] Verify receipt/permit signing with real keys in a multi-worker staging deploy

## Known limitations (follow-ups, in docs/threat-model.md)
- Permit allowance enforced at MCP tool calls only; `AgentMoney.charge` not yet permit-aware.
- Replay protection fails open on a state-store outage (availability choice; the single-use permit nonce is the hard guarantee).
- Audit export is an in-memory, per-process ring buffer (recent events only).

## Status
Closes the trust-gap items from `docs/threat-model.md`. Repo remains production-beta; this does not by itself lift the "paused prototype" status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core billing ledger writes, adds new crypto-based signing/verification paths and new authorization gates for MCP, and introduces new middleware that can block mutating requests when misconfigured. It also adds new persistent state tables/columns and relies on correct key management and durable-state backends in multi-worker deployments.
> 
> **Overview**
> Adds **replay protection** for state-changing HTTP requests via a new `ReplayProtectionMiddleware`, using a durable claim-once nonce (`Idempotency-Key`) backed by new durable-state primitives/tables; configuration is exposed via new settings/env vars.
> 
> Implements **signed, hash-chained ledger receipts** by adding receipt chain fields to `wallets`/`ledger_entries` (migration `014`) and routing ledger entry creation through a signing helper; adds public-key and verification endpoints to fetch/verify receipts and wallet chains.
> 
> Introduces **signed capability permits** (Ed25519 with HMAC fallback) with scope, TTL, optional single-use replay protection, and optional cumulative spend caps, plus `/v1/permits/*` endpoints and optional enforcement for MCP tool calls via `X-Agent-Permit`.
> 
> Expands **auditability and admin ops**: audit events now retain a recent in-memory ring buffer with an admin-only export endpoint, and auth denials are recorded; sandbox execution is hardened and can optionally use gVisor (`runsc`), with new regression tests to pin isolation flags and route-auth coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09834d02d44bbdd78a75eaacb286ffb0d8fd95dd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->