### PR TITLE
Flip trust-plane defaults to fail-closed

### DIFF
--- a/SECURITY_LIMITATIONS.md
+++ b/SECURITY_LIMITATIONS.md
@@ -22,8 +22,12 @@ and audit-chain primitives.
 
 ## Required Production Posture
 
-- Set `TRUST_MODE_ENABLED=true`.
-- Set `ALLOW_LEGACY_UNPERMITTED_MCP=false`.
+- `TRUST_MODE_ENABLED=true` and `ALLOW_LEGACY_UNPERMITTED_MCP=false` are the
+  shipped defaults. A production-like environment cannot boot under any
+  permissive combination — `app.core.trust_mode.validate_trust_mode_guardrails`
+  refuses to start. Local/dev/test deployments that need legacy behavior must
+  set both env vars explicitly; the startup log emits a `trust_mode_permissive`
+  warning so the opt-out is loud.
 - Configure `TRUST_SIGNING_PRIVATE_KEY_B64` from a secret manager or KMS-backed
   runtime injection.
 - Disable or isolate proof surfaces that execute code, drive browsers, generate

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -49,12 +49,20 @@ class Settings(BaseSettings):
     VALID_API_KEYS: str = ""
 
     # --- Trust Plane ---
-    # Strict trust mode requires both TRUST_MODE_ENABLED=true and
-    # ALLOW_LEGACY_UNPERMITTED_MCP=false. This lets local demos keep
-    # wallet-only MCP compatibility while production-like environments
-    # fail closed via app.core.trust_mode guardrails.
-    TRUST_MODE_ENABLED: bool = False
-    ALLOW_LEGACY_UNPERMITTED_MCP: bool = True
+    # Strict trust mode is the default and the only supported production
+    # posture: every governed MCP invocation must present a signed permit,
+    # legacy unpermitted calls are denied with `permit_required`, and a
+    # signing private key is required.
+    #
+    # To run a local demo or a legacy integration without permits, set both
+    # `TRUST_MODE_ENABLED=false` and `ALLOW_LEGACY_UNPERMITTED_MCP=true`
+    # explicitly in the environment. The startup banner in
+    # `app.core.trust_mode.warn_if_trust_mode_permissive` makes it loud when
+    # this opt-out is in effect, and the
+    # `app.core.trust_mode.validate_trust_mode_guardrails` check refuses to
+    # boot a production-like environment under any permissive combination.
+    TRUST_MODE_ENABLED: bool = True
+    ALLOW_LEGACY_UNPERMITTED_MCP: bool = False
     TRUST_SIGNING_KEY_ID: str = "local-dev-ed25519"
     TRUST_SIGNING_PRIVATE_KEY_B64: str = ""
 

--- a/app/core/trust_mode.py
+++ b/app/core/trust_mode.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from app.core.config import Settings
+
+
+logger = logging.getLogger(__name__)
 
 
 PRODUCTION_LIKE_ENVIRONMENTS = frozenset(
@@ -83,4 +87,52 @@ def validate_trust_mode_guardrails(settings: Settings) -> None:
         trust_mode_enabled=settings.TRUST_MODE_ENABLED,
         signing_private_key_b64=settings.TRUST_SIGNING_PRIVATE_KEY_B64,
         allow_legacy_unpermitted_mcp=settings.ALLOW_LEGACY_UNPERMITTED_MCP,
+    )
+
+
+def describe_permissive_trust_mode(
+    *,
+    trust_mode_enabled: bool,
+    allow_legacy_unpermitted_mcp: bool,
+) -> str | None:
+    """Describe a permissive trust-mode posture, or return None when strict.
+
+    The shipped defaults are `TRUST_MODE_ENABLED=true` and
+    `ALLOW_LEGACY_UNPERMITTED_MCP=false`. Any deviation is an explicit
+    operator opt-out and should be surfaced at startup so demos and
+    incremental migrations cannot drift into permissive territory by
+    accident.
+    """
+    if trust_mode_enabled and not allow_legacy_unpermitted_mcp:
+        return None
+    parts: list[str] = []
+    if not trust_mode_enabled:
+        parts.append("TRUST_MODE_ENABLED=false (no permit validation)")
+    if allow_legacy_unpermitted_mcp:
+        parts.append(
+            "ALLOW_LEGACY_UNPERMITTED_MCP=true (ungoverned MCP calls accepted)"
+        )
+    return "; ".join(parts)
+
+
+def warn_if_trust_mode_permissive(settings: Settings) -> None:
+    """Log a loud warning when the trust plane is running in opt-out mode.
+
+    Called once at startup, after `validate_trust_mode_guardrails`. In
+    production-like environments the validator has already refused to boot
+    under a permissive posture, so this only fires in local/dev/test
+    environments that explicitly opted out — exactly when we want a visible
+    reminder that ungoverned MCP calls are accepted.
+    """
+    description = describe_permissive_trust_mode(
+        trust_mode_enabled=settings.TRUST_MODE_ENABLED,
+        allow_legacy_unpermitted_mcp=settings.ALLOW_LEGACY_UNPERMITTED_MCP,
+    )
+    if description is None:
+        return
+    logger.warning(
+        "trust_mode_permissive: %s. The trust plane is in legacy/opt-out "
+        "mode; production deployments must set TRUST_MODE_ENABLED=true and "
+        "ALLOW_LEGACY_UNPERMITTED_MCP=false.",
+        description,
     )

--- a/app/main.py
+++ b/app/main.py
@@ -25,7 +25,10 @@ from .core.config import get_settings
 from .core.durable_state import close_durable_state, get_durable_state
 from .core.health import gather_dependency_report
 from .core.rate_limiter import RateLimitMiddleware
-from .core.trust_mode import validate_trust_mode_guardrails
+from .core.trust_mode import (
+    validate_trust_mode_guardrails,
+    warn_if_trust_mode_permissive,
+)
 from .db.database import init_db, close_db
 from .services.mcp_phase9_tools import (
     ensure_phase9_registered,
@@ -105,6 +108,7 @@ except ImportError:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     validate_trust_mode_guardrails(settings)
+    warn_if_trust_mode_permissive(settings)
 
     cleanup_task: asyncio.Task | None = None
     startup_time = time.monotonic()

--- a/docs/key-management.md
+++ b/docs/key-management.md
@@ -170,7 +170,8 @@ scope for the trust-plane key-management story.
 
 Until the KMS integration ships, the production posture is:
 
-- `TRUST_MODE_ENABLED=true`
+- `TRUST_MODE_ENABLED=true` and `ALLOW_LEGACY_UNPERMITTED_MCP=false` are the
+  shipped defaults; nothing extra to configure
 - `TRUST_SIGNING_PRIVATE_KEY_B64` injected at deploy time from the hosting
   platform secret manager
 - Rotation by redeploy with a new env var and a follow-up

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,14 @@ os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
 # Tests authenticate with X-API-Key: test-key (see RateLimitMiddleware, which
 # also special-cases this value to bypass rate limiting).
 os.environ.setdefault("VALID_API_KEYS", "test-key")
+# Production now defaults to strict trust mode (TRUST_MODE_ENABLED=true,
+# ALLOW_LEGACY_UNPERMITTED_MCP=false). Many tests predate that flip and
+# exercise MCP paths without supplying permits; opt the test suite back into
+# legacy/permissive behavior unless an individual test explicitly monkeypatches
+# strict mode (see test_mcp_trust_mode.py and test_trust_negative_security.py
+# for examples that flip back to strict at the test boundary).
+os.environ.setdefault("TRUST_MODE_ENABLED", "false")
+os.environ.setdefault("ALLOW_LEGACY_UNPERMITTED_MCP", "true")
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_trust_mode_guardrails.py
+++ b/tests/test_trust_mode_guardrails.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from app.core.config import Settings
 from app.core.trust_mode import (
     TrustModeGuardrailError,
+    describe_permissive_trust_mode,
     is_production_like_environment,
     validate_trust_mode_config,
     validate_trust_mode_guardrails,
+    warn_if_trust_mode_permissive,
 )
 
 
@@ -98,3 +102,130 @@ def test_settings_wrapper_uses_environment_field():
     )
 
     validate_trust_mode_guardrails(settings)
+
+
+def test_describe_permissive_returns_none_when_strict():
+    assert (
+        describe_permissive_trust_mode(
+            trust_mode_enabled=True,
+            allow_legacy_unpermitted_mcp=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("trust_mode_enabled", "allow_legacy_unpermitted_mcp", "expected_fragments"),
+    [
+        (False, False, ["TRUST_MODE_ENABLED=false"]),
+        (True, True, ["ALLOW_LEGACY_UNPERMITTED_MCP=true"]),
+        (
+            False,
+            True,
+            ["TRUST_MODE_ENABLED=false", "ALLOW_LEGACY_UNPERMITTED_MCP=true"],
+        ),
+    ],
+)
+def test_describe_permissive_lists_each_opt_out(
+    trust_mode_enabled: bool,
+    allow_legacy_unpermitted_mcp: bool,
+    expected_fragments: list[str],
+):
+    description = describe_permissive_trust_mode(
+        trust_mode_enabled=trust_mode_enabled,
+        allow_legacy_unpermitted_mcp=allow_legacy_unpermitted_mcp,
+    )
+    assert description is not None
+    for fragment in expected_fragments:
+        assert fragment in description
+
+
+class _ListHandler(logging.Handler):
+    """Minimal handler that collects records into a list.
+
+    Used in place of caplog because structlog reconfiguration earlier in the
+    test suite can disable propagation on `app.core.trust_mode`, which would
+    make caplog miss our records when the test runs as part of the full
+    suite (it still works in isolation).
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.WARNING)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _capture_trust_mode_warnings(callable_):
+    target = logging.getLogger("app.core.trust_mode")
+    handler = _ListHandler()
+    prior_level = target.level
+    prior_disabled = target.disabled
+    prior_propagate = target.propagate
+    target.addHandler(handler)
+    target.setLevel(logging.WARNING)
+    target.disabled = False
+    target.propagate = True
+    try:
+        callable_()
+    finally:
+        target.removeHandler(handler)
+        target.setLevel(prior_level)
+        target.disabled = prior_disabled
+        target.propagate = prior_propagate
+    return handler.records
+
+
+def test_warn_if_trust_mode_permissive_logs_warning_in_legacy_mode():
+    settings = Settings(
+        TRUST_MODE_ENABLED=False,
+        ALLOW_LEGACY_UNPERMITTED_MCP=True,
+    )
+    records = _capture_trust_mode_warnings(
+        lambda: warn_if_trust_mode_permissive(settings)
+    )
+    assert any(
+        "trust_mode_permissive" in record.getMessage() for record in records
+    ), records
+
+
+def test_warn_if_trust_mode_permissive_silent_when_strict():
+    settings = Settings(
+        TRUST_MODE_ENABLED=True,
+        ALLOW_LEGACY_UNPERMITTED_MCP=False,
+    )
+    records = _capture_trust_mode_warnings(
+        lambda: warn_if_trust_mode_permissive(settings)
+    )
+    assert all(
+        "trust_mode_permissive" not in record.getMessage() for record in records
+    ), records
+
+
+def test_shipped_defaults_are_strict():
+    """The shipped product defaults must be strict trust mode.
+
+    This is the pitch-critical invariant: a fresh deployment with no env
+    overrides should reject ungoverned MCP calls. The test suite opts back
+    into legacy via tests/conftest.py env vars, so this constructs Settings
+    in isolation to assert the *application* default rather than the
+    test-runtime override.
+    """
+    settings = Settings(
+        TRUST_MODE_ENABLED=True,
+        ALLOW_LEGACY_UNPERMITTED_MCP=False,
+    )
+    assert settings.TRUST_MODE_ENABLED is True
+    assert settings.ALLOW_LEGACY_UNPERMITTED_MCP is False
+    # And confirm the model fields' declared defaults match (independent of
+    # any env override the test runtime may have applied).
+    field_defaults = {
+        name: field.default
+        for name, field in Settings.model_fields.items()
+        if name in {"TRUST_MODE_ENABLED", "ALLOW_LEGACY_UNPERMITTED_MCP"}
+    }
+    assert field_defaults == {
+        "TRUST_MODE_ENABLED": True,
+        "ALLOW_LEGACY_UNPERMITTED_MCP": False,
+    }


### PR DESCRIPTION
## Summary

The pitch — "the boundary isn't optional" — was undermined by a fresh deployment of this server shipping with `TRUST_MODE_ENABLED=False` and `ALLOW_LEGACY_UNPERMITTED_MCP=True`. Those let ungoverned MCP calls through unless an operator explicitly hardened the environment. With #128's fail-closed demo proof and red-team battery now on main, the secure posture can become the default.

### Application changes

- **`app/core/config.py`** — `TRUST_MODE_ENABLED=True` and `ALLOW_LEGACY_UNPERMITTED_MCP=False` are the shipped defaults. Comment updated to point operators at the loud opt-out path for local demos and legacy integrations.
- **`app/core/trust_mode.py`** — new `describe_permissive_trust_mode` and `warn_if_trust_mode_permissive` helpers emit a `trust_mode_permissive` warning when an environment sets either flag back to the legacy value. The existing `validate_trust_mode_guardrails` still refuses to boot production-like environments under any permissive combination, so the warning only fires in local/dev/test — exactly where we want a visible reminder.
- **`app/main.py`** lifespan calls `warn_if_trust_mode_permissive` after the validator, so dev opt-out is loud but not fatal.

### Test changes

- **`tests/conftest.py`** opts the test suite back into legacy permissive defaults via env vars set before any imports, matching the existing conftest pattern for `DATABASE_URL` and `VALID_API_KEYS`. Many existing tests predate this flip and exercise MCP paths without supplying permits; individual trust tests that explicitly monkeypatch strict mode at the test boundary continue to work unchanged. **The application default is asserted in isolation** via `Settings.model_fields` so the test-runtime override cannot hide a regression in the shipped default.
- **`tests/test_trust_mode_guardrails.py`** gains 6 new tests (3 for `describe_permissive_trust_mode`, 2 for `warn_if_trust_mode_permissive`, 1 for the shipped defaults). The warning capture uses a custom handler with explicit level/disabled/propagate reset to survive structlog reconfiguration earlier in the suite.

### Documentation

- **`SECURITY_LIMITATIONS.md`** — production posture is now "nothing extra to configure"; legacy opt-out documented as explicit and loud.
- **`docs/key-management.md`** — same.

## Migration note

Existing deployments that ran with the previous loose defaults must now set `TRUST_MODE_ENABLED=false` and `ALLOW_LEGACY_UNPERMITTED_MCP=true` in the environment explicitly if they need to stay on the legacy posture. Production-like environments that were already configured strict (per `SECURITY_LIMITATIONS.md`'s prior "Required Production Posture") need no change.

## Test plan

- [x] `pytest tests/` — 710 passed, 1 skipped, 0 failures on Python 3.11
- [x] `make demo-trust-plane-check` green
- [x] `make red-team-trust-plane-check` green (10 denials, 0 ledger debits on either wallet, 1 positive control, intact audit chain)
- [x] `ruff check app/ tests/` clean
- [x] `Settings()` invariant: the shipped defaults are strict (asserted independently of the test-runtime env override)

## What this does not change

- Production guardrail behavior (`validate_trust_mode_guardrails`) — same semantics, just no longer needed for the common case because the defaults are already strict.
- The demo and red-team scripts — they already explicitly opt into strict mode in their setup; the default flip doesn't affect them.
- Any test behavior — `tests/conftest.py` keeps legacy defaults active for tests.

https://claude.ai/code/session_01RNmjNux6YMnyXWv2dJHJ3D

---
_Generated by [Claude Code](https://claude.ai/code/session_01RNmjNux6YMnyXWv2dJHJ3D)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default security posture for MCP governance and may break deployments that relied on implicit permissive defaults until they set legacy env vars explicitly.
> 
> **Overview**
> Fresh deployments now ship with **strict trust mode** (`TRUST_MODE_ENABLED=true`, `ALLOW_LEGACY_UNPERMITTED_MCP=false`) instead of accepting ungoverned MCP calls until an operator hardens the environment.
> 
> Startup adds **`warn_if_trust_mode_permissive`** (after existing guardrails) so local/dev/test runs that explicitly opt back into legacy behavior log a loud `trust_mode_permissive` warning. Production-like boots under a permissive combo are still refused by **`validate_trust_mode_guardrails`**.
> 
> **`tests/conftest.py`** sets permissive trust env defaults so older MCP tests keep working; **`test_trust_mode_guardrails.py`** locks in the new helpers and asserts shipped `Settings` field defaults stay strict. Docs in **`SECURITY_LIMITATIONS.md`** and **`docs/key-management.md`** describe strict as the default and legacy as an explicit opt-out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3722f14b62cc23d000f67d4b94efbdb087fc428. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Trust mode is now enabled by default for stricter security enforcement.
  * Legacy MCP support is disabled by default.
  * Warning messages are logged when permissive configurations are detected.

* **Documentation**
  * Updated security guidance to reflect new strict-by-default posture.
  * Clarified environment variable settings for production deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->