### PR TITLE
Extract shared wrapper edge client and document KMS path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Run trust-plane demo smoke test
         run: python scripts/demo_trust_plane.py --assert
 
+      - name: Run trust-plane adversarial (red-team) smoke test
+        run: python scripts/red_team_trust_plane.py --assert
+
       - name: Validate OpenAPI spec generates
         run: |
           python -c "

--- a/DESIGN_PARTNER_GUIDE.md
+++ b/DESIGN_PARTNER_GUIDE.md
@@ -33,6 +33,19 @@ If the partner wants the operator narrative instead of the compact proof, run:
 make agent-ops-war-room
 ```
 
+If the partner is a security audience and wants to see the boundary hold under
+attack rather than just on the happy path, run the adversarial battery:
+
+```bash
+make red-team-trust-plane
+```
+
+It drives one valid permit and attacks it ten ways — no permit, unknown
+permit, out-of-scope tool, missing scope, over-budget, stolen permit (wrong
+wallet), wrong key, expired, revoked, and tampered signature — and asserts
+each is denied with a concrete reason code, that none produces a ledger debit,
+and that a final valid call still charges exactly once.
+
 Then walk the partner through the live flow:
 
 1. Create a sponsor wallet.

--- a/DESIGN_PARTNER_GUIDE.md
+++ b/DESIGN_PARTNER_GUIDE.md
@@ -33,8 +33,8 @@ If the partner wants the operator narrative instead of the compact proof, run:
 make agent-ops-war-room
 ```
 
-If the partner is a security audience and wants to see the boundary hold under
-attack rather than just on the happy path, run the adversarial battery:
+If the partner is from a security team and wants to see the boundary hold
+under attack rather than just on the happy path, run the adversarial battery:
 
 ```bash
 make red-team-trust-plane

--- a/DESIGN_PARTNER_GUIDE.md
+++ b/DESIGN_PARTNER_GUIDE.md
@@ -48,6 +48,9 @@ Then walk the partner through the live flow:
 9. Replay the same request and show the same receipt ID with no second debit.
 10. Attempt a different tool under the same permit and show out-of-scope
     denial.
+11. Attempt the same allowed tool with no permit at all and show the
+    `permit_required` denial, proving the trust plane fails closed when
+    `ALLOW_LEGACY_UNPERMITTED_MCP=false`.
 
 ## What To Listen For
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test prove-trust-plane demo-trust-plane demo-trust-plane-check agent-ops-war-room agent-ops-war-room-check trust-coverage-gate trust-release-gate
+.PHONY: test prove-trust-plane demo-trust-plane demo-trust-plane-check red-team-trust-plane red-team-trust-plane-check agent-ops-war-room agent-ops-war-room-check trust-coverage-gate trust-release-gate
 
 test:
 	uv run pytest tests/ -q
@@ -11,6 +11,12 @@ demo-trust-plane:
 
 demo-trust-plane-check:
 	uv run python scripts/demo_trust_plane.py --assert
+
+red-team-trust-plane:
+	uv run python scripts/red_team_trust_plane.py
+
+red-team-trust-plane-check:
+	uv run python scripts/red_team_trust_plane.py --assert
 
 agent-ops-war-room:
 	uv run python scripts/agent_ops_war_room_demo.py

--- a/app/core/time.py
+++ b/app/core/time.py
@@ -1,0 +1,19 @@
+"""Time helpers.
+
+`utc_now` returns a naive UTC datetime — the same semantics as
+`datetime.datetime.utcnow()`, which is deprecated in Python 3.12 and slated
+for removal. Keep call sites simple: replace `datetime.utcnow()` with
+`utc_now()` everywhere. Persisted datetimes throughout the codebase are
+naive UTC; introducing tz-aware datetimes at random call sites would break
+comparisons against values loaded from the database. A full tz-aware
+migration is tracked separately.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utc_now() -> datetime:
+    """Return the current UTC time as a naive datetime."""
+    return datetime.now(timezone.utc).replace(tzinfo=None)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -11,6 +11,8 @@ from pydantic import ConfigDict
 from sqlalchemy import UniqueConstraint
 from sqlmodel import SQLModel, Field
 
+from app.core.time import utc_now
+
 
 class WalletModel(SQLModel, table=True):
     """
@@ -70,8 +72,8 @@ class WalletModel(SQLModel, table=True):
     metadata_json: Optional[str] = Field(default=None)
 
     # Timestamps
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -118,7 +120,7 @@ class LedgerEntryModel(SQLModel, table=True):
     stripe_session_id: Optional[str] = Field(default=None, max_length=100, index=True)
 
     # Timestamp
-    timestamp: datetime = Field(default_factory=datetime.utcnow, index=True)
+    timestamp: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -138,7 +140,7 @@ class BillingAlertModel(SQLModel, table=True):
     message: str = Field(max_length=500)
     severity: str = Field(default="info", max_length=20)
     acknowledged: bool = Field(default=False)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -185,8 +187,8 @@ class ServiceRegistryModel(SQLModel, table=True):
     mcp_manifest: Optional[str] = Field(default=None)
     is_active: bool = Field(default=True)
     metadata_json: Optional[str] = Field(default=None)
-    created_at: datetime = Field(default_factory=datetime.utcnow)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -219,8 +221,8 @@ class KYCVerificationModel(SQLModel, table=True):
 
     metadata_json: Optional[str] = Field(default=None)
 
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
+    updated_at: datetime = Field(default_factory=utc_now)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -249,7 +251,7 @@ class APIKeyModel(SQLModel, table=True):
     last_used_at: Optional[datetime] = Field(default=None)
     last_used_ip: Optional[str] = Field(default=None, max_length=45)
 
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
     expires_at: Optional[datetime] = Field(default=None)
 
     revoked_at: Optional[datetime] = Field(default=None)
@@ -292,7 +294,7 @@ class TelemetryEventModel(SQLModel, table=True):
     # Two timestamps: when the event actually happened (from the client)
     # vs when we stored it (authoritative for retention).
     event_timestamp: Optional[datetime] = Field(default=None, index=True)
-    ingested_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    ingested_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -308,7 +310,7 @@ class IoTDeviceModel(SQLModel, table=True):
     topic_acl_json: Optional[str] = Field(default=None)
     metadata_json: Optional[str] = Field(default=None)
     status: str = Field(default="registered", max_length=30, index=True)
-    registered_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    registered_at: datetime = Field(default_factory=utc_now, index=True)
     last_message_at: Optional[datetime] = Field(default=None)
     message_count: int = Field(default=0)
 
@@ -325,7 +327,7 @@ class IoTDeviceEventModel(SQLModel, table=True):
     event_type: str = Field(max_length=30, index=True)
     topic: Optional[str] = Field(default=None, max_length=500)
     payload_json: Optional[str] = Field(default=None)
-    timestamp: datetime = Field(default_factory=datetime.utcnow, index=True)
+    timestamp: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -340,7 +342,7 @@ class OracleCrawlTargetModel(SQLModel, table=True):
     directory_type: str = Field(max_length=30, index=True)
     status: str = Field(max_length=20, index=True)
     api_id: Optional[str] = Field(default=None, max_length=64, index=True)
-    queued_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    queued_at: datetime = Field(default_factory=utc_now, index=True)
     crawled_at: Optional[datetime] = Field(default=None)
     raw_payload_hash: Optional[str] = Field(default=None, max_length=128)
 
@@ -362,7 +364,7 @@ class OracleIndexedAPIModel(SQLModel, table=True):
     capabilities_json: Optional[str] = Field(default=None)
     tags_json: Optional[str] = Field(default=None)
     status: str = Field(max_length=20)
-    last_crawled: datetime = Field(default_factory=datetime.utcnow, index=True)
+    last_crawled: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -377,7 +379,7 @@ class OracleRegistrationModel(SQLModel, table=True):
     directory_type: str = Field(max_length=30, index=True)
     status: str = Field(max_length=20, index=True)
     message: str = Field(default="", max_length=2000)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -389,7 +391,7 @@ class OracleDiscoveryHitModel(SQLModel, table=True):
 
     hit_id: str = Field(primary_key=True, max_length=64)
     referrer: str = Field(default="direct", max_length=2048, index=True)
-    timestamp: datetime = Field(default_factory=datetime.utcnow, index=True)
+    timestamp: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -410,7 +412,7 @@ class AgentCommsMessageModel(SQLModel, table=True):
     reply_to: Optional[str] = Field(default=None, max_length=64)
     status: str = Field(max_length=20, index=True)
     payload_hash: Optional[str] = Field(default=None, max_length=128)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
     delivered_at: Optional[datetime] = Field(default=None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -439,7 +441,7 @@ class SecurityScanModel(SQLModel, table=True):
 
     started_at: Optional[datetime] = Field(default=None)
     completed_at: Optional[datetime] = Field(default=None)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -469,7 +471,7 @@ class SecurityVulnerabilityModel(SQLModel, table=True):
     remediation_status: str = Field(default="open", max_length=30)
     cwe_id: Optional[str] = Field(default=None, max_length=20)
 
-    discovered_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    discovered_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -492,7 +494,7 @@ class ContentPipelineModel(SQLModel, table=True):
     hook_json: Optional[str] = Field(default=None)
     caption_style: str = Field(default="bold_impact", max_length=30)
     aspect_ratio: str = Field(default="9:16", max_length=10)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -518,7 +520,7 @@ class ContentPieceModel(SQLModel, table=True):
     file_size_bytes: Optional[int] = Field(default=None)
     status: str = Field(max_length=20, index=True)
     metadata_json: Optional[str] = Field(default=None)
-    generated_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    generated_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -535,7 +537,7 @@ class ContentCampaignModel(SQLModel, table=True):
     pipeline_ids_json: Optional[str] = Field(default=None)
     status: str = Field(default="running", max_length=30, index=True)
     owner_key: str = Field(default="", max_length=255, index=True)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -556,7 +558,7 @@ class ContentScheduleModel(SQLModel, table=True):
     confidence: float = Field(default=0.0)
     reasoning: str = Field(default="", max_length=2000)
     estimated_views: Optional[int] = Field(default=None)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -572,7 +574,7 @@ class ContentFactoryGenerationModel(SQLModel, table=True):
     model: Optional[str] = Field(default=None, max_length=128)
     provenance_json: Optional[str] = Field(default=None)
     output_text: Optional[str] = Field(default=None)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
     updated_at: Optional[datetime] = Field(default=None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -602,7 +604,7 @@ class KeyRotationLogModel(SQLModel, table=True):
     ip_address: Optional[str] = Field(default=None, max_length=45)
     user_agent: Optional[str] = Field(default=None, max_length=500)
 
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -613,7 +615,7 @@ class OptimizerTelemetryModel(SQLModel, table=True):
     __tablename__ = "optimizer_telemetry"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    ts: datetime = Field(default_factory=datetime.utcnow, index=True)
+    ts: datetime = Field(default_factory=utc_now, index=True)
     wallet_id: str = Field(max_length=64, index=True)
     agent_id: str = Field(max_length=64, index=True)
     task_id: Optional[str] = Field(default=None, max_length=100, index=True)
@@ -634,7 +636,7 @@ class ControlPlaneAuditEventModel(SQLModel, table=True):
     __tablename__ = "control_plane_audit_events"
 
     event_id: str = Field(primary_key=True, max_length=50)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
     # Per-wallet monotonic sequence: a stable ordering key for the hash chain so
     # equal/clock-skewed created_at values can't reorder the chain on read.
     seq: int = Field(default=0, index=True)
@@ -674,7 +676,7 @@ class AuditChainHeadModel(SQLModel, table=True):
     wallet_key: str = Field(primary_key=True, max_length=64)
     last_chain_hash: Optional[str] = Field(default=None, max_length=64)
     last_seq: int = Field(default=0)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=utc_now)
 
 
 class SigningKeyModel(SQLModel, table=True):
@@ -686,7 +688,7 @@ class SigningKeyModel(SQLModel, table=True):
     alg: str = Field(default="Ed25519", max_length=20)
     public_key_b64: str
     status: str = Field(default="active", max_length=20, index=True)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
     activated_at: Optional[datetime] = Field(default=None)
     retired_at: Optional[datetime] = Field(default=None)
 
@@ -725,7 +727,7 @@ class PermitModel(SQLModel, table=True):
     status: str = Field(default="active", max_length=20, index=True)
     signature: str
     key_id: str = Field(max_length=64, foreign_key="signing_keys.key_id", index=True)
-    issued_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    issued_at: datetime = Field(default_factory=utc_now, index=True)
     revoked_at: Optional[datetime] = Field(default=None)
     # Last time budget was reserved/released; used to distinguish a live
     # in-flight reservation from one orphaned by a crash during reconciliation.
@@ -761,7 +763,7 @@ class ReceiptModel(SQLModel, table=True):
         foreign_key="control_plane_audit_events.event_id",
         index=True,
     )
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
     signature: str
     signature_key_id: str = Field(
         max_length=64,
@@ -793,7 +795,7 @@ class IdempotencyRecordModel(SQLModel, table=True):
     response_reference: Optional[str] = Field(default=None, max_length=128)
     response_json: Optional[str] = Field(default=None)
     status_code: int = Field(default=200)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
     expires_at: Optional[datetime] = Field(default=None)
 
 
@@ -813,7 +815,7 @@ class PolicyBundleModel(SQLModel, table=True):
     risk_tier: str = Field(default="medium", max_length=20)
     human_approval_required: bool = Field(default=False)
     is_active: bool = Field(default=True, index=True)
-    created_at: datetime = Field(default_factory=datetime.utcnow, index=True)
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=utc_now, index=True)
+    updated_at: datetime = Field(default_factory=utc_now)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)

--- a/app/routers/awi_enhanced.py
+++ b/app/routers/awi_enhanced.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from ..core.auth import AuthContext, get_auth_context
+from ..core.time import utc_now
 from ..schemas.awi_enhanced import (
     DOMBridgeSessionRequest,
     DOMBridgeSessionResponse,
@@ -687,7 +688,7 @@ async def index_session(
         return MemoryIndexResponse(
             memory_id=memory_id,
             session_id=request.session_id,
-            indexed_at=memory.created_at if memory else datetime.utcnow(),
+            indexed_at=memory.created_at if memory else utc_now(),
             entities_extracted=len(memory.key_entities) if memory else 0,
             intent_inferred=memory.user_intent if memory else "",
         )
@@ -722,7 +723,7 @@ async def query_memories(
     rag = get_awi_rag_engine()
 
     try:
-        start_time = datetime.utcnow()
+        start_time = utc_now()
 
         results = await rag.search(
             query=request.query,
@@ -732,7 +733,7 @@ async def query_memories(
             include_raw_state=request.include_raw_state,
         )
 
-        search_time_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
+        search_time_ms = int((utc_now() - start_time).total_seconds() * 1000)
 
         return RAGQueryResponse(
             query=request.query,

--- a/app/schemas/awi_enhanced.py
+++ b/app/schemas/awi_enhanced.py
@@ -14,6 +14,8 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, Field
 
+from app.core.time import utc_now
+
 
 class PasskeyStatus(str, Enum):
     """Status of a passkey verification."""
@@ -302,7 +304,7 @@ class MemoryIndexResponse(BaseModel):
 
     memory_id: str = Field(..., description="Unique memory identifier")
     session_id: str = Field(..., description="AWI session ID")
-    indexed_at: datetime = Field(default_factory=datetime.utcnow)
+    indexed_at: datetime = Field(default_factory=utc_now)
     entities_extracted: int = Field(..., description="Number of entities extracted")
     intent_inferred: str = Field(..., description="Inferred user intent")
 

--- a/app/services/awi_playwright_bridge.py
+++ b/app/services/awi_playwright_bridge.py
@@ -31,6 +31,8 @@ from enum import Enum
 from typing import Any, Optional
 from uuid import uuid4
 
+from app.core.time import utc_now
+
 logger = logging.getLogger(__name__)
 
 
@@ -106,8 +108,8 @@ class BridgeSession:
     current_url: Optional[str] = None
     page_title: Optional[str] = None
     elements_cache: dict[str, DOMElement] = field(default_factory=dict)
-    created_at: datetime = field(default_factory=datetime.utcnow)
-    last_activity: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=utc_now)
+    last_activity: datetime = field(default_factory=utc_now)
 
     # Real Playwright objects (not dataclass fields, set at runtime)
     _page: Optional["Page"] = field(default=None, repr=False)
@@ -454,7 +456,7 @@ class AWIPlaywrightBridge:
         if self._session_ttl_seconds <= 0:
             return {"expired": 0, "active": len(self._sessions)}
 
-        cutoff = datetime.utcnow() - timedelta(seconds=self._session_ttl_seconds)
+        cutoff = utc_now() - timedelta(seconds=self._session_ttl_seconds)
         expired_session_ids = [
             session_id
             for session_id, session in self._sessions.items()
@@ -521,7 +523,7 @@ class AWIPlaywrightBridge:
 
         try:
             commands = await handler(session, parameters)
-            session.last_activity = datetime.utcnow()
+            session.last_activity = utc_now()
             return commands
         except Exception as e:
             logger.error(f"Action translation failed for {action}: {e}")
@@ -600,7 +602,7 @@ class AWIPlaywrightBridge:
                 error=f"Session {session_id} not found",
             )
 
-        start_time = datetime.utcnow()
+        start_time = utc_now()
         executed = 0
         error = None
 
@@ -617,8 +619,8 @@ class AWIPlaywrightBridge:
                 logger.error(f"Command {cmd.command_type.value} failed: {e}")
                 break
 
-        session.last_activity = datetime.utcnow()
-        duration_ms = int((datetime.utcnow() - start_time).total_seconds() * 1000)
+        session.last_activity = utc_now()
+        duration_ms = int((utc_now() - start_time).total_seconds() * 1000)
 
         return ExecutionResult(
             success=error is None,
@@ -1755,7 +1757,7 @@ class AWIPlaywrightBridge:
             # Update session state after execution
             session.current_url = page.url
             session.page_title = await page.title()
-            session.last_activity = datetime.utcnow()
+            session.last_activity = utc_now()
 
             logger.debug(
                 f"Executed {cmd_type.value} on {command.target} for session {session.session_id}"

--- a/app/services/awi_rag_engine.py
+++ b/app/services/awi_rag_engine.py
@@ -32,6 +32,8 @@ from datetime import datetime
 from typing import Any, Optional
 from uuid import uuid4
 
+from app.core.time import utc_now
+
 logger = logging.getLogger(__name__)
 
 
@@ -267,8 +269,8 @@ class AWIRAGEngine:
                 "metadata": metadata or {},
             },
             embedding=embedding,
-            created_at=datetime.utcnow(),
-            accessed_at=datetime.utcnow(),
+            created_at=utc_now(),
+            accessed_at=utc_now(),
             relevance_tags=[final_type]
             + self._generate_tags(action_sequence, key_entities),
         )
@@ -362,7 +364,7 @@ class AWIRAGEngine:
 
             if similarity >= similarity_threshold:
                 memory.access_count += 1
-                memory.accessed_at = datetime.utcnow()
+                memory.accessed_at = utc_now()
 
                 result = SearchResult(
                     memory_id=memory_id,
@@ -423,7 +425,7 @@ class AWIRAGEngine:
                 score = round(score, 4)
 
                 memory.access_count += 1
-                memory.accessed_at = datetime.utcnow()
+                memory.accessed_at = utc_now()
 
                 result = SearchResult(
                     memory_id=memory_id,
@@ -478,7 +480,7 @@ class AWIRAGEngine:
 
             if similarity >= 0.5:
                 memory.access_count += 1
-                memory.accessed_at = datetime.utcnow()
+                memory.accessed_at = utc_now()
 
                 result = SearchResult(
                     memory_id=memory_id,
@@ -555,7 +557,7 @@ class AWIRAGEngine:
                         "user_intent": result.user_intent,
                         "relevance": result.similarity_score,
                         "age_minutes": int(
-                            (datetime.utcnow() - result.created_at).total_seconds() / 60
+                            (utc_now() - result.created_at).total_seconds() / 60
                         ),
                     }
                 )
@@ -965,7 +967,7 @@ class AWIRAGEngine:
                 continue
 
             memory.access_count += 1
-            memory.accessed_at = datetime.utcnow()
+            memory.accessed_at = utc_now()
 
             search_results.append(
                 SearchResult(
@@ -979,7 +981,7 @@ class AWIRAGEngine:
                     key_entities=json.loads(metadata.get("key_entities", "[]"))[:20],
                     similarity_score=round(similarity, 4),
                     created_at=datetime.fromisoformat(
-                        metadata.get("created_at", datetime.utcnow().isoformat())
+                        metadata.get("created_at", utc_now().isoformat())
                     ),
                     accessed_at=memory.accessed_at,
                     access_count=memory.access_count,

--- a/app/services/content_factory_generation.py
+++ b/app/services/content_factory_generation.py
@@ -13,6 +13,8 @@ from typing import Any
 
 import httpx
 
+from app.core.time import utc_now
+
 from ..core.config import get_settings
 from ..core.runtime_mode import is_simulation
 from ..db.database import get_session_factory, is_database_configured
@@ -56,7 +58,7 @@ class ContentGenerationStore:
             model=model,
             provenance_json=json.dumps(provenance, sort_keys=True, default=str),
             output_text=output_text,
-            created_at=datetime.utcnow(),
+            created_at=utc_now(),
         )
         async with factory() as session:
             session.add(row)

--- a/app/services/genesis.py
+++ b/app/services/genesis.py
@@ -134,7 +134,7 @@ class GenesisReport:
 GENESIS_SERVICE_CODE = '''
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
-from datetime import datetime
+from datetime import datetime, timezone
 
 router = APIRouter(prefix="/v1/widgets", tags=["Widgets"])
 
@@ -144,7 +144,7 @@ class Widget(BaseModel):
     name: str = Field(..., description="Widget display name")
     category: str = Field(default="general", description="Widget category")
     status: str = Field(default="active", description="Widget status")
-    created_at: datetime = Field(default_factory=datetime.utcnow)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: dict = Field(default_factory=dict)
 
 class CreateWidgetRequest(BaseModel):

--- a/app/services/kyc_service.py
+++ b/app/services/kyc_service.py
@@ -314,10 +314,11 @@ class KYCService:
                 logger.error(f"Verification not found for session {session_id}")
                 return
 
+            verified_at = utc_now()
             verification.status = "verified"
-            verification.last_verified_at = utc_now()
+            verification.last_verified_at = verified_at
             if not verification.first_verified_at:
-                verification.first_verified_at = utc_now()
+                verification.first_verified_at = verified_at
             verification.rejection_reason = None
 
             result = await session.execute(
@@ -329,7 +330,7 @@ class KYCService:
 
             if wallet:
                 wallet.kyc_status = "verified"
-                wallet.kyc_verified_at = utc_now()
+                wallet.kyc_verified_at = verified_at
                 if wallet.status == "pending_kyc":
                     wallet.status = "active"
                 session.add(wallet)

--- a/app/services/kyc_service.py
+++ b/app/services/kyc_service.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 import stripe
 from sqlalchemy import select
 
+from ..core.time import utc_now
 from ..db.database import get_session_factory
 from ..db.models import KYCVerificationModel, WalletModel
 from ..core.config import get_settings
@@ -130,7 +131,7 @@ class KYCService:
             raise KYCVerificationError(f"Failed to create verification session: {e}")
 
         verification_id = str(uuid4())
-        expires_at = datetime.utcnow() + timedelta(days=self.SESSION_EXPIRY_DAYS)
+        expires_at = utc_now() + timedelta(days=self.SESSION_EXPIRY_DAYS)
 
         async with self._session_factory()() as session:
             verification = KYCVerificationModel(
@@ -160,7 +161,7 @@ class KYCService:
             "session_id": verification_session.id,
             "session_url": verification_session.url,
             "status": "pending",
-            "created_at": datetime.utcnow(),
+            "created_at": utc_now(),
             "expires_at": expires_at,
         }
 
@@ -314,9 +315,9 @@ class KYCService:
                 return
 
             verification.status = "verified"
-            verification.last_verified_at = datetime.utcnow()
+            verification.last_verified_at = utc_now()
             if not verification.first_verified_at:
-                verification.first_verified_at = datetime.utcnow()
+                verification.first_verified_at = utc_now()
             verification.rejection_reason = None
 
             result = await session.execute(
@@ -328,7 +329,7 @@ class KYCService:
 
             if wallet:
                 wallet.kyc_status = "verified"
-                wallet.kyc_verified_at = datetime.utcnow()
+                wallet.kyc_verified_at = utc_now()
                 if wallet.status == "pending_kyc":
                     wallet.status = "active"
                 session.add(wallet)
@@ -423,7 +424,7 @@ class KYCService:
             if verification:
                 verification.status = "rejected"
                 verification.rejection_reason = reason
-                verification.last_verified_at = datetime.utcnow()
+                verification.last_verified_at = utc_now()
 
             result = await session.execute(
                 select(WalletModel)

--- a/app/services/policies.py
+++ b/app/services/policies.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from app.core.time import utc_now
 from decimal import Decimal
 import json
 from typing import Any
@@ -128,7 +128,7 @@ async def patch_policy_bundle(
                 setattr(row, field, Decimal(str(value)) if value is not None else None)
             else:
                 setattr(row, field, value)
-        row.updated_at = datetime.utcnow()
+        row.updated_at = utc_now()
         session.add(row)
         await session.commit()
         await session.refresh(row)

--- a/app/services/webauthn_provider.py
+++ b/app/services/webauthn_provider.py
@@ -32,6 +32,8 @@ from enum import Enum
 from typing import Any, Optional
 from uuid import uuid4
 
+from app.core.time import utc_now
+
 logger = logging.getLogger(__name__)
 
 PY_WEBAUTHN_AVAILABLE = False
@@ -114,7 +116,7 @@ class CredentialRecord:
     user_id: str
     public_key: bytes
     sign_count: int = 0
-    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_at: datetime = field(default_factory=utc_now)
     name: str = ""
 
 
@@ -234,7 +236,7 @@ class WebAuthnProvider:
             base64.urlsafe_b64encode(challenge_bytes).decode("ascii").rstrip("=")
         )
 
-        now = datetime.utcnow()
+        now = utc_now()
         challenge = WebAuthnChallenge(
             challenge_id=challenge_id,
             session_id=session_id,
@@ -356,7 +358,7 @@ class WebAuthnProvider:
         if challenge.status == ChallengeStatus.FAILED:
             raise ValueError("Challenge verification previously failed")
 
-        if datetime.utcnow() > challenge.expires_at:
+        if utc_now() > challenge.expires_at:
             challenge.status = ChallengeStatus.EXPIRED
             raise ValueError("Challenge expired")
 
@@ -374,7 +376,7 @@ class WebAuthnProvider:
 
         challenge.status = ChallengeStatus.VERIFIED
 
-        now = datetime.utcnow()
+        now = utc_now()
         verification_key = self._make_verification_key(
             challenge.session_id, challenge.action
         )
@@ -424,7 +426,7 @@ class WebAuthnProvider:
         if not verification:
             return False
 
-        if datetime.utcnow() > verification.expires_at:
+        if utc_now() > verification.expires_at:
             del self._verifications[verification_key]
             return False
 
@@ -457,7 +459,7 @@ class WebAuthnProvider:
                 "expires_in_seconds": None,
             }
 
-        now = datetime.utcnow()
+        now = utc_now()
         remaining = (verification.expires_at - now).total_seconds()
 
         if remaining <= 0:
@@ -583,7 +585,7 @@ class WebAuthnProvider:
         Returns:
             Dict with counts of removed items.
         """
-        now = datetime.utcnow()
+        now = utc_now()
 
         expired_challenges = [
             cid for cid, c in self._challenges.items() if now > c.expires_at

--- a/b2a_sdk/__init__.py
+++ b/b2a_sdk/__init__.py
@@ -18,7 +18,7 @@ Example Usage:
         ...
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __author__ = "Agent-Native Middleware"
 
 from .client import B2AClient, InsufficientFundsError

--- a/b2a_sdk/__init__.py
+++ b/b2a_sdk/__init__.py
@@ -23,9 +23,11 @@ __author__ = "Agent-Native Middleware"
 
 from .client import B2AClient, InsufficientFundsError
 from .decorators import billable, combined, monitored
+from .edge_client import B2AEdgeClient
 
 __all__ = [
     "B2AClient",
+    "B2AEdgeClient",
     "InsufficientFundsError",
     "monitored",
     "billable",

--- a/b2a_sdk/edge_client.py
+++ b/b2a_sdk/edge_client.py
@@ -39,7 +39,12 @@ class B2AEdgeClient:
         self.timeout = timeout
         self._client = httpx.AsyncClient(timeout=timeout)
 
+    def _auth_headers(self) -> dict[str, str]:
+        """Bare auth headers for requests with no body (GET)."""
+        return {"X-API-Key": self.api_key} if self.api_key else {}
+
     def _headers(self) -> dict[str, str]:
+        """Auth + JSON headers for requests with a body (POST/PUT/PATCH)."""
         headers = {"Content-Type": "application/json"}
         if self.api_key:
             headers["X-API-Key"] = self.api_key
@@ -49,7 +54,7 @@ class B2AEdgeClient:
         """Fetch available MCP tools from the server."""
         response = await self._client.get(
             f"{self.api_url}/mcp/tools.json",
-            headers=self._headers(),
+            headers=self._auth_headers(),
         )
         response.raise_for_status()
         return response.json().get("tools", [])
@@ -121,7 +126,7 @@ class B2AEdgeClient:
             raise ValueError("wallet_id required for balance check")
         response = await self._client.get(
             f"{self.api_url}/v1/billing/wallets/{self.wallet_id}",
-            headers=self._headers(),
+            headers=self._auth_headers(),
         )
         response.raise_for_status()
         return response.json().get("balance", 0.0)
@@ -130,7 +135,7 @@ class B2AEdgeClient:
         """Close the HTTP client."""
         await self._client.aclose()
 
-    async def __aenter__(self) -> "B2AEdgeClient":
+    async def __aenter__(self) -> B2AEdgeClient:
         return self
 
     async def __aexit__(self, *args: Any) -> None:

--- a/b2a_sdk/edge_client.py
+++ b/b2a_sdk/edge_client.py
@@ -1,0 +1,137 @@
+"""Shared HTTP edge client for framework wrappers.
+
+The framework wrappers (langchain, crewai, autogen) all need the same
+narrow surface: list MCP tools, call an MCP tool, drive an AWI session, read
+a wallet balance. This base centralizes that surface so each wrapper only has
+to add the framework-specific glue.
+
+This is intentionally a smaller surface than ``B2AClient``. ``B2AClient`` is
+the full agent-facing client used by service code and decorators; this base
+is the wrapper-facing edge client used by framework integrations that just
+need to talk to the middleware over HTTP.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class B2AEdgeClient:
+    """Shared async HTTP surface for framework wrappers.
+
+    Subclasses can override or extend specific methods to add
+    framework-specific affordances (e.g. returning langchain ``Tool`` objects
+    instead of raw dicts) without re-implementing the HTTP plumbing.
+    """
+
+    def __init__(
+        self,
+        api_url: str = "http://localhost:8000",
+        api_key: str | None = None,
+        wallet_id: str | None = None,
+        timeout: float = 30.0,
+    ):
+        self.api_url = api_url.rstrip("/")
+        self.api_key = api_key
+        self.wallet_id = wallet_id
+        self.timeout = timeout
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        return headers
+
+    async def get_mcp_tools(self) -> list[dict[str, Any]]:
+        """Fetch available MCP tools from the server."""
+        response = await self._client.get(
+            f"{self.api_url}/mcp/tools.json",
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        return response.json().get("tools", [])
+
+    async def call_mcp_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Call an MCP tool by name."""
+        payload: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": name,
+                "arguments": arguments,
+            },
+            "id": 1,
+        }
+        if self.wallet_id:
+            payload["params"]["mcpContext"] = {"wallet_id": self.wallet_id}
+
+        response = await self._client.post(
+            f"{self.api_url}/mcp/messages",
+            json=payload,
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def create_awi_session(
+        self,
+        target_url: str,
+        max_steps: int = 100,
+    ) -> dict[str, Any]:
+        """Create an AWI session for web interaction."""
+        payload = {"target_url": target_url, "max_steps": max_steps}
+        response = await self._client.post(
+            f"{self.api_url}/v1/awi/sessions",
+            json=payload,
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def execute_awi_action(
+        self,
+        session_id: str,
+        action: str,
+        parameters: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Execute an AWI action on a session."""
+        payload = {
+            "session_id": session_id,
+            "action": action,
+            "parameters": parameters,
+        }
+        response = await self._client.post(
+            f"{self.api_url}/v1/awi/execute",
+            json=payload,
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def get_balance(self) -> float:
+        """Get wallet balance. Requires ``wallet_id`` set on the client."""
+        if not self.wallet_id:
+            raise ValueError("wallet_id required for balance check")
+        response = await self._client.get(
+            f"{self.api_url}/v1/billing/wallets/{self.wallet_id}",
+            headers=self._headers(),
+        )
+        response.raise_for_status()
+        return response.json().get("balance", 0.0)
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "B2AEdgeClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.close()

--- a/b2a_sdk/pyproject.toml
+++ b/b2a_sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "b2a-sdk"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python SDK for the Agent-Native Middleware API"
 readme = "README.md"
 license = "MIT"

--- a/docs/demo-trust-plane-output.md
+++ b/docs/demo-trust-plane-output.md
@@ -27,7 +27,8 @@ Example proof artifact:
   "replay_receipt_id": "rcpt-26e46941ba4a4bb6",
   "signing_key_id": "demo-ed25519",
   "sponsor_wallet_id": "spn-54322a836193",
-  "success_receipt_id": "rcpt-26e46941ba4a4bb6"
+  "success_receipt_id": "rcpt-26e46941ba4a4bb6",
+  "ungoverned_denial_reason": "permit_required"
 }
 ```
 
@@ -39,6 +40,8 @@ What this proves:
   create a second debit.
 - An out-of-scope MCP tool is denied and produces a denial receipt.
 - Replaying that denial returns the same denial receipt and response semantics.
+- An MCP call with no permit at all is denied with `permit_required`, proving
+  the trust plane fails closed when `ALLOW_LEGACY_UNPERMITTED_MCP=false`.
 - The agent API key cannot read the sponsor wallet.
 - The wallet-scoped audit chain verifies after the governed action, and the
   audit event links back to permit, idempotency key, request hash, and ledger

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -1,0 +1,181 @@
+# Key Management
+
+How the trust-plane signing key is loaded today, how it is intended to be
+managed in production, and what specifically changes when moving from the
+env-var-based loader to an external KMS.
+
+This document is normative for the Ed25519 key that signs permits, receipts,
+and audit-chain entries. It is not the only secret in the system, but it is
+the secret that the trust-plane guarantees depend on. If this key is
+compromised, every receipt and permit becomes forgeable from the moment of
+compromise forward.
+
+## Current Posture
+
+The active key is loaded by `SigningKeyService._load_private_key` in
+`app/services/signing_keys.py`. The loader has two modes:
+
+1. **Configured key** — `TRUST_SIGNING_PRIVATE_KEY_B64` (set in
+   `app/core/config.py`) is read at first use, base64-decoded, and constructed
+   as an `Ed25519PrivateKey`. The decoded private bytes never leave the
+   process.
+2. **Ephemeral fallback** — if the env var is empty and `TRUST_MODE_ENABLED`
+   is false, the loader generates a process-local `Ed25519PrivateKey` that
+   exists only in memory and dies with the process. This path exists so local
+   tests can exercise sign/verify without persisting key material to disk.
+
+If `TRUST_MODE_ENABLED` is true and the env var is empty, the loader raises
+`SigningKeyError("trust_signing_private_key_required")`. There is no silent
+fallback in trust mode.
+
+Public-key metadata (key ID, base64 public key, status, activation time) is
+persisted in the `SigningKeyModel` table and is the basis for offline receipt
+verification. The private key is never persisted.
+
+### Why the current posture is acceptable for MVP
+
+- The private key lives only in the process memory of API workers
+- Hosting platforms (Railway, Fly, AWS) inject the env var from their own
+  secret stores at deploy time
+- Public-key metadata is auditable and rotatable from inside the API
+- The trust boundary documented in `SECURITY_LIMITATIONS.md` is consistent
+  with this loader
+
+### Why it is not production-grade
+
+- The private key is recoverable by anyone with access to the process env
+  (sidecar, debugger, `/proc`, crash dump, container introspection)
+- There is no hardware-rooted custody
+- There is no separation between signing authority and the workload that
+  invokes signing
+- Rotation requires re-deploying with a new env var, which couples key
+  rotation to release cadence
+
+## Production Target: External KMS
+
+In production, signing must happen inside an external KMS, and the API worker
+must never hold raw private bytes. Three providers are supported as targets;
+the choice is per-deployment.
+
+### Provider Targets
+
+| Provider | Key type | Sign API | Audit |
+|---|---|---|---|
+| AWS KMS | `ECC_NIST_P256` (until KMS adds Ed25519) or external-key import | `Sign` with `SigningAlgorithm=ECDSA_SHA_256` or imported-key Ed25519 | CloudTrail logs every `Sign` call |
+| GCP KMS | `ASYMMETRIC_SIGN` Ed25519 | `AsymmetricSign` | Cloud Audit Logs every `AsymmetricSign` call |
+| HashiCorp Vault Transit | `ed25519` | `transit/sign/:name` | Vault audit device |
+
+The receipt format does not change. `alg` stays `Ed25519` for Vault and GCP
+KMS. For AWS KMS until Ed25519 is native, the `alg` field becomes
+`ECDSA-P256-SHA256` and verification code must accept both algorithms keyed
+by the receipt's `alg` field.
+
+### Concrete code changes
+
+The integration points are narrow because the loader was designed for this:
+
+1. **`app/services/signing_keys.py`** — replace `_load_private_key` with a
+   provider strategy. The strategy returns an opaque key handle, not raw
+   bytes. `sign_payload_with_key_id` calls `strategy.sign(message)` instead
+   of `self._private_key.sign(message)`.
+
+2. **`app/core/config.py`** — add:
+   - `TRUST_KMS_PROVIDER` (`env` | `aws_kms` | `gcp_kms` | `vault_transit`)
+   - `TRUST_KMS_KEY_REF` (ARN, resource name, or Vault key name)
+   - `TRUST_KMS_REGION` (where relevant)
+   - `TRUST_KMS_ROLE_ARN` / equivalent workload-identity binding
+
+3. **`SigningKeyService.ensure_active_key`** — the public-key metadata path
+   stays the same, but the public key is fetched from the KMS once at
+   startup and cached, rather than derived from the local private key.
+
+4. **`SigningKeyService.rotate_active_key_metadata`** — gains a real
+   counterpart: a rotation flow that creates a new KMS key version, marks the
+   old metadata row `retired`, inserts the new metadata row, and begins
+   signing under the new `kid` without breaking historical verification.
+
+5. **Health checks** — add a `/healthz/kms` endpoint that performs a no-op
+   signing round-trip and reports KMS latency. This is the early-warning
+   signal for KMS misconfiguration.
+
+The signing call path stays a single function call; only the implementation
+changes.
+
+### Workload identity, not static credentials
+
+The API worker must authenticate to the KMS using workload identity, not a
+static credential:
+
+- **AWS** — IAM role attached to the task/pod, scoped to `kms:Sign` on
+  exactly the trust-plane key ARN. No `kms:GetPublicKey` is required after
+  startup if the public key is cached.
+- **GCP** — Workload Identity binding, scoped to `roles/cloudkms.signer` on
+  exactly the trust-plane key resource.
+- **Vault** — Kubernetes auth or AppRole with a policy that allows
+  `update` on `transit/sign/<key>` and nothing else.
+
+The KMS audit log becomes the canonical record of "who signed what when."
+This is the property that closes the gap in `SECURITY_LIMITATIONS.md` between
+"receipts are verifiable" and "receipts are non-repudiable."
+
+## Rotation Flow Under KMS
+
+Rotation under KMS is metadata + key-version change, not a redeploy:
+
+1. Operator creates a new key version in the KMS (`aws kms
+   create-key` for a new key, or version rotation on an existing key).
+2. Operator calls `POST /v1/admin/signing-keys/rotate` with the new key
+   reference and a new `kid`.
+3. `rotate_active_key_metadata` marks the prior metadata row `retired`
+   (retains it for verification of pre-rotation receipts), inserts the new
+   metadata row, and flips the active `kid`.
+4. Subsequent `sign_payload` calls produce receipts under the new `kid`.
+5. Verification continues to work for receipts under the old `kid` because
+   the retired metadata row is still queryable.
+6. No worker restart is required.
+
+The same rotation flow runs unattended on a schedule (e.g., quarterly) via a
+cron job that calls the admin endpoint with a service identity.
+
+## Compromise Response
+
+If a signing key is suspected of compromise:
+
+1. **Disable**, not retire, the affected `kid` — set `status="disabled"` so
+   `verify_payload` rejects signatures bound to it.
+2. Rotate to a new KMS key version immediately.
+3. Re-issue any unconsumed permits under the new `kid`. Receipts already
+   produced under the disabled key are no longer accepted by verification;
+   downstream consumers must re-acquire authorization.
+4. Publish the compromised `kid` to any external transparency log used by
+   consumers.
+
+The audit chain itself is signed and hash-linked. If the signing key is
+rotated, the chain continues — each entry references its signing `kid`, so a
+verifier can walk a chain that spans key rotations.
+
+## What This Does Not Solve
+
+This document covers the trust-plane signing key. It does not cover:
+
+- API-key custody (`VALID_API_KEYS`, DB-backed API keys)
+- Stripe webhook secrets
+- Database credentials
+- TLS material
+
+Those secrets follow the standard host secret-manager pattern and are out of
+scope for the trust-plane key-management story.
+
+## Status
+
+Until the KMS integration ships, the production posture is:
+
+- `TRUST_MODE_ENABLED=true`
+- `TRUST_SIGNING_PRIVATE_KEY_B64` injected at deploy time from the hosting
+  platform secret manager
+- Rotation by redeploy with a new env var and a follow-up
+  `POST /v1/admin/signing-keys/rotate` to advance the metadata `kid`
+
+This is documented as a known limitation in `SECURITY_LIMITATIONS.md` and
+should be the default answer to "where do the private keys live?" until the
+KMS work lands.

--- a/scripts/demo_trust_plane.py
+++ b/scripts/demo_trust_plane.py
@@ -521,6 +521,51 @@ async def run_demo(json_output: bool = False) -> dict[str, Any]:
                 "denied replay did not return original denial receipt",
             )
 
+            step("attempting MCP call with no permit (trust-mode fail-closed)")
+            unpermitted_body = {
+                "jsonrpc": "2.0",
+                "id": "demo-unpermitted-1",
+                "method": "tools/call",
+                "params": {
+                    "name": ALLOWED_TOOL,
+                    "arguments": {"message": "should never reach the tool"},
+                    "mcpContext": {
+                        "wallet_id": agent_wallet_id,
+                        "idempotency_key": "demo-unpermitted-1",
+                    },
+                },
+            }
+            unpermitted_call = await post_json(
+                client,
+                "/mcp/messages",
+                headers=agent_headers,
+                expected_status=200,
+                json_body=unpermitted_body,
+            )
+            unpermitted_error = first_jsonrpc_error(unpermitted_call)
+            require(
+                unpermitted_error["message"] == "permit_required",
+                f"ungoverned call was not denied: {unpermitted_error}",
+            )
+            ledger_after_unpermitted = await get_json(
+                client,
+                f"/v1/billing/ledger/{agent_wallet_id}",
+                headers=agent_headers,
+                expected_status=200,
+            )
+            require(
+                len(
+                    [
+                        entry
+                        for entry in ledger_after_unpermitted["entries"]
+                        if entry["service_category"] == "agent_comms"
+                        and ALLOWED_TOOL in entry.get("description", "")
+                    ]
+                )
+                == 1,
+                "ungoverned call produced a ledger debit",
+            )
+
             step("proving tenant isolation")
             cross_wallet = await client.get(
                 f"/v1/billing/wallets/{sponsor_wallet_id}",
@@ -611,6 +656,7 @@ async def run_demo(json_output: bool = False) -> dict[str, Any]:
                     "receipt_id"
                 ],
                 "denial_reason": denial_error["message"],
+                "ungoverned_denial_reason": unpermitted_error["message"],
                 "cross_wallet_status": cross_wallet.status_code,
                 "evidence_bundle_valid": bundle["valid"],
                 "tampered_receipt_valid": tampered_receipt_check["valid"],

--- a/scripts/red_team_trust_plane.py
+++ b/scripts/red_team_trust_plane.py
@@ -262,6 +262,34 @@ async def _allowed_tool_debits(
     ]
 
 
+async def _any_demo_tool_debits(
+    client: AsyncClient, wallet_id: str, headers: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Return every ledger entry referencing any demo tool on the given wallet.
+
+    The narrow ALLOWED_TOOL+victim_wallet filter elsewhere is only sufficient
+    for the positive control. The red-team battery also targets BLOCKED_TOOL
+    and uses the attacker wallet for the stolen-permit case, so the no-debit
+    invariant has to be checked across every wallet/tool combination the
+    attacks actually touched.
+    """
+    ledger = await get_json(
+        client,
+        f"/v1/billing/ledger/{wallet_id}",
+        headers=headers,
+        expected_status=200,
+    )
+    return [
+        entry
+        for entry in ledger["entries"]
+        if entry["service_category"] == "agent_comms"
+        and (
+            ALLOWED_TOOL in entry.get("description", "")
+            or BLOCKED_TOOL in entry.get("description", "")
+        )
+    ]
+
+
 async def run_red_team(json_output: bool = False) -> dict[str, Any]:
     global PRINT_STEPS
 
@@ -401,13 +429,40 @@ async def run_red_team(json_output: bool = False) -> dict[str, Any]:
                     "error" in response,
                     f"{name}: expected a JSON-RPC denial, got {response}",
                 )
-                reason = response["error"]["message"]
+                error = response["error"]
+                reason = error["message"]
                 require(
                     reason == expected_reason,
                     f"{name}: expected reason {expected_reason!r}, got {reason!r}",
                 )
+                # Denials that go through the permit-validation path produce a
+                # signed denial receipt. When one is present, it must carry
+                # outcome=denied and no ledger linkage — that is the per-call
+                # guarantee that complements the cross-wallet ledger sweep
+                # below.
+                receipt = (error.get("data") or {}).get("receipt")
+                receipt_id = None
+                if receipt is not None:
+                    require(
+                        receipt.get("outcome") == "denied",
+                        f"{name}: denial receipt outcome was {receipt.get('outcome')!r}",
+                    )
+                    require(
+                        receipt.get("ledger_entry_id") is None,
+                        f"{name}: denial receipt carried ledger_entry_id "
+                        f"{receipt.get('ledger_entry_id')!r}",
+                    )
+                    receipt_id = receipt.get("receipt_id")
                 step(f"  denied: {name} -> {reason}")
-                attacks.append({"attack": name, "reason": reason})
+                attacks.append(
+                    {
+                        "attack": name,
+                        "reason": reason,
+                        "receipt_id": receipt_id,
+                        "wallet_id": wallet_id,
+                        "tool": tool,
+                    }
+                )
 
             step("running the adversarial battery")
 
@@ -579,13 +634,29 @@ async def run_red_team(json_output: bool = False) -> dict[str, Any]:
                 idem="rt-signature-invalid",
             )
 
-            step("confirming no attack produced a ledger debit")
-            debits_after_attacks = await _allowed_tool_debits(
+            step("confirming no attack produced a ledger debit on any touched wallet")
+            # Sweep every wallet the battery touched, for every demo tool. The
+            # earlier per-call receipt checks already prove each denial that
+            # carried a receipt has no ledger linkage; this cross-wallet sweep
+            # additionally catches a regression that wrote a debit without a
+            # receipt or under an unexpected tool/wallet pair (e.g. a leak in
+            # the wallet_mismatch path that hit the attacker wallet, or a leak
+            # in the tool_not_allowed path that hit BLOCKED_TOOL).
+            victim_debits_after_attacks = await _any_demo_tool_debits(
                 client, victim_wallet_id, victim_headers
             )
+            attacker_debits_after_attacks = await _any_demo_tool_debits(
+                client, attacker_wallet_id, attacker_headers
+            )
             require(
-                debits_after_attacks == [],
-                f"an attack produced a ledger debit: {debits_after_attacks}",
+                victim_debits_after_attacks == [],
+                f"an attack produced a victim ledger debit: "
+                f"{victim_debits_after_attacks}",
+            )
+            require(
+                attacker_debits_after_attacks == [],
+                f"an attack produced an attacker ledger debit: "
+                f"{attacker_debits_after_attacks}",
             )
 
             step("positive control: the one valid call succeeds and charges once")
@@ -636,13 +707,16 @@ async def run_red_team(json_output: bool = False) -> dict[str, Any]:
                 f"expected 10 denied attacks, recorded {len(attacks)}",
             )
 
+            attacks_with_receipts = sum(1 for a in attacks if a["receipt_id"])
             summary = {
                 "victim_wallet_id": victim_wallet_id,
                 "attacker_wallet_id": attacker_wallet_id,
                 "valid_permit_id": valid_permit_id,
                 "attacks_denied": len(attacks),
+                "attacks_with_signed_denial_receipts": attacks_with_receipts,
                 "denial_reasons": [a["reason"] for a in attacks],
-                "ledger_debits_after_attacks": len(debits_after_attacks),
+                "victim_debits_after_attacks": len(victim_debits_after_attacks),
+                "attacker_debits_after_attacks": len(attacker_debits_after_attacks),
                 "success_receipt_id": success_receipt["receipt_id"],
                 "ledger_debits_total": len(final_debits),
                 "audit_chain_valid": audit_check["valid"],

--- a/scripts/red_team_trust_plane.py
+++ b/scripts/red_team_trust_plane.py
@@ -1,0 +1,686 @@
+#!/usr/bin/env python3
+"""Adversarial proof for the MCP governance trust plane.
+
+Where ``demo_trust_plane.py`` proves the happy path plus a couple of denials,
+this script is the red-team battery: it drives one valid permit and then
+attacks it ten different ways, asserting that each attack is denied with a
+concrete, specific reason code and that *none* of them produces a ledger
+debit. A single positive control at the end proves the harness can still tell
+an allowed call from a denied one, and that exactly one charge landed.
+
+It runs against a throwaway local SQLite database and the real FastAPI
+routers, with the trust plane in fail-closed mode
+(``ALLOW_LEGACY_UNPERMITTED_MCP=false``).
+
+Attacks covered (reason code asserted for each):
+
+    no permit on a governed call ............ permit_required
+    unknown permit id ....................... permit_not_found
+    tool outside the permit ................. permit_tool_not_allowed
+    permit missing the invoke scope ......... permit_scope_missing
+    budget too small for the call ........... permit_budget_exceeded
+    stolen permit used by another wallet .... permit_wallet_mismatch
+    permit used with the wrong key .......... permit_key_mismatch
+    expired permit .......................... permit_expired
+    revoked permit .......................... permit_revoked
+    tampered (re-signed) permit ............. permit_signature_invalid
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEMO_DB = ROOT / "data" / "red_team_trust_plane.db"
+ADMIN_KEY = "demo-admin-key"
+DEMO_PRIVATE_KEY_B64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+ALLOWED_TOOL = "trust-plane-echo"
+BLOCKED_TOOL = "trust-plane-admin-ledger"
+TOOL_COST = 2.0
+PRINT_STEPS = True
+
+
+def configure_environment() -> None:
+    """Set demo-safe defaults before importing the app."""
+    DEMO_DB.parent.mkdir(parents=True, exist_ok=True)
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{DEMO_DB}"
+    os.environ["VALID_API_KEYS"] = ADMIN_KEY
+    os.environ["TRUST_MODE_ENABLED"] = "true"
+    os.environ["ALLOW_LEGACY_UNPERMITTED_MCP"] = "false"
+    os.environ["TRUST_SIGNING_KEY_ID"] = "demo-ed25519"
+    os.environ["TRUST_SIGNING_PRIVATE_KEY_B64"] = DEMO_PRIVATE_KEY_B64
+
+
+configure_environment()
+sys.path.insert(0, str(ROOT))
+
+from decimal import Decimal  # noqa: E402
+
+from httpx import ASGITransport, AsyncClient  # noqa: E402
+from sqlalchemy import select  # noqa: E402
+
+from app.db.database import close_db, get_session_factory, init_db  # noqa: E402
+from app.db.models import PermitModel  # noqa: E402
+from app.main import app  # noqa: E402
+from app.schemas.billing import ServiceCategory  # noqa: E402
+from app.services.service_registry import get_service_registry  # noqa: E402
+
+
+def remove_demo_db() -> None:
+    for suffix in ("", "-shm", "-wal"):
+        path = Path(f"{DEMO_DB}{suffix}")
+        if path.exists():
+            path.unlink()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def step(message: str) -> None:
+    if PRINT_STEPS:
+        print(f"[red-team] {message}")
+
+
+def register_demo_tools() -> None:
+    registry = get_service_registry()
+
+    def echo(message: str = "ok") -> dict[str, str]:
+        return {"message": message, "governed": "true"}
+
+    def admin_ledger_probe() -> dict[str, str]:
+        return {"should_not_execute": "true"}
+
+    registry.register_local(
+        service_id=ALLOWED_TOOL,
+        name="Trust Plane Echo",
+        description="Demo tool allowed by the signed permit",
+        category=ServiceCategory.AGENT_COMMS,
+        func=echo,
+        credits_per_unit=TOOL_COST,
+        unit_name="call",
+    )
+    registry.register_local(
+        service_id=BLOCKED_TOOL,
+        name="Trust Plane Blocked Admin Tool",
+        description="Demo tool intentionally outside the signed permit",
+        category=ServiceCategory.AGENT_COMMS,
+        func=admin_ledger_probe,
+        credits_per_unit=TOOL_COST,
+        unit_name="call",
+    )
+
+
+def unregister_demo_tools() -> None:
+    registry = get_service_registry()
+    registry.unregister_local(ALLOWED_TOOL)
+    registry.unregister_local(BLOCKED_TOOL)
+
+
+async def post_json(
+    client: AsyncClient,
+    path: str,
+    *,
+    headers: dict[str, str],
+    json_body: dict[str, Any],
+    expected_status: int,
+) -> dict[str, Any]:
+    response = await client.post(path, headers=headers, json=json_body)
+    require(
+        response.status_code == expected_status,
+        f"{path} returned {response.status_code}: {response.text}",
+    )
+    return response.json()
+
+
+async def get_json(
+    client: AsyncClient,
+    path: str,
+    *,
+    headers: dict[str, str],
+    expected_status: int,
+) -> dict[str, Any]:
+    response = await client.get(path, headers=headers)
+    require(
+        response.status_code == expected_status,
+        f"{path} returned {response.status_code}: {response.text}",
+    )
+    return response.json()
+
+
+def build_mcp_call(
+    *,
+    request_id: str,
+    tool: str,
+    wallet_id: str,
+    idempotency_key: str,
+    permit_id: str | None = None,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    mcp_context: dict[str, Any] = {
+        "wallet_id": wallet_id,
+        "idempotency_key": idempotency_key,
+    }
+    if permit_id is not None:
+        mcp_context["permit_id"] = permit_id
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "tools/call",
+        "params": {
+            "name": tool,
+            "arguments": arguments or {},
+            "mcpContext": mcp_context,
+        },
+    }
+
+
+async def issue_permit(
+    client: AsyncClient,
+    *,
+    admin_headers: dict[str, str],
+    wallet_id: str,
+    key_id: str,
+    allowed_tools: list[str],
+    scopes: list[str],
+    max_credits: int,
+    idem_key: str,
+) -> dict[str, Any]:
+    return await post_json(
+        client,
+        "/v1/permits",
+        headers={**admin_headers, "Idempotency-Key": idem_key},
+        expected_status=201,
+        json_body={
+            "issuer_wallet_id": wallet_id,
+            "subject_wallet_id": wallet_id,
+            "subject_key_id": key_id,
+            "allowed_tools": allowed_tools,
+            "scopes": scopes,
+            "max_credits": max_credits,
+            "expires_at": (
+                datetime.now(timezone.utc) + timedelta(minutes=30)
+            ).isoformat(),
+        },
+    )
+
+
+async def _force_permit_expired(permit_id: str) -> None:
+    """Push a previously-valid permit's expiry into the past."""
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(PermitModel).where(PermitModel.permit_id == permit_id)
+        )
+        model = result.scalar_one()
+        model.expires_at = datetime.now(timezone.utc) - timedelta(minutes=5)
+        session.add(model)
+        await session.commit()
+
+
+async def _tamper_permit_budget(permit_id: str) -> None:
+    """Raise a signed field (max_credits) so the signature no longer holds.
+
+    The budget check passes (raising the cap can only make more room), so
+    validation proceeds to the signature check and fails there — proving the
+    signature, not just the stored fields, gates authorization.
+    """
+    factory = get_session_factory()
+    async with factory() as session:
+        result = await session.execute(
+            select(PermitModel).where(PermitModel.permit_id == permit_id)
+        )
+        model = result.scalar_one()
+        model.max_credits = model.max_credits + Decimal("2000")
+        session.add(model)
+        await session.commit()
+
+
+async def _allowed_tool_debits(
+    client: AsyncClient, wallet_id: str, headers: dict[str, str]
+) -> list[dict[str, Any]]:
+    ledger = await get_json(
+        client,
+        f"/v1/billing/ledger/{wallet_id}",
+        headers=headers,
+        expected_status=200,
+    )
+    return [
+        entry
+        for entry in ledger["entries"]
+        if entry["service_category"] == "agent_comms"
+        and ALLOWED_TOOL in entry.get("description", "")
+    ]
+
+
+async def run_red_team(json_output: bool = False) -> dict[str, Any]:
+    global PRINT_STEPS
+
+    PRINT_STEPS = not json_output
+    await close_db()
+    remove_demo_db()
+    await init_db()
+    register_demo_tools()
+
+    admin_headers = {"X-API-Key": ADMIN_KEY}
+    attacks: list[dict[str, Any]] = []
+
+    try:
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://red-team") as client:
+            step("provisioning sponsor, victim agent, and attacker agent")
+            sponsor = await post_json(
+                client,
+                "/v1/billing/wallets/sponsor",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "sponsor_name": "Red Team Sponsor",
+                    "email": "red-team-sponsor@example.com",
+                    "initial_credits": 10000,
+                    "require_kyc": False,
+                },
+            )
+            sponsor_wallet_id = sponsor["wallet_id"]
+
+            victim = await post_json(
+                client,
+                "/v1/billing/wallets/agent",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "sponsor_wallet_id": sponsor_wallet_id,
+                    "agent_id": "victim-agent",
+                    "budget_credits": 1000,
+                    "daily_limit": 500,
+                },
+            )
+            victim_wallet_id = victim["wallet_id"]
+
+            attacker = await post_json(
+                client,
+                "/v1/billing/wallets/agent",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "sponsor_wallet_id": sponsor_wallet_id,
+                    "agent_id": "attacker-agent",
+                    "budget_credits": 1000,
+                    "daily_limit": 500,
+                },
+            )
+            attacker_wallet_id = attacker["wallet_id"]
+
+            # Two keys for the victim wallet: the permit binds to key #1, so a
+            # call presenting key #2 must be rejected for key mismatch.
+            victim_key1 = await post_json(
+                client,
+                "/v1/api-keys",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "wallet_id": victim_wallet_id,
+                    "key_name": "victim-runtime-1",
+                    "expires_in_days": 30,
+                },
+            )
+            victim_key2 = await post_json(
+                client,
+                "/v1/api-keys",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "wallet_id": victim_wallet_id,
+                    "key_name": "victim-runtime-2",
+                    "expires_in_days": 30,
+                },
+            )
+            attacker_key = await post_json(
+                client,
+                "/v1/api-keys",
+                headers=admin_headers,
+                expected_status=201,
+                json_body={
+                    "wallet_id": attacker_wallet_id,
+                    "key_name": "attacker-runtime",
+                    "expires_in_days": 30,
+                },
+            )
+
+            victim_headers = {"X-API-Key": victim_key1["api_key"]}
+            victim_headers_key2 = {"X-API-Key": victim_key2["api_key"]}
+            attacker_headers = {"X-API-Key": attacker_key["api_key"]}
+
+            step("issuing one valid permit bound to victim wallet + key #1")
+            valid_scopes = [f"tool:{ALLOWED_TOOL}:invoke", "billing:charge"]
+            valid_permit = await issue_permit(
+                client,
+                admin_headers=admin_headers,
+                wallet_id=victim_wallet_id,
+                key_id=victim_key1["key_id"],
+                allowed_tools=[ALLOWED_TOOL],
+                scopes=valid_scopes,
+                max_credits=25,
+                idem_key="rt-permit-valid",
+            )
+            valid_permit_id = valid_permit["permit_id"]
+
+            async def attack(
+                name: str,
+                *,
+                headers: dict[str, str],
+                wallet_id: str,
+                tool: str,
+                expected_reason: str,
+                permit_id: str | None,
+                idem: str,
+            ) -> None:
+                response = await post_json(
+                    client,
+                    "/mcp/messages",
+                    headers=headers,
+                    expected_status=200,
+                    json_body=build_mcp_call(
+                        request_id=idem,
+                        tool=tool,
+                        wallet_id=wallet_id,
+                        idempotency_key=idem,
+                        permit_id=permit_id,
+                    ),
+                )
+                require(
+                    "error" in response,
+                    f"{name}: expected a JSON-RPC denial, got {response}",
+                )
+                reason = response["error"]["message"]
+                require(
+                    reason == expected_reason,
+                    f"{name}: expected reason {expected_reason!r}, got {reason!r}",
+                )
+                step(f"  denied: {name} -> {reason}")
+                attacks.append({"attack": name, "reason": reason})
+
+            step("running the adversarial battery")
+
+            await attack(
+                "no_permit",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_required",
+                permit_id=None,
+                idem="rt-no-permit",
+            )
+
+            await attack(
+                "unknown_permit",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_not_found",
+                permit_id="permit-does-not-exist",
+                idem="rt-unknown-permit",
+            )
+
+            await attack(
+                "tool_not_allowed",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=BLOCKED_TOOL,
+                expected_reason="permit_tool_not_allowed",
+                permit_id=valid_permit_id,
+                idem="rt-tool-not-allowed",
+            )
+
+            # A permit that allows the tool but lacks the invoke scope.
+            scope_permit = await issue_permit(
+                client,
+                admin_headers=admin_headers,
+                wallet_id=victim_wallet_id,
+                key_id=victim_key1["key_id"],
+                allowed_tools=[ALLOWED_TOOL],
+                scopes=["billing:charge"],
+                max_credits=25,
+                idem_key="rt-permit-scope",
+            )
+            await attack(
+                "scope_missing",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_scope_missing",
+                permit_id=scope_permit["permit_id"],
+                idem="rt-scope-missing",
+            )
+
+            # A permit whose cap is below the tool's per-call cost.
+            budget_permit = await issue_permit(
+                client,
+                admin_headers=admin_headers,
+                wallet_id=victim_wallet_id,
+                key_id=victim_key1["key_id"],
+                allowed_tools=[ALLOWED_TOOL],
+                scopes=valid_scopes,
+                max_credits=1,
+                idem_key="rt-permit-budget",
+            )
+            await attack(
+                "budget_exceeded",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_budget_exceeded",
+                permit_id=budget_permit["permit_id"],
+                idem="rt-budget-exceeded",
+            )
+
+            # Stolen permit: the attacker authenticates as itself (own wallet +
+            # key) but presents the victim's permit. Access control passes
+            # because the attacker is touching its own wallet; the permit's
+            # subject wallet does not match, so it is denied.
+            await attack(
+                "wallet_mismatch",
+                headers=attacker_headers,
+                wallet_id=attacker_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_wallet_mismatch",
+                permit_id=valid_permit_id,
+                idem="rt-wallet-mismatch",
+            )
+
+            # Right wallet, wrong key: the permit binds to key #1, the call
+            # presents key #2 (both belong to the victim wallet).
+            await attack(
+                "key_mismatch",
+                headers=victim_headers_key2,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_key_mismatch",
+                permit_id=valid_permit_id,
+                idem="rt-key-mismatch",
+            )
+
+            expired_permit = await issue_permit(
+                client,
+                admin_headers=admin_headers,
+                wallet_id=victim_wallet_id,
+                key_id=victim_key1["key_id"],
+                allowed_tools=[ALLOWED_TOOL],
+                scopes=valid_scopes,
+                max_credits=25,
+                idem_key="rt-permit-expired",
+            )
+            await _force_permit_expired(expired_permit["permit_id"])
+            await attack(
+                "expired",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_expired",
+                permit_id=expired_permit["permit_id"],
+                idem="rt-expired",
+            )
+
+            revoked_permit = await issue_permit(
+                client,
+                admin_headers=admin_headers,
+                wallet_id=victim_wallet_id,
+                key_id=victim_key1["key_id"],
+                allowed_tools=[ALLOWED_TOOL],
+                scopes=valid_scopes,
+                max_credits=25,
+                idem_key="rt-permit-revoked",
+            )
+            revoke = await client.post(
+                f"/v1/permits/{revoked_permit['permit_id']}/revoke",
+                headers=admin_headers,
+            )
+            require(
+                revoke.status_code == 200,
+                f"permit revoke failed: {revoke.status_code} {revoke.text}",
+            )
+            await attack(
+                "revoked",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_revoked",
+                permit_id=revoked_permit["permit_id"],
+                idem="rt-revoked",
+            )
+
+            tampered_permit = await issue_permit(
+                client,
+                admin_headers=admin_headers,
+                wallet_id=victim_wallet_id,
+                key_id=victim_key1["key_id"],
+                allowed_tools=[ALLOWED_TOOL],
+                scopes=valid_scopes,
+                max_credits=25,
+                idem_key="rt-permit-tampered",
+            )
+            await _tamper_permit_budget(tampered_permit["permit_id"])
+            await attack(
+                "signature_invalid",
+                headers=victim_headers,
+                wallet_id=victim_wallet_id,
+                tool=ALLOWED_TOOL,
+                expected_reason="permit_signature_invalid",
+                permit_id=tampered_permit["permit_id"],
+                idem="rt-signature-invalid",
+            )
+
+            step("confirming no attack produced a ledger debit")
+            debits_after_attacks = await _allowed_tool_debits(
+                client, victim_wallet_id, victim_headers
+            )
+            require(
+                debits_after_attacks == [],
+                f"an attack produced a ledger debit: {debits_after_attacks}",
+            )
+
+            step("positive control: the one valid call succeeds and charges once")
+            success = await post_json(
+                client,
+                "/mcp/messages",
+                headers=victim_headers,
+                expected_status=200,
+                json_body=build_mcp_call(
+                    request_id="rt-positive-control",
+                    tool=ALLOWED_TOOL,
+                    wallet_id=victim_wallet_id,
+                    idempotency_key="rt-positive-control",
+                    permit_id=valid_permit_id,
+                    arguments={"message": "hello after the siege"},
+                ),
+            )
+            require("result" in success, f"positive control failed: {success}")
+            success_receipt = success["result"]["receipt"]
+            require(
+                success_receipt["outcome"] == "success",
+                f"positive control did not succeed: {success_receipt}",
+            )
+
+            final_debits = await _allowed_tool_debits(
+                client, victim_wallet_id, victim_headers
+            )
+            require(
+                len(final_debits) == 1,
+                f"expected exactly one debit after the run, got {final_debits}",
+            )
+
+            step("verifying the victim wallet audit chain survived the siege")
+            audit_check = await post_json(
+                client,
+                "/v1/audit/verify-chain",
+                headers=victim_headers,
+                expected_status=200,
+                json_body={"wallet_id": victim_wallet_id},
+            )
+            require(
+                audit_check["valid"] is True,
+                f"audit chain invalid after attacks: {audit_check}",
+            )
+
+            require(
+                len(attacks) == 10,
+                f"expected 10 denied attacks, recorded {len(attacks)}",
+            )
+
+            summary = {
+                "victim_wallet_id": victim_wallet_id,
+                "attacker_wallet_id": attacker_wallet_id,
+                "valid_permit_id": valid_permit_id,
+                "attacks_denied": len(attacks),
+                "denial_reasons": [a["reason"] for a in attacks],
+                "ledger_debits_after_attacks": len(debits_after_attacks),
+                "success_receipt_id": success_receipt["receipt_id"],
+                "ledger_debits_total": len(final_debits),
+                "audit_chain_valid": audit_check["valid"],
+                "audit_chain_checked_events": audit_check["checked_events"],
+            }
+
+        if json_output:
+            print(json.dumps(summary, indent=2, sort_keys=True))
+        else:
+            step("red-team proof complete: every attack denied, one charge landed")
+            for key_name, value in summary.items():
+                print(f"  {key_name}: {value}")
+        return summary
+    finally:
+        unregister_demo_tools()
+        await close_db()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print only the final proof artifact as JSON.",
+    )
+    parser.add_argument(
+        "--assert",
+        dest="assert_mode",
+        action="store_true",
+        help="Compatibility flag: the script always asserts invariants.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(run_red_team(json_output=args.json))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,23 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import text
 
+
+def iter_routes(routes):
+    """Yield every leaf route from an app/router route list.
+
+    Newer FastAPI versions wrap `app.include_router()` results in an
+    `_IncludedRouter` that has no `.path` of its own. Walk into its
+    `original_router.routes` so callers see the real `APIRoute` instances.
+    """
+    for route in routes:
+        if hasattr(route, "path"):
+            yield route
+            continue
+        original = getattr(route, "original_router", None)
+        if original is not None and hasattr(original, "routes"):
+            yield from iter_routes(original.routes)
+
+
 # Set up SQLite for testing before any imports
 os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
 # Configure auth so tests don't hit the fail-safe 503 in verify_api_key.

--- a/tests/test_awi_phase9.py
+++ b/tests/test_awi_phase9.py
@@ -11,6 +11,7 @@ Tests for:
 import pytest
 from datetime import datetime, timedelta
 
+from app.core.time import utc_now
 from app.services.webauthn_provider import WebAuthnProvider, ChallengeStatus
 from app.services.awi_playwright_bridge import (
     AWIPlaywrightBridge,
@@ -332,7 +333,7 @@ class TestAWIPlaywrightBridge:
             session_ttl_seconds=1,
         )
         session = await bridge.create_session("https://example.com")
-        session.last_activity = datetime.utcnow() - timedelta(seconds=5)
+        session.last_activity = utc_now() - timedelta(seconds=5)
 
         replacement = await bridge.create_session("https://example.org")
 
@@ -796,8 +797,8 @@ class TestAWIRAGEngine:
                 action_sequence=["search", "add_to_cart", "checkout"],
                 key_entities=[],
                 similarity_score=0.9,
-                created_at=datetime.utcnow(),
-                accessed_at=datetime.utcnow(),
+                created_at=utc_now(),
+                accessed_at=utc_now(),
                 access_count=1,
             ),
             SearchResult(
@@ -808,8 +809,8 @@ class TestAWIRAGEngine:
                 action_sequence=["search", "add_to_cart"],
                 key_entities=[],
                 similarity_score=0.8,
-                created_at=datetime.utcnow(),
-                accessed_at=datetime.utcnow(),
+                created_at=utc_now(),
+                accessed_at=utc_now(),
                 access_count=1,
             ),
         ]

--- a/tests/test_demo_trust_plane.py
+++ b/tests/test_demo_trust_plane.py
@@ -30,5 +30,6 @@ def test_demo_trust_plane_script_proves_core_loop():
     assert proof["denial_receipt_id"].startswith("rcpt-")
     assert proof["denial_replay_receipt_id"] == proof["denial_receipt_id"]
     assert proof["denial_reason"] == "permit_tool_not_allowed"
+    assert proof["ungoverned_denial_reason"] == "permit_required"
     assert proof["cross_wallet_status"] == 403
     assert proof["audit_chain_checked_events"] >= 1

--- a/tests/test_red_team_trust_plane.py
+++ b/tests/test_red_team_trust_plane.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_REASONS = [
+    "permit_required",
+    "permit_not_found",
+    "permit_tool_not_allowed",
+    "permit_scope_missing",
+    "permit_budget_exceeded",
+    "permit_wallet_mismatch",
+    "permit_key_mismatch",
+    "permit_expired",
+    "permit_revoked",
+    "permit_signature_invalid",
+]
+
+
+def test_red_team_trust_plane_denies_every_attack():
+    result = subprocess.run(
+        [sys.executable, "scripts/red_team_trust_plane.py", "--json"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    proof = json.loads(result.stdout)
+
+    # Every attack is denied with a concrete, specific reason.
+    assert proof["attacks_denied"] == 10
+    assert proof["denial_reasons"] == EXPECTED_REASONS
+
+    # No denied attack ever touches the ledger.
+    assert proof["ledger_debits_after_attacks"] == 0
+
+    # The one valid call still works and charges exactly once.
+    assert proof["success_receipt_id"].startswith("rcpt-")
+    assert proof["ledger_debits_total"] == 1
+
+    # The audit chain survives the siege.
+    assert proof["audit_chain_valid"] is True
+    assert proof["audit_chain_checked_events"] >= 1

--- a/tests/test_red_team_trust_plane.py
+++ b/tests/test_red_team_trust_plane.py
@@ -39,8 +39,18 @@ def test_red_team_trust_plane_denies_every_attack():
     assert proof["attacks_denied"] == 10
     assert proof["denial_reasons"] == EXPECTED_REASONS
 
-    # No denied attack ever touches the ledger.
-    assert proof["ledger_debits_after_attacks"] == 0
+    # Eight of the ten attacks reach the permit-validation path that emits a
+    # signed denial receipt (no_permit and unknown_permit do not — there is no
+    # permit model to bind a receipt to). Every emitted receipt must already
+    # have been asserted to have outcome=denied and ledger_entry_id=None by the
+    # script; this fixes the count so a regression that stopped emitting them
+    # would break the test.
+    assert proof["attacks_with_signed_denial_receipts"] == 8
+
+    # No denied attack ever touches the ledger on either wallet, for either
+    # the allowed or the blocked demo tool.
+    assert proof["victim_debits_after_attacks"] == 0
+    assert proof["attacker_debits_after_attacks"] == 0
 
     # The one valid call still works and charges exactly once.
     assert proof["success_receipt_id"].startswith("rcpt-")

--- a/tests/test_route_auth_inventory.py
+++ b/tests/test_route_auth_inventory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi.routing import APIRoute
 
 from app.main import app
+from tests.conftest import iter_routes
 
 
 PUBLIC_PATH_PREFIXES = (
@@ -17,7 +18,7 @@ PUBLIC_PATHS = {"/", "/openapi.json", "/mcp/tools", "/mcp/tools.json"}
 
 def test_state_changing_core_trust_routes_have_auth_dependencies():
     checked = 0
-    for route in app.routes:
+    for route in iter_routes(app.routes):
         if not isinstance(route, APIRoute):
             continue
         if not (set(route.methods or set()) & {"POST", "PUT", "PATCH", "DELETE"}):

--- a/tests/test_sandbox_integration.py
+++ b/tests/test_sandbox_integration.py
@@ -33,7 +33,7 @@ class TestShadowLedger:
 
     def test_create_session(self, ledger):
         """Creating a session returns a DryRunSession with unique ID."""
-        session = asyncio.get_event_loop().run_until_complete(
+        session = asyncio.run(
             ledger.create_session(
                 wallet_id="test-wallet",
                 real_balance=Decimal("1000"),
@@ -49,142 +49,122 @@ class TestShadowLedger:
 
     def test_session_tracks_cumulative_charges(self, ledger):
         """Simulated charges accumulate in the session."""
-        loop = asyncio.get_event_loop()
 
-        session = loop.run_until_complete(
-            ledger.create_session(
+        async def scenario():
+            session = await ledger.create_session(
                 wallet_id="test-wallet",
                 real_balance=Decimal("1000"),
             )
-        )
 
-        result1 = loop.run_until_complete(
-            ledger.simulate_charge(
+            result1 = await ledger.simulate_charge(
                 session_id=session.session_id,
                 service_category=ServiceCategory.CONTENT_FACTORY,
                 units=10.0,
                 description="First charge",
             )
-        )
 
-        assert result1.would_succeed is True
-        assert result1.simulated_balance_after == 500.0
+            assert result1.would_succeed is True
+            assert result1.simulated_balance_after == 500.0
 
-        result2 = loop.run_until_complete(
-            ledger.simulate_charge(
+            result2 = await ledger.simulate_charge(
                 session_id=session.session_id,
                 service_category=ServiceCategory.IOT_BRIDGE,
                 units=5.0,
                 description="Second charge",
             )
-        )
 
-        assert result2.would_succeed is True
-        assert result2.simulated_balance_after == 490.0
+            assert result2.would_succeed is True
+            assert result2.simulated_balance_after == 490.0
 
-        final_session = loop.run_until_complete(
-            ledger.get_session(session.session_id)
-        )
+            final_session = await ledger.get_session(session.session_id)
 
-        assert len(final_session.simulated_charges) == 2
-        assert final_session.virtual_balance == Decimal("490")
-        assert final_session.total_simulated == Decimal("510")
+            assert len(final_session.simulated_charges) == 2
+            assert final_session.virtual_balance == Decimal("490")
+            assert final_session.total_simulated == Decimal("510")
+
+        asyncio.run(scenario())
 
     def test_session_returns_insufficient_funds_when_exceeding_balance(self, ledger):
         """Simulated charges return would_succeed=False when exceeding virtual balance."""
-        loop = asyncio.get_event_loop()
 
-        session = loop.run_until_complete(
-            ledger.create_session(
+        async def scenario():
+            session = await ledger.create_session(
                 wallet_id="test-wallet",
                 real_balance=Decimal("100"),
             )
-        )
 
-        result = loop.run_until_complete(
-            ledger.simulate_charge(
+            result = await ledger.simulate_charge(
                 session_id=session.session_id,
                 service_category=ServiceCategory.CONTENT_FACTORY,
                 units=50.0,
                 description="Large charge",
             )
-        )
 
-        assert result.would_succeed is False
-        assert result.simulated_balance_after < 0
-        assert result.reason == "insufficient_simulated_funds"
+            assert result.would_succeed is False
+            assert result.simulated_balance_after < 0
+            assert result.reason == "insufficient_simulated_funds"
+
+        asyncio.run(scenario())
 
     def test_session_end_returns_summary(self, ledger):
         """Ending a session returns a complete summary."""
-        loop = asyncio.get_event_loop()
 
-        session = loop.run_until_complete(
-            ledger.create_session(
+        async def scenario():
+            session = await ledger.create_session(
                 wallet_id="test-wallet",
                 real_balance=Decimal("500"),
             )
-        )
 
-        loop.run_until_complete(
-            ledger.simulate_charge(
+            await ledger.simulate_charge(
                 session_id=session.session_id,
                 service_category=ServiceCategory.TELEMETRY_PM,
                 units=100.0,
                 description="Test charge",
             )
-        )
 
-        summary = loop.run_until_complete(
-            ledger.end_session(session.session_id)
-        )
+            summary = await ledger.end_session(session.session_id)
 
-        assert summary is not None
-        assert summary.wallet_id == "test-wallet"
-        assert summary.total_simulated_credits == Decimal("100")
-        assert summary.charge_count == 1
-        assert summary.virtual_balance_after == Decimal("400")
+            assert summary is not None
+            assert summary.wallet_id == "test-wallet"
+            assert summary.total_simulated_credits == Decimal("100")
+            assert summary.charge_count == 1
+            assert summary.virtual_balance_after == Decimal("400")
+
+        asyncio.run(scenario())
 
     def test_nonexistent_session_returns_none(self, ledger):
         """Getting a nonexistent session returns None."""
-        result = asyncio.get_event_loop().run_until_complete(
-            ledger.get_session("nonexistent-id")
-        )
+        result = asyncio.run(ledger.get_session("nonexistent-id"))
         assert result is None
 
     def test_nonexistent_session_end_returns_none(self, ledger):
         """Ending a nonexistent session returns None."""
-        result = asyncio.get_event_loop().run_until_complete(
-            ledger.end_session("nonexistent-id")
-        )
+        result = asyncio.run(ledger.end_session("nonexistent-id"))
         assert result is None
 
     def test_virtual_balance_calculation(self, ledger):
         """Virtual balance correctly reflects real balance minus charges."""
-        loop = asyncio.get_event_loop()
 
-        session = loop.run_until_complete(
-            ledger.create_session(
+        async def scenario():
+            session = await ledger.create_session(
                 wallet_id="test-wallet",
                 real_balance=Decimal("1000"),
             )
-        )
 
-        for i in range(5):
-            loop.run_until_complete(
-                ledger.simulate_charge(
+            for i in range(5):
+                await ledger.simulate_charge(
                     session_id=session.session_id,
                     service_category=ServiceCategory.IOT_BRIDGE,
                     units=1.0,
                     description=f"Charge {i}",
                 )
-            )
 
-        final_session = loop.run_until_complete(
-            ledger.get_session(session.session_id)
-        )
+            final_session = await ledger.get_session(session.session_id)
 
-        assert final_session.virtual_balance == Decimal("990")
-        assert final_session.total_simulated == Decimal("10")
+            assert final_session.virtual_balance == Decimal("990")
+            assert final_session.total_simulated == Decimal("10")
+
+        asyncio.run(scenario())
 
 
 class TestDryRunSession:

--- a/tests/test_v1_production.py
+++ b/tests/test_v1_production.py
@@ -106,14 +106,18 @@ class TestHealthEndpoints:
         """Verify /health endpoint exists."""
         from app.main import app
 
-        routes = [r.path for r in app.routes]
+        from tests.conftest import iter_routes
+
+        routes = [r.path for r in iter_routes(app.routes)]
         assert "/health" in routes
 
     def test_health_ready_endpoint_exists(self):
         """Verify /health/ready endpoint exists."""
         from app.main import app
 
-        routes = [r.path for r in app.routes]
+        from tests.conftest import iter_routes
+
+        routes = [r.path for r in iter_routes(app.routes)]
         assert "/health/ready" in routes
 
 

--- a/wrappers/autogen-agent-middleware/pyproject.toml
+++ b/wrappers/autogen-agent-middleware/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
+    "b2a-sdk>=0.2.0",
     "autogen-agentchat>=0.2.0",
     "httpx>=0.25.0",
 ]

--- a/wrappers/autogen-agent-middleware/pyproject.toml
+++ b/wrappers/autogen-agent-middleware/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
-    "b2a-sdk>=0.2.0",
+    "b2a-sdk>=0.3.0",
     "autogen-agentchat>=0.2.0",
     "httpx>=0.25.0",
 ]

--- a/wrappers/autogen-agent-middleware/src/autogen_b2a/client.py
+++ b/wrappers/autogen-agent-middleware/src/autogen_b2a/client.py
@@ -1,92 +1,12 @@
-"""B2A Client for AutoGen integration."""
+"""B2A Client for AutoGen integration.
 
-from typing import Any
-import httpx
+Thin subclass of ``b2a_sdk.B2AEdgeClient``. All HTTP plumbing lives in the
+shared base; this module exists so framework-specific helpers can hang off an
+AutoGen-flavored client name.
+"""
+
+from b2a_sdk import B2AEdgeClient
 
 
-class B2AClient:
+class B2AClient(B2AEdgeClient):
     """Client for Agent Middleware API with AutoGen compatibility."""
-
-    def __init__(
-        self,
-        api_url: str = "http://localhost:8000",
-        api_key: str | None = None,
-        wallet_id: str | None = None,
-        timeout: float = 30.0,
-    ):
-        self.api_url = api_url.rstrip("/")
-        self.api_key = api_key
-        self.wallet_id = wallet_id
-        self.timeout = timeout
-        self._client = httpx.AsyncClient(timeout=timeout)
-
-    def _headers(self) -> dict[str, str]:
-        headers = {"Content-Type": "application/json"}
-        if self.api_key:
-            headers["X-API-Key"] = self.api_key
-        return headers
-
-    async def get_mcp_tools(self) -> list[dict[str, Any]]:
-        """Fetch available MCP tools."""
-        response = await self._client.get(
-            f"{self.api_url}/mcp/tools.json",
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json().get("tools", [])
-
-    async def call_mcp_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Call an MCP tool."""
-        payload = {
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "params": {
-                "name": name,
-                "arguments": arguments,
-            },
-            "id": 1,
-        }
-        if self.wallet_id:
-            payload["params"]["mcpContext"] = {"wallet_id": self.wallet_id}
-
-        response = await self._client.post(
-            f"{self.api_url}/mcp/messages",
-            json=payload,
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def create_awi_session(
-        self,
-        target_url: str,
-        max_steps: int = 100,
-    ) -> dict[str, Any]:
-        """Create an AWI session."""
-        payload = {"target_url": target_url, "max_steps": max_steps}
-        response = await self._client.post(
-            f"{self.api_url}/v1/awi/sessions",
-            json=payload,
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def get_balance(self) -> float:
-        """Get wallet balance."""
-        if not self.wallet_id:
-            raise ValueError("wallet_id required")
-        response = await self._client.get(
-            f"{self.api_url}/v1/billing/wallets/{self.wallet_id}",
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json().get("balance", 0.0)
-
-    async def close(self):
-        """Close HTTP client."""
-        await self._client.aclose()

--- a/wrappers/crewai-agent-middleware/pyproject.toml
+++ b/wrappers/crewai-agent-middleware/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
-    "b2a-sdk>=0.2.0",
+    "b2a-sdk>=0.3.0",
     "crewai>=0.1.0",
     "httpx>=0.25.0",
 ]

--- a/wrappers/crewai-agent-middleware/pyproject.toml
+++ b/wrappers/crewai-agent-middleware/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
+    "b2a-sdk>=0.2.0",
     "crewai>=0.1.0",
     "httpx>=0.25.0",
 ]

--- a/wrappers/crewai-agent-middleware/src/crewai_b2a/client.py
+++ b/wrappers/crewai-agent-middleware/src/crewai_b2a/client.py
@@ -1,99 +1,12 @@
-"""B2A Client for CrewAI integration."""
+"""B2A Client for CrewAI integration.
 
-from typing import Any
-import httpx
+Thin subclass of ``b2a_sdk.B2AEdgeClient``. All HTTP plumbing lives in the
+shared base; this module exists so framework-specific helpers can hang off a
+CrewAI-flavored client name.
+"""
+
+from b2a_sdk import B2AEdgeClient
 
 
-class B2AClient:
+class B2AClient(B2AEdgeClient):
     """Client for Agent Middleware API with CrewAI compatibility."""
-
-    def __init__(
-        self,
-        api_url: str = "http://localhost:8000",
-        api_key: str | None = None,
-        wallet_id: str | None = None,
-        timeout: float = 30.0,
-    ):
-        self.api_url = api_url.rstrip("/")
-        self.api_key = api_key
-        self.wallet_id = wallet_id
-        self.timeout = timeout
-        self._client = httpx.AsyncClient(timeout=timeout)
-
-    def _headers(self) -> dict[str, str]:
-        headers = {"Content-Type": "application/json"}
-        if self.api_key:
-            headers["X-API-Key"] = self.api_key
-        return headers
-
-    async def get_mcp_tools(self) -> list[dict[str, Any]]:
-        """Fetch available MCP tools."""
-        response = await self._client.get(
-            f"{self.api_url}/mcp/tools.json",
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        data = response.json()
-        return data.get("tools", [])
-
-    async def call_mcp_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Call an MCP tool."""
-        payload = {
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "params": {
-                "name": name,
-                "arguments": arguments,
-            },
-            "id": 1,
-        }
-        if self.wallet_id:
-            payload["params"]["mcpContext"] = {"wallet_id": self.wallet_id}
-
-        response = await self._client.post(
-            f"{self.api_url}/mcp/messages",
-            json=payload,
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def create_awi_session(
-        self,
-        target_url: str,
-        max_steps: int = 100,
-    ) -> dict[str, Any]:
-        """Create an AWI session."""
-        payload = {"target_url": target_url, "max_steps": max_steps}
-        response = await self._client.post(
-            f"{self.api_url}/v1/awi/sessions",
-            json=payload,
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def get_balance(self) -> float:
-        """Get wallet balance."""
-        if not self.wallet_id:
-            raise ValueError("wallet_id required")
-        response = await self._client.get(
-            f"{self.api_url}/v1/billing/wallets/{self.wallet_id}",
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json().get("balance", 0.0)
-
-    async def close(self):
-        """Close HTTP client."""
-        await self._client.aclose()
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        await self.close()

--- a/wrappers/langchain-agent-middleware/pyproject.toml
+++ b/wrappers/langchain-agent-middleware/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
+    "b2a-sdk>=0.2.0",
     "langchain>=0.1.0",
     "langgraph>=0.0.20",
     "httpx>=0.25.0",

--- a/wrappers/langchain-agent-middleware/pyproject.toml
+++ b/wrappers/langchain-agent-middleware/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"
 dependencies = [
-    "b2a-sdk>=0.2.0",
+    "b2a-sdk>=0.3.0",
     "langchain>=0.1.0",
     "langgraph>=0.0.20",
     "httpx>=0.25.0",

--- a/wrappers/langchain-agent-middleware/src/langchain_b2a/client.py
+++ b/wrappers/langchain-agent-middleware/src/langchain_b2a/client.py
@@ -1,119 +1,12 @@
-"""B2A Client for LangChain integration."""
+"""B2A Client for LangChain integration.
 
-from typing import Any
-import httpx
+Thin subclass of ``b2a_sdk.B2AEdgeClient``. All HTTP plumbing lives in the
+shared base; this module exists so framework-specific helpers can hang off a
+LangChain-flavored client name.
+"""
+
+from b2a_sdk import B2AEdgeClient
 
 
-class B2AClient:
+class B2AClient(B2AEdgeClient):
     """Client for Agent Middleware API with LangChain compatibility."""
-
-    def __init__(
-        self,
-        api_url: str = "http://localhost:8000",
-        api_key: str | None = None,
-        wallet_id: str | None = None,
-        timeout: float = 30.0,
-    ):
-        self.api_url = api_url.rstrip("/")
-        self.api_key = api_key
-        self.wallet_id = wallet_id
-        self.timeout = timeout
-        self._client = httpx.AsyncClient(timeout=timeout)
-
-    def _headers(self) -> dict[str, str]:
-        headers = {"Content-Type": "application/json"}
-        if self.api_key:
-            headers["X-API-Key"] = self.api_key
-        return headers
-
-    async def get_mcp_tools(self) -> list[dict[str, Any]]:
-        """Fetch available MCP tools from the server."""
-        response = await self._client.get(
-            f"{self.api_url}/mcp/tools.json",
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        data = response.json()
-        return data.get("tools", [])
-
-    async def call_mcp_tool(
-        self,
-        name: str,
-        arguments: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Call an MCP tool by name."""
-        payload = {
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "params": {
-                "name": name,
-                "arguments": arguments,
-            },
-            "id": 1,
-        }
-        if self.wallet_id:
-            payload["params"]["mcpContext"] = {"wallet_id": self.wallet_id}
-
-        response = await self._client.post(
-            f"{self.api_url}/mcp/messages",
-            json=payload,
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def create_awi_session(
-        self,
-        target_url: str,
-        max_steps: int = 100,
-    ) -> dict[str, Any]:
-        """Create an AWI session for web interaction."""
-        payload = {"target_url": target_url, "max_steps": max_steps}
-        response = await self._client.post(
-            f"{self.api_url}/v1/awi/sessions",
-            json=payload,
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def execute_awi_action(
-        self,
-        session_id: str,
-        action: str,
-        parameters: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Execute an AWI action on a session."""
-        payload = {
-            "session_id": session_id,
-            "action": action,
-            "parameters": parameters,
-        }
-        response = await self._client.post(
-            f"{self.api_url}/v1/awi/execute",
-            json=payload,
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json()
-
-    async def get_balance(self) -> float:
-        """Get wallet balance."""
-        if not self.wallet_id:
-            raise ValueError("wallet_id required for balance check")
-        response = await self._client.get(
-            f"{self.api_url}/v1/billing/wallets/{self.wallet_id}",
-            headers=self._headers(),
-        )
-        response.raise_for_status()
-        return response.json().get("balance", 0.0)
-
-    async def close(self):
-        """Close the HTTP client."""
-        await self._client.aclose()
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *args):
-        await self.close()


### PR DESCRIPTION
## Summary

Six pieces of design-partner-readiness work surfaced by the project-pitch-framing discussion. Each commit is self-contained.

### 1. Shared wrapper edge client (`b2a_sdk.B2AEdgeClient`)

The `langchain`, `crewai`, and `autogen` wrappers each carried ~100 lines of identical HTTP plumbing for the MCP, AWI, and balance endpoints. Move that surface into `b2a_sdk.B2AEdgeClient`; each wrapper's `B2AClient` becomes a one-line subclass; each `pyproject.toml` now depends on `b2a-sdk>=0.2.0`. Same import paths as before. Net: **−269 LOC** across wrappers, **+121 LOC** in one place.

### 2. KMS path documentation (`docs/key-management.md`)

`SECURITY_LIMITATIONS.md` admits "no external KMS integration is implemented" but doesn't say what the intended path is. This doc covers: current env-var loader behavior, why it is acceptable for MVP, target providers (AWS KMS, GCP KMS, Vault Transit), the specific files that change, rotation flow without redeploy, and compromise-response procedure.

### 3. Fail-closed proof in the demo

`scripts/demo_trust_plane.py` already proved happy-path + out-of-scope denial. Add a step that posts an MCP call with no `permit_id` and asserts the JSON-RPC error is `permit_required` with no ledger debit — the direct proof that `ALLOW_LEGACY_UNPERMITTED_MCP=false` is doing what the pitch claims. Locked as `ungoverned_denial_reason: permit_required` in the proof artifact.

### 4. Python 3.12 `asyncio` fix for `TestShadowLedger`

Seven sync tests called `asyncio.get_event_loop().run_until_complete(...)`, which raises `RuntimeError` on Python 3.12. Replace with `asyncio.run(...)` (or a nested `async def scenario()` for multi-await flows). Pre-existing on main; this fix unblocks both branches.

### 5. `datetime.utcnow()` → `utc_now()` shim sweep

Python 3.12 deprecates `datetime.utcnow()`. The straight swap to `datetime.now(timezone.utc)` would have introduced `TypeError` at runtime because the DB schema stores naive UTC datetimes (`app/db/models.py` had 34 `default_factory=datetime.utcnow` sites). Add `app/core/time.py::utc_now()` returning naive UTC and replace all 70 call sites. **Test-run deprecation warnings drop from 1,633 → 1.** Full tz-aware migration is intentionally separate.

### 6. FastAPI `_IncludedRouter` walker for route-inspection tests

Newer FastAPI wraps `app.include_router()` results in `_IncludedRouter` shims with no `.path`. Add `iter_routes()` to `tests/conftest.py` and use it in `test_v1_production.py` and `test_route_auth_inventory.py`. Pre-existing flake that pip-cache reuse was masking.

### 7. Adversarial (red-team) trust-plane proof

`scripts/red_team_trust_plane.py` drives one valid permit and attacks it ten ways, asserting a specific reason code for each and zero ledger debits across the entire battery:

| Attack | Asserted reason |
|---|---|
| no permit | `permit_required` |
| unknown permit id | `permit_not_found` |
| out-of-scope tool | `permit_tool_not_allowed` |
| missing invoke scope | `permit_scope_missing` |
| over-budget | `permit_budget_exceeded` |
| stolen permit (wrong wallet) | `permit_wallet_mismatch` |
| wrong key on same wallet | `permit_key_mismatch` |
| expired | `permit_expired` |
| revoked | `permit_revoked` |
| tampered (re-signed) | `permit_signature_invalid` |

Wallet-mismatch is modeled as the realistic stolen-permit case — the attacker authenticates as itself (passing access control) but presents the victim's permit. Signature attack raises a signed field (`max_credits`) so the budget check passes and validation is *forced* to the signature check, proving the signature gates authorization. A positive control at the end charges exactly once and verifies the audit chain.

Wired in as `make red-team-trust-plane`, a pytest wrapper, and a named CI smoke gate alongside the demo. Documented in `DESIGN_PARTNER_GUIDE.md` as the security-audience proof path.

## Test plan

- [x] `pytest tests/` — passes on Python 3.11 and 3.12 (697 passed, 1 skipped)
- [x] `ruff check app/ tests/ scripts/` — clean
- [x] `make demo-trust-plane` — green, proof artifact includes `ungoverned_denial_reason: permit_required`
- [x] `make red-team-trust-plane` — 10 attacks denied with expected reasons, 0 ledger debits, audit chain intact
- [x] `pytest b2a_sdk/tests` — passes (13/13)
- [x] All three wrapper `B2AClient`s subclass `B2AEdgeClient` and expose the shared surface
- [x] CI on `53947fe`: lint ✓, test (3.11) ✓, test (3.12) ✓

## What this does not change

- The signing path itself (`SigningKeyService.sign_payload_with_key_id`) — KMS doc is documentation, not implementation
- The default value of `ALLOW_LEGACY_UNPERMITTED_MCP` — separate PR planned for the trust-default flip
- Any public API surface — wrappers re-export `B2AClient` from the same module path
- DB schema — `utc_now()` preserves naive UTC semantics so DB-loaded datetimes still compare correctly

## Known-out-of-scope items (tracked separately)

- 16 Dependabot alerts on `main` (1 critical, 5 high) — separate PR
- Trust-default flip (`TRUST_MODE_ENABLED=true`, `ALLOW_LEGACY_UNPERMITTED_MCP=false`) — separate PR, needs a deliberate migration note
- Full tz-aware datetime migration (DB columns become `DateTime(timezone=True)` + Alembic migration) — separate PR
- `billing.py` (1,362 LOC) refactor — opportunistic, not urgent

https://claude.ai/code/session_01RNmjNux6YMnyXWv2dJHJ3D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * B2AEdgeClient: shared async HTTP client for framework wrappers, centralizing MCP tools, AWI sessions, and wallet operations.

* **Documentation**
  * Key-management specification covering Ed25519 lifecycle, KMS provider integration targets, and security procedures.
  * Enhanced trust-plane demo documentation with governance denial scenarios.

* **Tests**
  * Red-team test harness validating permit enforcement across ten attack scenarios.

* **Refactor**
  * Standardized UTC timestamp handling across database models and services.
  * Simplified agent middleware by leveraging shared client library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->