### PR TITLE
Bump deps to clear 18 of 19 known CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Operational control plane for autonomous agents"
 requires-python = ">=3.11"
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.0.0"]
+mcp = ["mcp>=1.28.0,<2"]
 playwright = ["playwright>=1.40.0"]
 browser = ["playwright>=1.40.0"]
 webauthn = ["webauthn>=1.0.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,16 +17,16 @@ aiocoap>=0.4.17          # CoAP protocol support
 httpx>=0.28.1           # Async HTTP client for git API calls
 
 # --- Media Engine ---
-python-multipart>=0.0.29 # File upload support
+python-multipart>=0.0.32 # File upload support (>=0.0.30 fixes CVE-2026-53538/53539, >=0.0.31 fixes CVE-2026-53540)
 
 # --- Utilities ---
 python-dotenv>=1.2.2    # .env file loading
-cryptography>=48.0.0    # Ed25519 trust-plane signatures
+cryptography>=49.0.0    # Ed25519 trust-plane signatures (>=48.0.1 fixes GHSA-537c-gmf6-5ccf)
 redis>=7.4.0            # Redis-backed rate limiting and runtime persistence
 asyncpg>=0.31.0         # PostgreSQL-backed runtime persistence
 greenlet>=3.5.1         # SQLAlchemy async engine support
 stripe>=15.1.0           # Stripe payment processing
-mcp>=1.0.0             # MCP (Model Context Protocol) SDK for tool servers
+mcp>=1.28.0,<2         # MCP (Model Context Protocol) SDK for tool servers (>=1.28.0 carries pyjwt>=2.13.0 fixing PYSEC-2026-175..179 and starlette>=1.3.1 fixing CVE-2026-48817/48818/54282/54283 + PYSEC-2026-161); upper bound guards against breaking 2.x
 
 # --- Database ---
 sqlmodel>=0.0.38        # SQLAlchemy + Pydantic hybrid ORM

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ webauthn = [
 requires-dist = [
     { name = "chromadb", marker = "extra == 'chromadb'", specifier = ">=0.4.0" },
     { name = "chromadb", marker = "extra == 'rag'", specifier = ">=0.4.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0.0" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.28.0,<2" },
     { name = "playwright", marker = "extra == 'browser'", specifier = ">=1.40.0" },
     { name = "playwright", marker = "extra == 'playwright'", specifier = ">=1.40.0" },
     { name = "structlog", marker = "extra == 'observability'", specifier = ">=24.1.0" },
@@ -893,7 +893,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -911,9 +911,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/ee/94c6c50ffc5b5cf4737052275d11b57367f32d1a8516e31dcd60591b3916/mcp-1.28.0.tar.gz", hash = "sha256:559d3f9943674cafbe5744c5d3794f3237e8b47f9bbc58e20c0fad680d8487c2", size = 636040, upload-time = "2026-06-16T21:37:17.996Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/4c1dc1fbb688641a712d34650c3d58bbbdcb314ddb75bc5817bbf33515a4/mcp-1.28.0-py3-none-any.whl", hash = "sha256:9c1e7cf3a9125557e418ecd4fed8e9adddce81b0dfdae4d6601d700f5beb71a4", size = 221959, upload-time = "2026-06-16T21:37:16.579Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pip-audit` against the resolved environment (with optional extras enabled) reported **19 vulnerabilities across 5 packages**. Three floor bumps in `requirements.txt` and `pyproject.toml` resolve **18 of them**:

| Package | Before | After | Fixes |
|---|---|---|---|
| `cryptography` | `>=48.0.0` | `>=49.0.0` | GHSA-537c-gmf6-5ccf (fixed at 48.0.1; jumping to current 49.x line) |
| `python-multipart` | `>=0.0.29` | `>=0.0.32` | CVE-2026-53538/53539 (fixed 0.0.30), CVE-2026-53540 (fixed 0.0.31) |
| `mcp` | `>=1.0.0` | `>=1.28.0,<2` | Carries `pyjwt 2.12.1 → 2.13.0` (fixes PYSEC-2026-175..179, 8 alerts) and `starlette 1.0.0 → 1.3.1` (fixes CVE-2026-48817/48818/54282/54283 + PYSEC-2026-161). Adds `<2` upper bound so a breaking 2.x release doesn't land on the trust-plane MCP adapter without review. |

### Remaining unresolved (1)

`chromadb 1.5.9` — `CVE-2026-45829`. No upstream fix version published yet. It's an optional `rag`/`chromadb` extra and per `WEDGE.md` is proof surface, not the trust-plane core. Document and ship; revisit when an upstream fix lands.

### Verification

- `pip-audit`: 19 → 1 known vulnerabilities
- 45 trust-core and MCP tests pass under the bumped resolution
- `ruff check app/ tests/` clean
- `python -c "from app.main import app"` clean

### Note on pre-existing test failures

During the full-suite run on Python 3.12, the same 10 tests fail that also fail on `main` HEAD: 7× `TestShadowLedger` (Python 3.12 `asyncio.get_event_loop()` pattern) and 3× `TestHealthEndpoints` / `test_route_auth_inventory` (FastAPI `_IncludedRouter` walker). These are **not regressions from the bumps** — they reproduce against `main` without these changes. PR #128 already fixes both.

## Test plan

- [x] `pip-audit` reports 1 remaining (chromadb only)
- [x] Trust core + MCP tests pass (45/45)
- [x] Ruff clean
- [x] App imports clean
- [ ] CI green on the new bumps (pending)

https://claude.ai/code/session_01RNmjNux6YMnyXWv2dJHJ3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNmjNux6YMnyXWv2dJHJ3D)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only changes with no application logic edits; main residual risk is subtle behavior shifts from newer transitive packages (MCP/Starlette/PyJWT), mitigated by existing trust/MCP tests per the PR description.
> 
> **Overview**
> Raises minimum dependency floors in **`requirements.txt`** and **`pyproject.toml`** (with **`uv.lock`** updated for **`mcp` 1.27.1 → 1.28.0**) to address **`pip-audit`** findings: **`cryptography`** `>=49.0.0`, **`python-multipart`** `>=0.0.32`, and **`mcp`** `>=1.28.0,<2`.
> 
> The **`mcp`** change also pins an upper bound below 2.x so a future major release cannot land without review; comments document which transitive fixes (PyJWT, Starlette) motivated the floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8c3a7f2621208655d77e139a610c3692c9e2f8f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple project dependency version constraints to improve platform support
  * Increased minimum version requirements across core utility and supporting packages
  * Applied upper version bounds to major releases to ensure compatibility and prevent breaking changes
  * Refined transitive dependency specifications to address known issues
  * Enhanced overall dependency management strategy for better stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->