### PR TITLE
Dev-loop efficiency: fast test split, fix mypy hook, quiet warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,10 @@ repos:
     hooks:
       - id: mypy
         name: mypy (project env)
-        entry: uv run mypy --config-file=mypy.ini app/
+        # `--with mypy` makes the hook self-contained: uv installs mypy for the
+        # run if it isn't already in the project env, so a clean checkout can't
+        # fail on a missing mypy executable.
+        entry: uv run --with mypy mypy --config-file=mypy.ini app/
         language: system
         types: [python]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,17 @@ repos:
         args: [--fix]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.0
+  # mypy runs from the project environment (language: system) via `uv run`,
+  # matching how the Makefile invokes tools. The previous mirrors-mypy setup
+  # used an isolated env + the unbuildable `types-all` dep, which broke the
+  # hook entirely; an isolated env also lacks the project's runtime deps, so
+  # types resolve to Any and produce spurious errors. mypy.ini already sets
+  # ignore_missing_imports, so no third-party stubs are needed.
+  - repo: local
     hooks:
       - id: mypy
-        args: [--config-file=mypy.ini, app/]
-        additional_dependencies: [types-all]
+        name: mypy (project env)
+        entry: uv run mypy --config-file=mypy.ini app/
+        language: system
+        types: [python]
+        pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
-.PHONY: test prove-trust-plane demo-trust-plane demo-trust-plane-check red-team-trust-plane red-team-trust-plane-check agent-ops-war-room agent-ops-war-room-check trust-coverage-gate trust-release-gate
+.PHONY: test test-all test-proof prove-trust-plane demo-trust-plane demo-trust-plane-check red-team-trust-plane red-team-trust-plane-check agent-ops-war-room agent-ops-war-room-check trust-coverage-gate trust-release-gate
 
+# Fast inner loop: trust-plane (product) tests only. Proof-surface workloads
+# are skipped here — run them with `make test-all` (what CI runs) or `make test-proof`.
 test:
+	uv run pytest tests/ -q -m "not proof"
+
+test-all:
 	uv run pytest tests/ -q
+
+test-proof:
+	uv run pytest tests/ -q -m proof
 
 prove-trust-plane:
 	uv run python scripts/demo_trust_plane.py --assert

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,13 @@ resilience = ["tenacity>=8.0.0"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+markers = [
+    "proof: exercises an example proof-surface workload, not the trust-plane product. Skipped by `make test`; run the full suite with `make test-all`.",
+]
+filterwarnings = [
+    # Pydantic v2 calls the deprecated datetime.utcnow() internally
+    # (pydantic/_internal/_fields.py), emitting ~1,600 warnings that bury real
+    # signal. Scoped to pydantic so any utcnow reintroduction in our own code
+    # still surfaces.
+    "ignore::DeprecationWarning:pydantic._internal._fields",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,61 @@ Sets up pytest-asyncio, database, and common fixtures.
 
 import os
 import asyncio
+from pathlib import Path
+
 import pytest
 import pytest_asyncio
 from sqlalchemy import text
+
+# --- Proof-surface test classification -------------------------------------
+# The product is the trust plane (app/trust + the core trust routers). Everything
+# else is a "proof surface" — example workloads that exercise the spine but are
+# NOT the product (see README "Core platform vs. example workloads"). Tests for
+# these are auto-marked `proof` so the inner dev loop can skip them:
+#     make test       -> fast, core only  (pytest -m "not proof")
+#     make test-all   -> full suite       (what CI runs)
+# Conservative by design: when a test's surface is ambiguous, leave it OUT of
+# this set so it stays in the fast (core) loop and is never silently skipped.
+PROOF_SURFACE_TEST_MODULES = frozenset(
+    {
+        "test_awi",
+        "test_awi_adoption",
+        "test_awi_dom_bridge_integration",
+        "test_awi_phase9",
+        "test_behavioral_sandbox",
+        "test_broadcast",
+        "test_comms",
+        "test_agent_comms_durable",
+        "test_content_factory_generation_durable",
+        "test_content_store",
+        "test_dashboard",
+        "test_factory",
+        "test_iot",
+        "test_iot_registry",
+        "test_launch",
+        "test_media",
+        "test_oracle",
+        "test_oracle_durable_crawl",
+        "test_oracle_store",
+        "test_protocol",
+        "test_red_team",
+        "test_rtaas",
+        "test_sandbox",
+        "test_sandbox_integration",
+        "test_telemetry",
+        "test_telemetry_scope",
+        "test_telemetry_store",
+    }
+)
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-apply the `proof` marker to proof-surface test modules."""
+    proof = pytest.mark.proof
+    for item in items:
+        stem = Path(item.nodeid.split("::", 1)[0]).stem
+        if stem in PROOF_SURFACE_TEST_MODULES:
+            item.add_marker(proof)
 
 
 def iter_routes(routes):


### PR DESCRIPTION
Three independent, low-risk developer-experience fixes — cut clean off `main` (none of the broken/redundant work from the stalled `codex/trust-readiness-gap-map` branch).

## 1. Fast inner test loop
A `proof` pytest marker is auto-applied to proof-surface test modules via a central list in `tests/conftest.py`.
- `make test` → trust-plane (product) tests only (`-m "not proof"`, ~370 of 711) — the fast edit→test loop
- `make test-all` → full suite (what CI runs)
- `make test-proof` → just the workloads

No coverage lost: CI invokes `pytest tests/` directly, so it still runs everything. Classification errs toward keeping ambiguous tests in the fast loop so no product test is silently skipped.

## 2. Fix the broken pre-commit `mypy` hook
The hook used an isolated env + the unbuildable `types-all` dependency, so it failed to install and every commit needed `SKIP=mypy`. Now it runs mypy from the project env via `uv run` (matching the Makefile). `mypy.ini` already sets `ignore_missing_imports`, so no third-party stubs are needed. Verified: `mypy ... Passed`.

## 3. Quiet Pydantic-internal `utcnow` deprecation noise
Pydantic v2 calls `datetime.utcnow()` internally (`pydantic/_internal/_fields.py`), emitting ~1,600 `DeprecationWarning`s per run that bury real signal. A scoped `filterwarnings` ignore (limited to that module so our own code's warnings still surface) brings a full run from **~1,600 → 13 warnings**.

## Verification
Full suite green locally (710 passed). The one local failure — `test_planner_constraints::test_feasible_unselected_candidate_is_not_policy_rejected` — is **pre-existing on main**: macOS CBC-solver nondeterminism, unrelated to this change (none of these edits touch the planner), and Linux CI passes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-experience and tooling only; no production runtime, auth, or CI test scope changes beyond faster local defaults.
> 
> **Overview**
> Improves the **local dev loop** by introducing a `proof` pytest marker (registered in `pyproject.toml` and auto-applied in `tests/conftest.py` from a conservative module list) so **`make test`** runs only trust-plane tests (`-m "not proof"`), while **`make test-all`** and **`make test-proof`** run the full suite and proof workloads respectively. CI behavior is unchanged because workflows still invoke `pytest tests/` directly.
> 
> **Pre-commit mypy** is switched from the broken `mirrors-mypy` + `types-all` isolated hook to a **local hook** that runs `uv run mypy --config-file=mypy.ini app/` with `language: system`, aligning with how the project already runs tools.
> 
> **Test output noise** is reduced by ignoring `DeprecationWarning` from `pydantic._internal._fields` only, so Pydantic’s internal `utcnow` usage no longer floods runs while warnings from project code still appear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88933bd3a1ed3547d9353d7bf03e71d79a742f65. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed a recurring deprecation warning during test runs for cleaner output.
* **New Features**
  * Added a dedicated “proof” test category; standard test runs now exclude it by default.
  * Added separate commands to run all tests or only proof-focused tests.
* **Tests**
  * Automatically groups selected test modules into the “proof” category during collection.
* **Chores**
  * Streamlined local static type checking to run within the project environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->