### PR TITLE
fix(security): require agent ownership on comms send/ack/handoff

### DIFF
--- a/app/routers/agent_comms_durable.py
+++ b/app/routers/agent_comms_durable.py
@@ -83,7 +83,14 @@ def _audit_hash(payload: dict) -> str:
     ).hexdigest()
 
 
-async def _require_inbox_access(auth: AuthContext, comms: AgentComms, agent_id: str) -> None:
+async def _require_agent_owner(
+    auth: AuthContext, comms: AgentComms, agent_id: str
+) -> None:
+    """Reject the request unless the caller's API key owns this agent.
+
+    Applied to send (on ``from_agent``) and to inbox listing so an
+    authenticated caller cannot impersonate an agent they do not own.
+    """
     agent = await comms.registry.get(agent_id)
     if agent and agent.owner_key and agent.owner_key != auth.raw_key:
         raise HTTPException(
@@ -103,6 +110,7 @@ async def agent_comms_send(
     auth: AuthContext = Depends(get_auth_context),
     comms: AgentComms = Depends(get_agent_comms),
 ):
+    await _require_agent_owner(auth, comms, request.from_agent)
     msg = await comms.send_message(
         from_agent=request.from_agent,
         to_agent=request.to_agent,
@@ -157,7 +165,7 @@ async def agent_comms_inbox(
     auth: AuthContext = Depends(get_auth_context),
     comms: AgentComms = Depends(get_agent_comms),
 ):
-    await _require_inbox_access(auth, comms, agent_id)
+    await _require_agent_owner(auth, comms, agent_id)
     audit_basis = {"agent_id": agent_id, "limit": limit, "offset": offset}
     audit_h = _audit_hash(audit_basis)
     rows, total, _ = await comms.list_inbox_for_http(agent_id, limit, offset)

--- a/app/routers/comms.py
+++ b/app/routers/comms.py
@@ -32,8 +32,10 @@ router = APIRouter(
 
 # --- Request/Response Schemas ---
 
+
 class AgentRegistrationRequest(BaseModel):
     """Register an agent in the communication network."""
+
     name: str = Field(
         ...,
         description="Human-readable agent name.",
@@ -61,8 +63,7 @@ class AgentRegistrationResponse(BaseModel):
     api_key: str = Field(
         ...,
         description=(
-            "Agent-specific API key for sending/receiving messages. "
-            "Store securely."
+            "Agent-specific API key for sending/receiving messages. Store securely."
         ),
     )
     webhook_url: str | None
@@ -72,6 +73,7 @@ class AgentRegistrationResponse(BaseModel):
 
 class SendMessageRequest(BaseModel):
     """Send a message to another agent."""
+
     to_agent: str = Field(
         ...,
         description="Recipient agent ID.",
@@ -117,6 +119,7 @@ class MessageResponse(BaseModel):
 
 class HandoffRequest(BaseModel):
     """Request a task handoff to an agent with a specific capability."""
+
     capability: str = Field(
         ...,
         description="The capability needed. System finds the best available agent.",
@@ -139,7 +142,30 @@ class HandoffResponse(BaseModel):
     error: str | None = None
 
 
+# --- Auth helpers ---
+
+
+async def _require_agent_owner(comms: AgentComms, api_key: str, agent_id: str) -> None:
+    """Reject the request unless the calling API key owns this agent.
+
+    Applied to every endpoint that acts on behalf of an agent (send, ack,
+    handoff, inbox) so an authenticated caller cannot impersonate an agent
+    they do not own. Unregistered or owner-less agents pass through; the
+    underlying service handles "not found".
+    """
+    agent = await comms.registry.get(agent_id)
+    if agent and agent.owner_key and agent.owner_key != api_key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "access_denied",
+                "message": "You do not own this agent.",
+            },
+        )
+
+
 # --- Endpoints ---
+
 
 @router.post(
     "/agents",
@@ -230,6 +256,7 @@ async def send_message(
     api_key: str = Depends(verify_api_key),
     comms: AgentComms = Depends(get_agent_comms),
 ):
+    await _require_agent_owner(comms, api_key, from_agent)
     msg = await comms.send_message(
         from_agent=from_agent,
         to_agent=request.to_agent,
@@ -268,13 +295,7 @@ async def poll_inbox(
     api_key: str = Depends(verify_api_key),
     comms: AgentComms = Depends(get_agent_comms),
 ):
-    # RED TEAM FIX: Verify the requesting key owns this agent
-    agent = await comms.registry.get(agent_id)
-    if agent and agent.owner_key and agent.owner_key != api_key:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail={"error": "access_denied", "message": "You do not own this agent."},
-        )
+    await _require_agent_owner(comms, api_key, agent_id)
     messages = await comms.router.poll(agent_id, limit=limit)
     return {
         "agent_id": agent_id,
@@ -307,6 +328,7 @@ async def acknowledge_message(
     api_key: str = Depends(verify_api_key),
     comms: AgentComms = Depends(get_agent_comms),
 ):
+    await _require_agent_owner(comms, api_key, agent_id)
     acked = await comms.router.acknowledge(agent_id, message_id)
     if not acked:
         raise HTTPException(
@@ -336,6 +358,7 @@ async def request_handoff(
     api_key: str = Depends(verify_api_key),
     comms: AgentComms = Depends(get_agent_comms),
 ):
+    await _require_agent_owner(comms, api_key, from_agent)
     msg = await comms.request_handoff(
         from_agent=from_agent,
         capability=request.capability,

--- a/tests/test_agent_comms_durable.py
+++ b/tests/test_agent_comms_durable.py
@@ -125,3 +125,43 @@ async def test_simulation_skips_db_row_for_send():
             )
         ).scalar_one_or_none()
     assert row is None
+
+
+@pytest.mark.anyio
+async def test_durable_send_denied_when_caller_does_not_own_from_agent():
+    """Authenticated callers cannot impersonate an agent they do not own on
+    the durable send path."""
+    from app.core.dependencies import get_agent_comms
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        sender = await client.post(
+            "/v1/comms/agents",
+            json={"name": "durable-foreign-sender", "capabilities": ["x"]},
+            headers=HEADERS,
+        )
+        sender_id = sender.json()["agent_id"]
+        # Rewrite owner_key so test-key no longer owns this agent.
+        comms = get_agent_comms()
+        agent = await comms.registry.get(sender_id)
+        agent.owner_key = "owner-from-some-other-tenant-key"
+
+        receiver = await client.post(
+            "/v1/comms/agents",
+            json={"name": "durable-foreign-receiver", "capabilities": ["y"]},
+            headers=HEADERS,
+        )
+        receiver_id = receiver.json()["agent_id"]
+
+        resp = await client.post(
+            "/v1/agent-comms/send",
+            json={
+                "from_agent": sender_id,
+                "to_agent": receiver_id,
+                "subject": "spoof",
+                "body": {"a": 1},
+            },
+            headers=HEADERS,
+        )
+        assert resp.status_code == 403
+        assert resp.json()["detail"]["error"] == "access_denied"

--- a/tests/test_comms.py
+++ b/tests/test_comms.py
@@ -22,6 +22,7 @@ def api_headers():
 
 # --- Agent Registration ---
 
+
 @pytest.mark.anyio
 async def test_register_agent(client, api_headers):
     resp = await client.post(
@@ -70,6 +71,7 @@ async def test_filter_agents_by_capability(client, api_headers):
 
 
 # --- Messaging ---
+
 
 @pytest.mark.anyio
 async def test_send_message(client, api_headers):
@@ -123,6 +125,7 @@ async def test_poll_inbox(client, api_headers):
 
 # --- Handoff ---
 
+
 @pytest.mark.anyio
 async def test_handoff_no_agent_found(client, api_headers):
     resp = await client.post(
@@ -157,3 +160,77 @@ async def test_handoff_with_matching_agent(client, api_headers):
     assert resp.status_code == 200
     assert resp.json()["status"] == "handoff_sent"
     assert resp.json()["target_agent_name"] == "transcriber"
+
+
+# --- Cross-agent ownership (impersonation prevention) ---
+
+
+async def _register_foreign_owned_agent(client, api_headers, name: str) -> str:
+    """Register an agent and rewrite its owner_key so the caller no longer
+    owns it — sets up a 'caller does not own this agent' scenario without
+    needing two independently-valid API keys configured."""
+    from app.core.dependencies import get_agent_comms
+
+    resp = await client.post(
+        "/v1/comms/agents",
+        json={"name": name, "capabilities": ["x"]},
+        headers=api_headers,
+    )
+    assert resp.status_code == 201
+    agent_id = resp.json()["agent_id"]
+    comms = get_agent_comms()
+    agent = await comms.registry.get(agent_id)
+    agent.owner_key = "owner-from-some-other-tenant-key"
+    return agent_id
+
+
+@pytest.mark.anyio
+async def test_send_denied_when_caller_does_not_own_from_agent(client, api_headers):
+    from_agent = await _register_foreign_owned_agent(
+        client, api_headers, "foreign-sender"
+    )
+    receiver = await client.post(
+        "/v1/comms/agents",
+        json={"name": "rx-cross-send", "capabilities": ["y"]},
+        headers=api_headers,
+    )
+    receiver_id = receiver.json()["agent_id"]
+    resp = await client.post(
+        f"/v1/comms/messages?from_agent={from_agent}",
+        json={"to_agent": receiver_id, "subject": "spoof", "body": {"x": 1}},
+        headers=api_headers,
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["error"] == "access_denied"
+
+
+@pytest.mark.anyio
+async def test_inbox_denied_when_caller_does_not_own_agent(client, api_headers):
+    agent_id = await _register_foreign_owned_agent(client, api_headers, "foreign-inbox")
+    resp = await client.get(f"/v1/comms/messages/{agent_id}/inbox", headers=api_headers)
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["error"] == "access_denied"
+
+
+@pytest.mark.anyio
+async def test_ack_denied_when_caller_does_not_own_agent(client, api_headers):
+    agent_id = await _register_foreign_owned_agent(client, api_headers, "foreign-ack")
+    resp = await client.post(
+        f"/v1/comms/messages/{agent_id}/ack/any-msg-id", headers=api_headers
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["error"] == "access_denied"
+
+
+@pytest.mark.anyio
+async def test_handoff_denied_when_caller_does_not_own_from_agent(client, api_headers):
+    from_agent = await _register_foreign_owned_agent(
+        client, api_headers, "foreign-handoff"
+    )
+    resp = await client.post(
+        f"/v1/comms/handoff?from_agent={from_agent}",
+        json={"capability": "x", "context": {"why": "spoof"}},
+        headers=api_headers,
+    )
+    assert resp.status_code == 403
+    assert resp.json()["detail"]["error"] == "access_denied"


### PR DESCRIPTION
## Summary
Closes a live agent-impersonation gap. On `main`, the legacy `/v1/comms` and durable `/v1/agent-comms` endpoints accept any valid API key with no check that the caller owns the source agent — so any authenticated caller can spoof messages, acknowledgements, or handoffs as any registered agent. Only the inbox endpoints had the ownership check.

## What changed
- Shared private helper `_require_agent_owner` added to both `app/routers/comms.py` and `app/routers/agent_comms_durable.py` (returns 403 when caller's key ≠ agent's `owner_key`).
- Applied on:
  - `POST /v1/comms/messages` (send) — gates `from_agent`
  - `POST /v1/comms/messages/{agent_id}/ack/{message_id}` — gates `agent_id`
  - `POST /v1/comms/handoff` — gates `from_agent`
  - `POST /v1/agent-comms/send` — gates `request.from_agent`
- `poll_inbox`'s inline check refactored to use the helper; durable router's `_require_inbox_access` renamed to `_require_agent_owner` (single caller updated). Consistent enforcement across all five endpoints.
- 5 new cross-agent denial tests added (main previously had **zero** ownership-style assertions in `test_comms.py`).

## What didn't change
- No route or schema changes — OpenAPI unchanged (`export_openapi.py --check` passes).
- No new dependencies. No migrations.
- Existing tests still pass (they use `test-key` throughout, so the ownership check is a no-op for them).

## Test plan
- [x] `pytest tests/test_comms.py tests/test_agent_comms_durable.py` → 14 passed (9 existing + 5 new)
- [x] Full suite: 702 passed, 1 failed (pre-existing `test_planner_constraints::test_feasible_unselected_candidate_is_not_policy_rejected` — fails on bare `main` too, unrelated)
- [x] `ruff check` clean; `mypy` clean on the changed files (verified directly)
- [ ] Independent review

## Notes for reviewers
- The `mypy` pre-commit hook was skipped on this commit (`SKIP=mypy`) because main's `.pre-commit-config.yaml` lists `additional_dependencies: [types-all]`, which is unbuildable on current PyPI (`types-pkg-resources` no longer exists). The hook can't install its environment for **any** contributor. Worth a separate small fix (pin specific `types-*` packages instead of the deprecated `types-all` metapackage). My changes were verified with mypy directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authorization logic on message send/inbox/ack/handoff paths; mistakes could incorrectly block legitimate traffic or leave gaps if ownership data is inconsistent.
> 
> **Overview**
> Closes an agent-impersonation gap by enforcing **agent ownership** checks (API key must match the agent’s `owner_key`) on endpoints that act “as” an agent.
> 
> Adds a shared `_require_agent_owner` guard and applies it to durable `POST /v1/agent-comms/send` and legacy `/v1/comms` `send`, `poll_inbox`, `acknowledge`, and `handoff` routes, with new tests asserting `403 access_denied` when a caller attempts cross-agent spoofing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdaad9eb20da163cdccd143ae41c9a35912bff43. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent ownership verification now enforced for message operations: sending, inbox access, acknowledgement, and handoff requests
  * Unauthorized callers receive HTTP 403 response with "access_denied" error

* **Tests**
  * Added comprehensive authorization tests covering message sending, inbox polling, acknowledgement, and handoff scenarios to verify access restrictions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PetrefiedThunder/agent-middleware-api/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->